### PR TITLE
feat(escrow): add reusable escrow templates (#149)

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -251,3 +251,51 @@ pub fn emit_token_allowlisted(e: &Env, admin: Address, token: Address) {
 pub fn emit_token_removed_from_allowlist(e: &Env, admin: Address, token: Address) {
     TokenRemovedFromAllowlist { admin, token }.publish(e);
 }
+
+/// Event: Escrow template created
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct EscrowTemplateCreated {
+    pub template_id: u32,
+    pub creator: Address,
+}
+
+/// Event: Escrow template config updated
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct EscrowTemplateUpdated {
+    pub template_id: u32,
+    pub creator: Address,
+}
+
+/// Event: Escrow template deactivated
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct EscrowTemplateDeactivated {
+    pub template_id: u32,
+    pub creator: Address,
+}
+
+/// Event: Escrow created from a template
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct EscrowCreatedFromTemplate {
+    pub escrow_id: u32,
+    pub template_id: u32,
+}
+
+pub fn emit_escrow_template_created(e: &Env, template_id: u32, creator: Address) {
+    EscrowTemplateCreated { template_id, creator }.publish(e);
+}
+
+pub fn emit_escrow_template_updated(e: &Env, template_id: u32, creator: Address) {
+    EscrowTemplateUpdated { template_id, creator }.publish(e);
+}
+
+pub fn emit_escrow_template_deactivated(e: &Env, template_id: u32, creator: Address) {
+    EscrowTemplateDeactivated { template_id, creator }.publish(e);
+}
+
+pub fn emit_escrow_created_from_template(e: &Env, escrow_id: u32, template_id: u32) {
+    EscrowCreatedFromTemplate { escrow_id, template_id }.publish(e);
+}

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -51,6 +51,23 @@ pub struct DeadlineProposal {
     pub proposed_at: u64,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowTemplateConfig {
+    pub arbiter: Address,
+    pub token: Address,
+    pub deadline_duration: u64, // seconds from escrow creation
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowTemplate {
+    pub id: u32,
+    pub creator: Address,
+    pub config: EscrowTemplateConfig,
+    pub active: bool,
+}
+
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
@@ -64,6 +81,8 @@ pub enum DataKey {
     Dispute(u32),
     DeadlineProposal(u32),
     AllowedToken(Address),
+    TemplateCounter,
+    Template(u32),
 }
 
 mod events;
@@ -693,6 +712,219 @@ impl AhjoorEscrowContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Create a reusable escrow template. Returns the template ID.
+    pub fn create_escrow_template(
+        env: Env,
+        creator: Address,
+        config: EscrowTemplateConfig,
+    ) -> u32 {
+        creator.require_auth();
+
+        let is_allowed = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowedToken(config.token.clone()))
+            .unwrap_or(false);
+        if !is_allowed {
+            panic!("TokenNotAllowed");
+        }
+        if config.deadline_duration == 0 {
+            panic!("deadline_duration must be positive");
+        }
+
+        let mut counter: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TemplateCounter)
+            .unwrap_or(0);
+        let template_id = counter;
+        counter += 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::TemplateCounter, &counter);
+
+        let template = EscrowTemplate {
+            id: template_id,
+            creator: creator.clone(),
+            config,
+            active: true,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Template(template_id), &template);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Template(template_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_escrow_template_created(&env, template_id, creator);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        template_id
+    }
+
+    /// Create an escrow from an existing template. Any caller may use any active template.
+    pub fn create_escrow_from_template(
+        env: Env,
+        buyer: Address,
+        seller: Address,
+        template_id: u32,
+        amount: i128,
+    ) -> u32 {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        let template: EscrowTemplate = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Template(template_id))
+            .expect("Template not found");
+
+        if !template.active {
+            panic!("Template is deactivated");
+        }
+        if amount <= 0 {
+            panic!("Escrow amount must be positive");
+        }
+
+        let deadline = env.ledger().timestamp() + template.config.deadline_duration;
+
+        let client = token::Client::new(&env, &template.config.token);
+        client.transfer(&buyer, &env.current_contract_address(), &amount);
+
+        let escrow_id = Self::next_escrow_id(&env);
+        let escrow = Escrow {
+            id: escrow_id,
+            buyer: buyer.clone(),
+            seller: seller.clone(),
+            arbiter: template.config.arbiter.clone(),
+            amount,
+            token: template.config.token.clone(),
+            status: EscrowStatus::Active,
+            created_at: env.ledger().timestamp(),
+            deadline,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_escrow_created(
+            &env,
+            escrow_id,
+            buyer,
+            seller,
+            template.config.arbiter,
+            amount,
+            template.config.token,
+            deadline,
+        );
+        events::emit_escrow_created_from_template(&env, escrow_id, template_id);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        escrow_id
+    }
+
+    /// Update a template's config. Only the template creator can call this.
+    pub fn update_escrow_template(
+        env: Env,
+        creator: Address,
+        template_id: u32,
+        new_config: EscrowTemplateConfig,
+    ) {
+        creator.require_auth();
+
+        let mut template: EscrowTemplate = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Template(template_id))
+            .expect("Template not found");
+
+        if template.creator != creator {
+            panic!("Only template creator can update");
+        }
+        if !template.active {
+            panic!("Template is deactivated");
+        }
+
+        let is_allowed = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowedToken(new_config.token.clone()))
+            .unwrap_or(false);
+        if !is_allowed {
+            panic!("TokenNotAllowed");
+        }
+        if new_config.deadline_duration == 0 {
+            panic!("deadline_duration must be positive");
+        }
+
+        template.config = new_config;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Template(template_id), &template);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Template(template_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_escrow_template_updated(&env, template_id, creator);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Deactivate a template. Only the template creator can call this.
+    pub fn deactivate_escrow_template(env: Env, creator: Address, template_id: u32) {
+        creator.require_auth();
+
+        let mut template: EscrowTemplate = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Template(template_id))
+            .expect("Template not found");
+
+        if template.creator != creator {
+            panic!("Only template creator can deactivate");
+        }
+        if !template.active {
+            panic!("Template already deactivated");
+        }
+
+        template.active = false;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Template(template_id), &template);
+
+        events::emit_escrow_template_deactivated(&env, template_id, creator);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get template details.
+    pub fn get_escrow_template(env: Env, template_id: u32) -> EscrowTemplate {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Template(template_id))
+            .expect("Template not found")
     }
 
     // --- Internal Helpers ---


### PR DESCRIPTION
- Add EscrowTemplateConfig { arbiter, token, deadline_duration } struct
- Add EscrowTemplate { id, creator, config, active } struct
- Add TemplateCounter and Template(u32) DataKeys
- Add create_escrow_template: creator-auth'd, validates token allowlist and deadline_duration > 0, stores template in persistent storage
- Add create_escrow_from_template: any caller, uses template config to derive deadline (now + deadline_duration), transfers funds and creates escrow
- Add update_escrow_template: creator-only, validates new config, updates in place
- Add deactivate_escrow_template: creator-only, sets active = false
- Add get_escrow_template: read-only getter
- Add EscrowTemplateCreated, EscrowTemplateUpdated, EscrowTemplateDeactivated, EscrowCreatedFromTemplate events with emit helpers

Closes #149

