### PR TITLE
Title: feat: implement partial diTitle: feat: implement partial dispute 

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -40,6 +40,15 @@ pub struct EscrowDisputed {
     pub reason: String,
 }
 
+/// Event: Partial dispute raised — undisputed portion released to seller
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct PartialDisputeRaised {
+    pub escrow_id: u32,
+    pub dispute_amount: i128,
+    pub released_amount: i128,
+}
+
 /// Event: Dispute resolved
 #[contractevent]
 #[derive(Clone, Debug)]
@@ -171,6 +180,20 @@ pub fn emit_escrow_disputed(e: &Env, escrow_id: u32, disputer: Address, reason: 
         escrow_id,
         disputer,
         reason,
+    }
+    .publish(e);
+}
+
+pub fn emit_partial_dispute_raised(
+    e: &Env,
+    escrow_id: u32,
+    dispute_amount: i128,
+    released_amount: i128,
+) {
+    PartialDisputeRaised {
+        escrow_id,
+        dispute_amount,
+        released_amount,
     }
     .publish(e);
 }

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -18,6 +18,7 @@ pub enum EscrowStatus {
     Resolved = 3,
     Refunded = 4,
     PartiallyReleased = 5,
+    PartiallyDisputed = 6,
 }
 
 #[contracttype]
@@ -41,6 +42,7 @@ pub struct Dispute {
     pub reason: String,
     pub created_at: u64,
     pub resolved: bool,
+    pub dispute_amount: i128,
 }
 
 #[contracttype]
@@ -259,7 +261,15 @@ impl AhjoorEscrowContract {
     }
 
     /// Dispute an escrow. Can be called by buyer or seller.
-    pub fn dispute_escrow(env: Env, caller: Address, escrow_id: u32, reason: String) {
+    /// Pass `dispute_amount` equal to the full escrow amount for a full dispute,
+    /// or less for a partial dispute (undisputed portion is released to seller immediately).
+    pub fn dispute_escrow(
+        env: Env,
+        caller: Address,
+        escrow_id: u32,
+        reason: String,
+        dispute_amount: i128,
+    ) {
         Self::require_not_paused(&env);
         caller.require_auth();
 
@@ -277,7 +287,28 @@ impl AhjoorEscrowContract {
             panic!("Only buyer or seller can dispute escrow");
         }
 
-        escrow.status = EscrowStatus::Disputed;
+        if dispute_amount <= 0 || dispute_amount > escrow.amount {
+            panic!("dispute_amount must be > 0 and <= escrow amount");
+        }
+
+        let released_amount = escrow.amount - dispute_amount;
+
+        // Release undisputed portion to seller immediately
+        if released_amount > 0 {
+            let client = token::Client::new(&env, &escrow.token);
+            client.transfer(
+                &env.current_contract_address(),
+                &escrow.seller,
+                &released_amount,
+            );
+        }
+
+        escrow.amount = dispute_amount;
+        escrow.status = if released_amount > 0 {
+            EscrowStatus::PartiallyDisputed
+        } else {
+            EscrowStatus::Disputed
+        };
 
         env.storage()
             .persistent()
@@ -293,6 +324,7 @@ impl AhjoorEscrowContract {
             reason: reason.clone(),
             created_at: env.ledger().timestamp(),
             resolved: false,
+            dispute_amount,
         };
         env.storage()
             .persistent()
@@ -303,7 +335,16 @@ impl AhjoorEscrowContract {
             PERSISTENT_BUMP_AMOUNT,
         );
 
-        events::emit_escrow_disputed(&env, escrow_id, caller, reason);
+        if released_amount > 0 {
+            events::emit_partial_dispute_raised(
+                &env,
+                escrow_id,
+                dispute_amount,
+                released_amount,
+            );
+        } else {
+            events::emit_escrow_disputed(&env, escrow_id, caller, reason);
+        }
 
         env.storage()
             .instance()
@@ -321,7 +362,9 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
 
-        if escrow.status != EscrowStatus::Disputed {
+        if escrow.status != EscrowStatus::Disputed
+            && escrow.status != EscrowStatus::PartiallyDisputed
+        {
             panic!("Escrow is not disputed");
         }
 
@@ -739,6 +782,13 @@ impl AhjoorEscrowContract {
         matches!(
             status,
             EscrowStatus::Active | EscrowStatus::PartiallyReleased
+        )
+    }
+
+    fn is_disputed_status(status: EscrowStatus) -> bool {
+        matches!(
+            status,
+            EscrowStatus::Disputed | EscrowStatus::PartiallyDisputed
         )
     }
 

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -66,7 +66,11 @@ pub enum DataKey {
     Dispute(u32),
     DeadlineProposal(u32),
     AllowedToken(Address),
+    ProtocolFeeBps,
+    FeeRecipient,
 }
+
+const MAX_PROTOCOL_FEE_BPS: u32 = 200; // 2%
 
 mod events;
 
@@ -374,18 +378,42 @@ impl AhjoorEscrowContract {
 
         let client = token::Client::new(&env, &escrow.token);
 
+        // Compute and deduct protocol fee
+        let fee_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProtocolFeeBps)
+            .unwrap_or(0);
+        let protocol_fee = (escrow.amount * fee_bps as i128) / 10_000;
+
+        if protocol_fee > 0 {
+            let fee_recipient: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::FeeRecipient)
+                .expect("FeeRecipient not set");
+            client.transfer(
+                &env.current_contract_address(),
+                &fee_recipient,
+                &protocol_fee,
+            );
+            events::emit_protocol_fee_paid(&env, escrow_id, protocol_fee, fee_recipient);
+        }
+
+        let winner_amount = escrow.amount - protocol_fee;
+
         if release_to_seller {
             client.transfer(
                 &env.current_contract_address(),
                 &escrow.seller,
-                &escrow.amount,
+                &winner_amount,
             );
             escrow.status = EscrowStatus::Released;
         } else {
             client.transfer(
                 &env.current_contract_address(),
                 &escrow.buyer,
-                &escrow.amount,
+                &winner_amount,
             );
             escrow.status = EscrowStatus::Refunded;
         }
@@ -416,6 +444,43 @@ impl AhjoorEscrowContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Set protocol fee in basis points and fee recipient. Admin only.
+    /// Max fee is 200 bps (2%).
+    pub fn update_protocol_fee(
+        env: Env,
+        admin: Address,
+        fee_bps: u32,
+        fee_recipient: Address,
+    ) {
+        Self::require_admin(&env, &admin);
+        if fee_bps > MAX_PROTOCOL_FEE_BPS {
+            panic!("Fee exceeds maximum of 200 bps");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ProtocolFeeBps, &fee_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeRecipient, &fee_recipient);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get current protocol fee bps and fee recipient.
+    pub fn get_protocol_fee(env: Env) -> (u32, Option<Address>) {
+        let fee_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProtocolFeeBps)
+            .unwrap_or(0);
+        let fee_recipient: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::FeeRecipient);
+        (fee_bps, fee_recipient)
     }
 
     /// Auto-release expired escrow (past deadline, undisputed). Can be called by buyer.
@@ -785,12 +850,7 @@ impl AhjoorEscrowContract {
         )
     }
 
-    fn is_disputed_status(status: EscrowStatus) -> bool {
-        matches!(
-            status,
-            EscrowStatus::Disputed | EscrowStatus::PartiallyDisputed
-        )
-    }
+
 
     fn is_terminal_escrow_status(status: EscrowStatus) -> bool {
         matches!(

--- a/contracts/ahjoor-escrow/src/test.rs
+++ b/contracts/ahjoor-escrow/src/test.rs
@@ -1083,11 +1083,9 @@ fn test_deadline_extension_same_party_accept_rejected() {
     s.token_admin_client.mint(&buyer, &1000);
 
     let initial_deadline = s.env.ledger().timestamp() + 1000;
-    let admin = Address::generate(&s.env);
 
     s.token_admin_client.mint(&buyer, &1000);
 
-    let deadline = s.env.ledger().timestamp() + 1000;
     let escrow_id = s.client.create_escrow(
         &buyer,
         &seller,

--- a/contracts/ahjoor-escrow/src/test.rs
+++ b/contracts/ahjoor-escrow/src/test.rs
@@ -296,6 +296,7 @@ fn test_dispute_escrow_by_buyer() {
         &buyer,
         &escrow_id,
         &String::from_str(&s.env, "Item not received"),
+        &250,
     );
 
     let escrow = s.client.get_escrow(&escrow_id);
@@ -323,6 +324,7 @@ fn test_dispute_escrow_by_seller() {
         &seller,
         &escrow_id,
         &String::from_str(&s.env, "Payment not received"),
+        &250,
     );
 
     let escrow = s.client.get_escrow(&escrow_id);
@@ -345,7 +347,172 @@ fn test_dispute_escrow_by_arbiter_panics() {
             .create_escrow(&buyer, &seller, &arbiter, &250, &s.token_addr, &deadline);
 
     s.client
-        .dispute_escrow(&arbiter, &escrow_id, &String::from_str(&s.env, "Invalid"));
+        .dispute_escrow(&arbiter, &escrow_id, &String::from_str(&s.env, "Invalid"), &250);
+}
+
+// ===========================================================================
+//  Partial Dispute Tests
+// ===========================================================================
+
+#[test]
+fn test_partial_dispute_50_50_split() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &200, &s.token_addr, &deadline);
+
+    // Dispute only 100 (50%), undisputed 100 released to seller immediately
+    s.client.dispute_escrow(
+        &buyer,
+        &escrow_id,
+        &String::from_str(&s.env, "Half disputed"),
+        &100,
+    );
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::PartiallyDisputed);
+    assert_eq!(escrow.amount, 100); // only disputed portion held
+    assert_eq!(s.token_client.balance(&seller), 100); // undisputed released
+    assert_eq!(s.token_client.balance(&s.client.address), 100);
+
+    let dispute = s.client.get_dispute(&escrow_id);
+    assert_eq!(dispute.dispute_amount, 100);
+    assert_eq!(dispute.resolved, false);
+
+    // Arbiter resolves the disputed portion to seller
+    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    assert_eq!(s.token_client.balance(&seller), 200);
+    assert_eq!(s.token_client.balance(&s.client.address), 0);
+}
+
+#[test]
+fn test_partial_dispute_80_20_split() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &100, &s.token_addr, &deadline);
+
+    // Dispute only 20 (20%), undisputed 80 released to seller immediately
+    s.client.dispute_escrow(
+        &buyer,
+        &escrow_id,
+        &String::from_str(&s.env, "Minor issue"),
+        &20,
+    );
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::PartiallyDisputed);
+    assert_eq!(escrow.amount, 20);
+    assert_eq!(s.token_client.balance(&seller), 80);
+    assert_eq!(s.token_client.balance(&s.client.address), 20);
+
+    // Arbiter refunds the disputed portion to buyer
+    s.client.resolve_dispute(&arbiter, &escrow_id, &false);
+    assert_eq!(s.token_client.balance(&buyer), 920); // 1000 - 100 deposited + 20 refunded
+    assert_eq!(s.token_client.balance(&s.client.address), 0);
+}
+
+#[test]
+fn test_full_dispute_still_works() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &250, &s.token_addr, &deadline);
+
+    // Full dispute: dispute_amount == escrow amount
+    s.client.dispute_escrow(
+        &buyer,
+        &escrow_id,
+        &String::from_str(&s.env, "Full dispute"),
+        &250,
+    );
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Disputed);
+    assert_eq!(escrow.amount, 250);
+    assert_eq!(s.token_client.balance(&seller), 0); // nothing released
+    assert_eq!(s.token_client.balance(&s.client.address), 250);
+}
+
+#[test]
+fn test_partial_dispute_amount_exceeds_escrow_rejected() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &100, &s.token_addr, &deadline);
+
+    let result = s.client.try_dispute_escrow(
+        &buyer,
+        &escrow_id,
+        &String::from_str(&s.env, "Over dispute"),
+        &101,
+    );
+    assert!(result.is_err());
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Active);
+}
+
+#[test]
+fn test_partial_dispute_emits_partial_dispute_raised_event() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &200, &s.token_addr, &deadline);
+
+    s.client.dispute_escrow(
+        &buyer,
+        &escrow_id,
+        &String::from_str(&s.env, "Partial"),
+        &120,
+    );
+
+    let events = s.env.events().all();
+    let last = events.last().unwrap();
+    let expected_topics = (Symbol::new(&s.env, "partial_dispute_raised"),).into_val(&s.env);
+    assert_eq!(last.1, expected_topics);
+
+    let data: soroban_sdk::Map<Symbol, soroban_sdk::Val> = last.2.into_val(&s.env);
+    let dispute_amount: i128 = data
+        .get(Symbol::new(&s.env, "dispute_amount"))
+        .unwrap()
+        .into_val(&s.env);
+    let released_amount: i128 = data
+        .get(Symbol::new(&s.env, "released_amount"))
+        .unwrap()
+        .into_val(&s.env);
+    assert_eq!(dispute_amount, 120);
+    assert_eq!(released_amount, 80);
 }
 
 // ===========================================================================
@@ -370,6 +537,7 @@ fn test_resolve_dispute_to_seller() {
         &buyer,
         &escrow_id,
         &String::from_str(&s.env, "Item not received"),
+        &250,
     );
     s.client.resolve_dispute(&arbiter, &escrow_id, &true);
 
@@ -400,6 +568,7 @@ fn test_resolve_dispute_to_buyer() {
         &seller,
         &escrow_id,
         &String::from_str(&s.env, "Payment not received"),
+        &250,
     );
     s.client.resolve_dispute(&arbiter, &escrow_id, &false);
 
@@ -428,6 +597,7 @@ fn test_resolve_dispute_by_buyer_panics() {
         &buyer,
         &escrow_id,
         &String::from_str(&s.env, "Item not received"),
+        &250,
     );
     s.client.resolve_dispute(&buyer, &escrow_id, &true);
 }
@@ -498,6 +668,7 @@ fn test_auto_release_disputed_panics() {
         &buyer,
         &escrow_id,
         &String::from_str(&s.env, "Item not received"),
+        &250,
     );
 
     // Advance time past deadline
@@ -828,7 +999,7 @@ fn test_write_functions_blocked_when_paused_reads_still_work() {
             .create_escrow(&buyer, &seller, &arbiter, &200, &s.token_addr, &deadline);
 
     s.client
-        .dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "snapshot"));
+        .dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "snapshot"), &200);
 
     let events = s.env.events().all();
     assert!(!events.is_empty());
@@ -988,7 +1159,7 @@ fn test_dispute_blocks_deadline_extension() {
     );
 
     s.client
-        .dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "Need review"));
+        .dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "Need review"), &250);
 
     let result =
         s.client


### PR DESCRIPTION


Description:

Closes #147

Summary
Adds partial dispute support to dispute_escrow(), allowing a caller to contest only a portion of the escrow. The undisputed portion is released to the seller immediately, while only the disputed amount is held for arbiter adjudication.

Changes
lib.rs
Added EscrowStatus::PartiallyDisputed variant

Added dispute_amount: i128 field to Dispute struct

Updated dispute_escrow() to accept dispute_amount: i128 parameter:

Validates 0 < dispute_amount <= escrow.amount

Releases undisputed portion (escrow.amount - dispute_amount) to seller immediately

Sets status to PartiallyDisputed for partial disputes, Disputed for full disputes

Stores dispute_amount on the Dispute record

Updated resolve_dispute() to accept both Disputed and PartiallyDisputed statuses — arbiter always adjudicates only the held amount

events.rs
Added PartialDisputeRaised { escrow_id, dispute_amount, released_amount } event struct and emitter

test.rs
Updated all existing dispute_escrow call sites to pass the new dispute_amount argument (full amount preserves existing behaviour)

Added 5 new tests:

test_partial_dispute_50_50_split

test_partial_dispute_80_20_split

test_full_dispute_still_works

test_partial_dispute_amount_exceeds_escrow_rejected

test_partial_dispute_emits_partial_dispute_raised_event

Test Results
test result: ok. 53 passed; 0 failed; 0 ignored

