### PR TITLE
Title: feat: per-payment refund amount cap tracking (#165)

### DIFF
--- a/contracts/ahjoor-refund/src/events.rs
+++ b/contracts/ahjoor-refund/src/events.rs
@@ -75,6 +75,14 @@ pub struct RefundAutoApproved {
     pub amount: i128,
 }
 
+/// Event: Partial refund cap applied — emitted when remaining refundable is near zero
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct PartialRefundCapApplied {
+    pub refund_id: u32,
+    pub remaining_refundable: i128,
+}
+
 // --- Helper Emission Functions ---
 
 pub fn emit_refund_requested(
@@ -149,6 +157,14 @@ pub fn emit_refund_auto_approved(e: &Env, refund_id: u32, customer: Address, amo
         refund_id,
         customer,
         amount,
+    }
+    .publish(e);
+}
+
+pub fn emit_partial_refund_cap_applied(e: &Env, refund_id: u32, remaining_refundable: i128) {
+    PartialRefundCapApplied {
+        refund_id,
+        remaining_refundable,
     }
     .publish(e);
 }

--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -92,6 +92,8 @@ pub enum DataKey {
     PaymentRefunds(u32),
     /// Dispute window in seconds; after this period a Requested refund can be auto-approved.
     DisputeWindow,
+    /// Cumulative refunded amount per payment_id (#165).
+    RefundedAmount(u32),
 }
 
 mod events;
@@ -173,9 +175,13 @@ impl AhjoorRefundContract {
         let merchant = payment.merchant.clone();
 
         // Validate refund amount does not exceed original payment amount
-        let remaining = payment.amount - payment.refunded_amount;
-        if amount > remaining {
-            panic!("PaymentAmountMismatch: refund amount exceeds remaining payment amount");
+        let already_refunded: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RefundedAmount(payment_id))
+            .unwrap_or(0);
+        if amount + already_refunded > payment.amount {
+            panic!("ExceedsRefundableAmount");
         }
 
         // Cache validated payment data — token comes from the payment record
@@ -348,6 +354,41 @@ impl AhjoorRefundContract {
             &refund.amount,
         );
 
+        // Update cumulative refunded amount for this payment
+        let already_refunded: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RefundedAmount(refund.payment_id))
+            .unwrap_or(0);
+        let new_total = already_refunded + refund.amount;
+        env.storage()
+            .persistent()
+            .set(&DataKey::RefundedAmount(refund.payment_id), &new_total);
+        env.storage().persistent().extend_ttl(
+            &DataKey::RefundedAmount(refund.payment_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        // Emit cap event when remaining refundable is low (< 10% of original or zero)
+        let payment_contract_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentContractAddress)
+            .expect("Payment contract not configured");
+        let payment_client =
+            payment_contract::PaymentContractClient::new(&env, &payment_contract_addr);
+        if let Ok(Ok(payment)) = payment_client.try_get_payment(&refund.payment_id) {
+            let remaining_refundable = payment.amount - new_total;
+            if remaining_refundable <= payment.amount / 10 {
+                events::emit_partial_refund_cap_applied(
+                    &env,
+                    refund_id,
+                    remaining_refundable,
+                );
+            }
+        }
+
         refund.status = RefundStatus::Processed;
         refund.processed_at = Some(env.ledger().timestamp());
 
@@ -460,6 +501,27 @@ impl AhjoorRefundContract {
         offset: u32,
     ) -> Vec<u32> {
         Self::paginate(&env, &DataKey::MerchantRefunds(merchant), limit, offset)
+    }
+
+    /// Get the remaining refundable amount for a payment.
+    pub fn get_refundable_remaining(env: Env, payment_id: u32) -> i128 {
+        let payment_contract_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentContractAddress)
+            .expect("Payment contract not configured");
+        let payment_client =
+            payment_contract::PaymentContractClient::new(&env, &payment_contract_addr);
+        let payment = payment_client
+            .try_get_payment(&payment_id)
+            .unwrap_or_else(|_| panic!("PaymentContractError: payment not found"))
+            .unwrap_or_else(|_| panic!("PaymentContractError: payment not found"));
+        let already_refunded: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RefundedAmount(payment_id))
+            .unwrap_or(0);
+        payment.amount - already_refunded
     }
 
     /// Get all refund IDs for a given payment ID.

--- a/contracts/ahjoor-refund/src/test.rs
+++ b/contracts/ahjoor-refund/src/test.rs
@@ -6,7 +6,7 @@ use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
-    Address, BytesN, Env, Map, String,
+    Address, BytesN, Env, String,
 };
 
 const UPGRADE_WASM: &[u8] = include_bytes!("../../../fixtures/upgrade_contract.wasm");
@@ -172,7 +172,7 @@ fn test_request_refund_nonexistent_payment_panics() {
 }
 
 #[test]
-#[should_panic(expected = "PaymentAmountMismatch: refund amount exceeds remaining payment amount")]
+#[should_panic(expected = "ExceedsRefundableAmount")]
 fn test_request_refund_exceeds_payment_amount_panics() {
     let s = setup();
     let customer = Address::generate(&s.env);
@@ -1048,6 +1048,153 @@ fn test_different_customers_indexes_are_isolated() {
             .len(),
         1
     );
+}
+
+// ===========================================================================
+//  Per-Payment Refund Cap Tracking Tests (#165)
+// ===========================================================================
+
+#[test]
+fn test_get_refundable_remaining_full_before_any_refund() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+
+    let pid = create_completed_payment(&s, &customer, &merchant, 300);
+    assert_eq!(s.refund_client.get_refundable_remaining(&pid), 300);
+}
+
+#[test]
+fn test_get_refundable_remaining_decreases_after_processed_refund() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+
+    let pid = create_completed_payment(&s, &customer, &merchant, 300);
+    s.token_admin_client.mint(&customer, &100);
+    let rid = s
+        .refund_client
+        .request_refund(&customer, &pid, &100, &String::from_str(&s.env, "r1"));
+    s.refund_client.approve_refund(&s.admin, &rid);
+    s.refund_client.process_refund(&s.admin, &rid);
+
+    assert_eq!(s.refund_client.get_refundable_remaining(&pid), 200);
+}
+
+#[test]
+fn test_three_partial_refunds_exhaust_payment() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+
+    // Payment of 300; three refunds of 100 each
+    let pid = create_completed_payment(&s, &customer, &merchant, 300);
+
+    for i in 0..3u32 {
+        s.token_admin_client.mint(&customer, &100);
+        let reason = if i == 0 {
+            String::from_str(&s.env, "first")
+        } else if i == 1 {
+            String::from_str(&s.env, "second")
+        } else {
+            String::from_str(&s.env, "third")
+        };
+        let rid = s
+            .refund_client
+            .request_refund(&customer, &pid, &100, &reason);
+        s.refund_client.approve_refund(&s.admin, &rid);
+        s.refund_client.process_refund(&s.admin, &rid);
+    }
+
+    assert_eq!(s.refund_client.get_refundable_remaining(&pid), 0);
+}
+
+#[test]
+fn test_cumulative_over_refund_rejected() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+
+    // Payment of 200; refund 150, then try to refund 100 more (total 250 > 200)
+    let pid = create_completed_payment(&s, &customer, &merchant, 200);
+
+    s.token_admin_client.mint(&customer, &150);
+    let rid = s
+        .refund_client
+        .request_refund(&customer, &pid, &150, &String::from_str(&s.env, "partial"));
+    s.refund_client.approve_refund(&s.admin, &rid);
+    s.refund_client.process_refund(&s.admin, &rid);
+
+    // 50 remaining — requesting 100 should fail
+    s.token_admin_client.mint(&customer, &100);
+    let result = s.refund_client.try_request_refund(
+        &customer,
+        &pid,
+        &100,
+        &String::from_str(&s.env, "over-refund"),
+    );
+    assert!(result.is_err());
+    assert_eq!(s.refund_client.get_refundable_remaining(&pid), 50);
+}
+
+#[test]
+fn test_multiple_partial_refunds_accumulate_correctly() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+
+    let pid = create_completed_payment(&s, &customer, &merchant, 500);
+
+    // Refund 100
+    s.token_admin_client.mint(&customer, &100);
+    let rid1 = s
+        .refund_client
+        .request_refund(&customer, &pid, &100, &String::from_str(&s.env, "r1"));
+    s.refund_client.approve_refund(&s.admin, &rid1);
+    s.refund_client.process_refund(&s.admin, &rid1);
+    assert_eq!(s.refund_client.get_refundable_remaining(&pid), 400);
+
+    // Refund 150
+    s.token_admin_client.mint(&customer, &150);
+    let rid2 = s
+        .refund_client
+        .request_refund(&customer, &pid, &150, &String::from_str(&s.env, "r2"));
+    s.refund_client.approve_refund(&s.admin, &rid2);
+    s.refund_client.process_refund(&s.admin, &rid2);
+    assert_eq!(s.refund_client.get_refundable_remaining(&pid), 250);
+
+    // Refund 250 (exactly remaining)
+    s.token_admin_client.mint(&customer, &250);
+    let rid3 = s
+        .refund_client
+        .request_refund(&customer, &pid, &250, &String::from_str(&s.env, "r3"));
+    s.refund_client.approve_refund(&s.admin, &rid3);
+    s.refund_client.process_refund(&s.admin, &rid3);
+    assert_eq!(s.refund_client.get_refundable_remaining(&pid), 0);
+}
+
+#[test]
+fn test_cap_event_emitted_when_remaining_near_zero() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+
+    // Payment of 100; refund 95 (remaining = 5, which is <= 10% of 100)
+    let pid = create_completed_payment(&s, &customer, &merchant, 100);
+    s.token_admin_client.mint(&customer, &95);
+    let rid = s
+        .refund_client
+        .request_refund(&customer, &pid, &95, &String::from_str(&s.env, "near-cap"));
+    s.refund_client.approve_refund(&s.admin, &rid);
+    s.refund_client.process_refund(&s.admin, &rid);
+
+    use soroban_sdk::IntoVal;
+    let events = s.env.events().all();
+    let cap_event = events.iter().find(|e| {
+        e.1 == (soroban_sdk::Symbol::new(&s.env, "partial_refund_cap_applied"),)
+            .into_val(&s.env)
+    });
+    assert!(cap_event.is_some());
 }
 
 // ===========================================================================


### PR DESCRIPTION
Description:

Closes #165

Summary
Adds cumulative refund tracking per payment to prevent customers from requesting more than the original payment amount across multiple partial refunds. Introduces a get_refundable_remaining() query and a PartialRefundCapApplied event emitted when the remaining refundable balance drops to ≤ 10%.

Changes 

lib.rs
Added RefundedAmount(u32) variant to DataKey for per-payment cumulative tracking

Updated request_refund() to validate amount + already_refunded <= payment.amount, panicking with ExceedsRefundableAmount on violation

Updated process_refund() to:

Increment RefundedAmount(payment_id) by the processed refund amount

Emit PartialRefundCapApplied when remaining refundable is ≤ 10% of original payment

Added get_refundable_remaining(env, payment_id) -> i128 — returns payment.amount - total_refunded_so_far

events.rs
Added PartialRefundCapApplied { refund_id, remaining_refundable } event struct and emit_partial_refund_cap_applied() helper

test.rs
Updated test_request_refund_exceeds_payment_amount_panics to expect new ExceedsRefundableAmount panic message

Added 6 new tests:

Test	What it covers
test_get_refundable_remaining_full_before_any_refund	Returns full amount before any refund
test_get_refundable_remaining_decreases_after_processed_refund	Remaining decreases correctly after processing
test_three_partial_refunds_exhaust_payment	3 × 100 refunds on 300 payment → remaining = 0
test_cumulative_over_refund_rejected	150 processed + 100 request on 200 payment → rejected
test_multiple_partial_refunds_accumulate_correctly	100 + 150 + 250 on 500 payment, remaining verified at each step
test_cap_event_emitted_when_remaining_near_zero	partial_refund_cap_applied event emitted when ≤ 10% remains
Test Results
test result: ok. 63 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

