### PR TITLE
feat(escrow): add atomic batch escrow creation

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -13,6 +13,15 @@ pub struct EscrowCreated {
     pub deadline: u64,
 }
 
+/// Event: Batch escrow created summary
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BatchEscrowCreated {
+    pub count: u32,
+    pub first_id: u32,
+    pub last_id: u32,
+}
+
 /// Event: Escrow released to seller
 #[contractevent]
 #[derive(Clone, Debug)]
@@ -199,6 +208,15 @@ pub fn emit_escrow_created(
         amount,
         token,
         deadline,
+    }
+    .publish(e);
+}
+
+pub fn emit_batch_escrow_created(e: &Env, count: u32, first_id: u32, last_id: u32) {
+    BatchEscrowCreated {
+        count,
+        first_id,
+        last_id,
     }
     .publish(e);
 }

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -10,6 +10,7 @@ const PERSISTENT_BUMP_AMOUNT: u32 = 120_000;
 const DEADLINE_EXTENSION_PROPOSAL_WINDOW: u64 = 24 * 60 * 60;
 const MAX_EVIDENCE_ENTRIES_PER_PARTY: u32 = 5;
 const DEFAULT_DISPUTE_TIMEOUT_SECONDS: u64 = 7 * 24 * 60 * 60;
+const MAX_BATCH_ESCROWS: u32 = 10;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[contracttype]
@@ -87,6 +88,20 @@ pub struct EscrowTemplate {
     pub active: bool,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowBatchConfig {
+    pub seller: Address,
+    pub arbiter: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub deadline: u64,
+    pub metadata_hash: Option<BytesN<32>>,
+    pub sellers: Vec<(Address, u32)>,
+    pub auto_renew: bool,
+    pub renewal_count: u32,
+}
+
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
@@ -159,6 +174,88 @@ impl AhjoorEscrowContract {
         Self::require_not_paused(&env);
         buyer.require_auth();
 
+        Self::create_escrow_core(
+            &env,
+            &buyer,
+            seller,
+            arbiter,
+            amount,
+            token,
+            deadline,
+            metadata_hash,
+            sellers,
+            auto_renew,
+            renewal_count,
+        )
+    }
+
+    /// Create up to 10 escrows in one atomic transaction.
+    /// Returns the list of contiguous escrow IDs created.
+    pub fn create_escrows_batch(
+        env: Env,
+        buyer: Address,
+        escrow_configs: Vec<EscrowBatchConfig>,
+    ) -> Vec<u32> {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        if escrow_configs.is_empty() {
+            panic!("Batch must contain at least one escrow config");
+        }
+        if escrow_configs.len() > MAX_BATCH_ESCROWS {
+            panic!("Batch size exceeds maximum of 10 escrows");
+        }
+
+        let mut created_ids: Vec<u32> = Vec::new(&env);
+        let mut first_id: Option<u32> = None;
+        let mut last_id: u32 = 0;
+
+        for i in 0..escrow_configs.len() {
+            let cfg = escrow_configs.get(i).unwrap();
+            let escrow_id = Self::create_escrow_core(
+                &env,
+                &buyer,
+                cfg.seller,
+                cfg.arbiter,
+                cfg.amount,
+                cfg.token,
+                cfg.deadline,
+                cfg.metadata_hash,
+                cfg.sellers,
+                cfg.auto_renew,
+                cfg.renewal_count,
+            );
+
+            if first_id.is_none() {
+                first_id = Some(escrow_id);
+            }
+            last_id = escrow_id;
+            created_ids.push_back(escrow_id);
+        }
+
+        events::emit_batch_escrow_created(
+            &env,
+            escrow_configs.len(),
+            first_id.expect("Batch contained no escrows"),
+            last_id,
+        );
+
+        created_ids
+    }
+
+    fn create_escrow_core(
+        env: &Env,
+        buyer: &Address,
+        seller: Address,
+        arbiter: Address,
+        amount: i128,
+        token: Address,
+        deadline: u64,
+        metadata_hash: Option<BytesN<32>>,
+        sellers: Vec<(Address, u32)>,
+        auto_renew: bool,
+        renewal_count: u32,
+    ) -> u32 {
         if amount <= 0 {
             panic!("Escrow amount must be positive");
         }
@@ -179,7 +276,7 @@ impl AhjoorEscrowContract {
         // Validate multi-party sellers if provided
         let resolved_sellers: Vec<(Address, u32)> = if sellers.is_empty() {
             // Single-seller mode: wrap seller with 10000 bps
-            let mut v = Vec::new(&env);
+            let mut v = Vec::new(env);
             v.push_back((seller.clone(), 10_000u32));
             v
         } else {
@@ -194,20 +291,20 @@ impl AhjoorEscrowContract {
             if total_bps != 10_000 {
                 panic!("Seller allocations must sum to 10000 bps");
             }
-            sellers.clone()
+            sellers
         };
 
         // Transfer tokens from buyer to contract (escrow)
-        let client = token::Client::new(&env, &token);
-        client.transfer(&buyer, &env.current_contract_address(), &amount);
+        let client = token::Client::new(env, &token);
+        client.transfer(buyer, &env.current_contract_address(), &amount);
 
-        let escrow_id = Self::next_escrow_id(&env);
+        let escrow_id = Self::next_escrow_id(env);
 
         // Primary seller is the first in the list (or the passed seller for single-party)
-        let primary_seller = if sellers.is_empty() {
-            seller.clone()
+        let primary_seller = if resolved_sellers.len() == 1 {
+            resolved_sellers.get(0).unwrap().0
         } else {
-            resolved_sellers.get(0).unwrap().0.clone()
+            resolved_sellers.get(0).unwrap().0
         };
 
         let escrow = Escrow {
@@ -255,12 +352,19 @@ impl AhjoorEscrowContract {
         }
 
         events::emit_escrow_created(
-            &env, escrow_id, buyer.clone(), primary_seller, arbiter, amount, token, deadline,
+            env,
+            escrow_id,
+            buyer.clone(),
+            primary_seller,
+            arbiter,
+            amount,
+            token,
+            deadline,
         );
 
         // Emit multi-party event if more than one seller
         if resolved_sellers.len() > 1 {
-            events::emit_multi_party_escrow_created(&env, escrow_id, resolved_sellers.len());
+            events::emit_multi_party_escrow_created(env, escrow_id, resolved_sellers.len());
         }
 
         env.storage()
@@ -1398,7 +1502,7 @@ impl AhjoorEscrowContract {
     /// Active escrows with this arbiter are flagged via ArbiterNeedsReplacement.
     pub fn remove_arbiter(env: Env, admin: Address, arbiter: Address, escrow_ids: Vec<u32>) {
         Self::require_admin(&env, &admin);
-        let mut pool: Vec<Address> = env
+        let pool: Vec<Address> = env
             .storage()
             .instance()
             .get(&DataKey::ArbiterPool)

--- a/contracts/ahjoor-escrow/src/test.rs
+++ b/contracts/ahjoor-escrow/src/test.rs
@@ -2240,3 +2240,198 @@ fn test_auto_renew_fails_with_insufficient_allowance() {
     assert!(result.is_err());
 }
 
+fn make_batch_config(
+    env: &Env,
+    seller: Address,
+    arbiter: Address,
+    amount: i128,
+    token: Address,
+    deadline: u64,
+) -> EscrowBatchConfig {
+    EscrowBatchConfig {
+        seller,
+        arbiter,
+        amount,
+        token,
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(env),
+        auto_renew: false,
+        renewal_count: 0,
+    }
+}
+
+#[test]
+fn test_create_escrows_batch_max_size_contiguous_and_events() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &20_000);
+
+    let mut configs: Vec<EscrowBatchConfig> = Vec::new(&s.env);
+    let deadline = s.env.ledger().timestamp() + 1000;
+    for _ in 0..10 {
+        configs.push_back(make_batch_config(
+            &s.env,
+            Address::generate(&s.env),
+            Address::generate(&s.env),
+            100,
+            s.token_addr.clone(),
+            deadline,
+        ));
+    }
+
+    let ids = s.client.create_escrows_batch(&buyer, &configs);
+    assert_eq!(ids.len(), 10);
+    for i in 0..ids.len() {
+        assert_eq!(ids.get(i).unwrap(), i);
+    }
+
+    let events = s.env.events().all();
+    let created_topic = (Symbol::new(&s.env, "escrow_created"),).into_val(&s.env);
+    let mut created_count: u32 = 0;
+    for i in 0..events.len() {
+        let evt = events.get(i).unwrap();
+        if evt.1 == created_topic {
+            created_count += 1;
+        }
+    }
+    assert_eq!(created_count, 10);
+
+    let batch_topic = (Symbol::new(&s.env, "batch_escrow_created"),).into_val(&s.env);
+    let summary = events
+        .iter()
+        .find(|e| e.1 == batch_topic)
+        .expect("Expected batch summary event");
+
+    let summary_data: soroban_sdk::Map<Symbol, soroban_sdk::Val> = summary.2.into_val(&s.env);
+    let count: u32 = summary_data
+        .get(Symbol::new(&s.env, "count"))
+        .unwrap()
+        .into_val(&s.env);
+    let first_id: u32 = summary_data
+        .get(Symbol::new(&s.env, "first_id"))
+        .unwrap()
+        .into_val(&s.env);
+    let last_id: u32 = summary_data
+        .get(Symbol::new(&s.env, "last_id"))
+        .unwrap()
+        .into_val(&s.env);
+
+    assert_eq!(count, 10);
+    assert_eq!(first_id, 0);
+    assert_eq!(last_id, 9);
+}
+
+#[test]
+fn test_create_escrows_batch_rejects_above_cap() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &20_000);
+
+    let mut configs: Vec<EscrowBatchConfig> = Vec::new(&s.env);
+    let deadline = s.env.ledger().timestamp() + 1000;
+    for _ in 0..11 {
+        configs.push_back(make_batch_config(
+            &s.env,
+            Address::generate(&s.env),
+            Address::generate(&s.env),
+            50,
+            s.token_addr.clone(),
+            deadline,
+        ));
+    }
+
+    let res = s.client.try_create_escrows_batch(&buyer, &configs);
+    assert!(res.is_err());
+    assert_eq!(s.client.get_escrow_counter(), 0);
+    assert_eq!(s.token_client.balance(&buyer), 20_000);
+}
+
+#[test]
+fn test_create_escrows_batch_invalid_config_reverts_entire_batch() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &20_000);
+
+    let mut configs: Vec<EscrowBatchConfig> = Vec::new(&s.env);
+    let deadline = s.env.ledger().timestamp() + 1000;
+
+    configs.push_back(make_batch_config(
+        &s.env,
+        Address::generate(&s.env),
+        Address::generate(&s.env),
+        100,
+        s.token_addr.clone(),
+        deadline,
+    ));
+    configs.push_back(make_batch_config(
+        &s.env,
+        Address::generate(&s.env),
+        Address::generate(&s.env),
+        0,
+        s.token_addr.clone(),
+        deadline,
+    ));
+    configs.push_back(make_batch_config(
+        &s.env,
+        Address::generate(&s.env),
+        Address::generate(&s.env),
+        100,
+        s.token_addr.clone(),
+        deadline,
+    ));
+
+    let res = s.client.try_create_escrows_batch(&buyer, &configs);
+    assert!(res.is_err());
+    assert_eq!(s.client.get_escrow_counter(), 0);
+    assert_eq!(s.token_client.balance(&buyer), 20_000);
+    assert!(s.client.try_get_escrow(&0).is_err());
+}
+
+#[test]
+fn test_create_escrows_batch_single_item() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let mut configs: Vec<EscrowBatchConfig> = Vec::new(&s.env);
+    let deadline = s.env.ledger().timestamp() + 1000;
+    configs.push_back(make_batch_config(
+        &s.env,
+        Address::generate(&s.env),
+        Address::generate(&s.env),
+        250,
+        s.token_addr.clone(),
+        deadline,
+    ));
+
+    let ids = s.client.create_escrows_batch(&buyer, &configs);
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids.get(0).unwrap(), 0);
+
+    let events = s.env.events().all();
+    let batch_topic = (Symbol::new(&s.env, "batch_escrow_created"),).into_val(&s.env);
+    let summary = events
+        .iter()
+        .find(|e| e.1 == batch_topic)
+        .expect("Expected batch summary event");
+    let summary_data: soroban_sdk::Map<Symbol, soroban_sdk::Val> = summary.2.into_val(&s.env);
+
+    let count: u32 = summary_data
+        .get(Symbol::new(&s.env, "count"))
+        .unwrap()
+        .into_val(&s.env);
+    let first_id: u32 = summary_data
+        .get(Symbol::new(&s.env, "first_id"))
+        .unwrap()
+        .into_val(&s.env);
+    let last_id: u32 = summary_data
+        .get(Symbol::new(&s.env, "last_id"))
+        .unwrap()
+        .into_val(&s.env);
+
+    assert_eq!(count, 1);
+    assert_eq!(first_id, 0);
+    assert_eq!(last_id, 0);
+}
+


### PR DESCRIPTION

- add create_escrows_batch for creating multiple escrows in one call
- enforce max batch size of 10 escrows per transaction
- make batch processing atomic so any invalid config reverts the full batch
- return contiguous created escrow IDs to caller
- emit per-escrow EscrowCreated events and BatchEscrowCreated summary event
- add tests for max batch, cap rejection, partial-invalid rollback, and single-item batch

Closes #142