### PR TITLE
feat(escrow): support buyer role transfer for active escrows

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -179,6 +179,15 @@ pub struct EscrowAutoRenewed {
     pub renewals_remaining: u32,
 }
 
+/// Event: Buyer role transferred to another address
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BuyerRoleTransferred {
+    pub escrow_id: u32,
+    pub old_buyer: Address,
+    pub new_buyer: Address,
+}
+
 // --- Helper Emission Functions ---
 
 pub fn emit_escrow_created(
@@ -423,6 +432,20 @@ pub fn emit_escrow_auto_renewed(
         old_escrow_id,
         new_escrow_id,
         renewals_remaining,
+    }
+    .publish(e);
+}
+
+pub fn emit_buyer_role_transferred(
+    e: &Env,
+    escrow_id: u32,
+    old_buyer: Address,
+    new_buyer: Address,
+) {
+    BuyerRoleTransferred {
+        escrow_id,
+        old_buyer,
+        new_buyer,
     }
     .publish(e);
 }

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -1038,6 +1038,53 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found")
     }
 
+    /// Transfer buyer role in an active escrow to a new address.
+    pub fn transfer_buyer_role(
+        env: Env,
+        current_buyer: Address,
+        escrow_id: u32,
+        new_buyer: Address,
+    ) {
+        Self::require_not_paused(&env);
+        current_buyer.require_auth();
+
+        if current_buyer == new_buyer {
+            panic!("New buyer must be different from current buyer");
+        }
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::Active {
+            panic!("Buyer transfer only allowed for active escrows");
+        }
+
+        if escrow.buyer != current_buyer {
+            panic!("Only current buyer can transfer buyer role");
+        }
+
+        let old_buyer = escrow.buyer.clone();
+        escrow.buyer = new_buyer.clone();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_buyer_role_transferred(&env, escrow_id, old_buyer, new_buyer);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
     /// Update metadata hash for an escrow. Requires auth from buyer or seller.
     pub fn update_metadata(
         env: Env,
@@ -1398,7 +1445,7 @@ impl AhjoorEscrowContract {
     /// Active escrows with this arbiter are flagged via ArbiterNeedsReplacement.
     pub fn remove_arbiter(env: Env, admin: Address, arbiter: Address, escrow_ids: Vec<u32>) {
         Self::require_admin(&env, &admin);
-        let mut pool: Vec<Address> = env
+        let pool: Vec<Address> = env
             .storage()
             .instance()
             .get(&DataKey::ArbiterPool)

--- a/contracts/ahjoor-escrow/src/test.rs
+++ b/contracts/ahjoor-escrow/src/test.rs
@@ -2240,3 +2240,140 @@ fn test_auto_renew_fails_with_insufficient_allowance() {
     assert!(result.is_err());
 }
 
+#[test]
+fn test_transfer_buyer_role_requires_current_buyer_authorization() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    let outsider = Address::generate(&s.env);
+    let new_buyer = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &250,
+        &s.token_addr,
+        &deadline,
+        &None,
+        &Vec::new(&s.env),
+        &false,
+        &0u32,
+    );
+
+    let result = s
+        .client
+        .try_transfer_buyer_role(&outsider, &escrow_id, &new_buyer);
+    assert!(result.is_err());
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.buyer, buyer);
+}
+
+#[test]
+fn test_transfer_buyer_role_rejected_during_dispute() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    let new_buyer = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &250,
+        &s.token_addr,
+        &deadline,
+        &None,
+        &Vec::new(&s.env),
+        &false,
+        &0u32,
+    );
+
+    s.client.dispute_escrow(
+        &buyer,
+        &escrow_id,
+        &String::from_str(&s.env, "dispute"),
+        &250,
+    );
+
+    let result = s
+        .client
+        .try_transfer_buyer_role(&buyer, &escrow_id, &new_buyer);
+    assert!(result.is_err());
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.buyer, buyer);
+}
+
+#[test]
+fn test_transfer_buyer_role_new_buyer_inherits_rights_old_buyer_loses_them() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    let new_buyer = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &250,
+        &s.token_addr,
+        &deadline,
+        &None,
+        &Vec::new(&s.env),
+        &false,
+        &0u32,
+    );
+
+    s.client
+        .transfer_buyer_role(&buyer, &escrow_id, &new_buyer);
+
+    let transfer_event = s
+        .env
+        .events()
+        .all()
+        .last()
+        .expect("Expected buyer role transfer event");
+    let data: soroban_sdk::Map<Symbol, soroban_sdk::Val> = transfer_event.2.into_val(&s.env);
+    let event_escrow_id: u32 = data
+        .get(Symbol::new(&s.env, "escrow_id"))
+        .unwrap()
+        .into_val(&s.env);
+    let event_old_buyer: Address = data
+        .get(Symbol::new(&s.env, "old_buyer"))
+        .unwrap()
+        .into_val(&s.env);
+    let event_new_buyer: Address = data
+        .get(Symbol::new(&s.env, "new_buyer"))
+        .unwrap()
+        .into_val(&s.env);
+
+    assert_eq!(event_escrow_id, escrow_id);
+    assert_eq!(event_old_buyer, buyer);
+    assert_eq!(event_new_buyer, new_buyer);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.buyer, new_buyer);
+
+    let old_buyer_release = s.client.try_release_escrow(&buyer, &escrow_id);
+    assert!(old_buyer_release.is_err());
+
+    s.client.release_escrow(&new_buyer, &escrow_id);
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+
+}
+


### PR DESCRIPTION
- add transfer_buyer_role(current_buyer, escrow_id, new_buyer)
- require current buyer authorization before transfer
- restrict transfer to Active escrows and reject disputed escrows
- update escrow buyer ownership and emit BuyerRoleTransferred event
- ensure new buyer inherits release/dispute rights and old buyer loses them
- add tests for auth enforcement, dispute-blocked transfer, and rights inheritance

Closes #143