### PR TITLE
feat:  add Insurance Pool, Arbiter Fee, Time Lock, and Oracle-Conditional Escrow Release

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -13,6 +13,14 @@ pub struct EscrowCreated {
     pub deadline: u64,
 }
 
+/// Event: Escrow creation includes a lock window
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct EscrowTimeLocked {
+    pub escrow_id: u32,
+    pub locked_until: u64,
+}
+
 /// Event: Batch escrow created summary
 #[contractevent]
 #[derive(Clone, Debug)]
@@ -82,6 +90,36 @@ pub struct EscrowProtocolFeePaid {
     pub escrow_id: u32,
     pub fee_amount: i128,
     pub fee_recipient: Address,
+}
+
+/// Event: Arbiter fee paid on dispute resolution
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct ArbiterFeePaid {
+    pub escrow_id: u32,
+    pub arbiter: Address,
+    pub fee_amount: i128,
+}
+
+/// Event: Insurance payout claimed
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct InsuranceClaimed {
+    pub escrow_id: u32,
+    pub claimant: Address,
+    pub amount: i128,
+}
+
+/// Event: Oracle-triggered release executed
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct OracleReleaseTriggered {
+    pub escrow_id: u32,
+    pub oracle_price: i128,
+    pub base: Address,
+    pub quote: Address,
+    pub comparison: u32,
+    pub threshold_price: i128,
 }
 
 /// Event: Escrow refunded to buyer
@@ -221,6 +259,14 @@ pub fn emit_escrow_created(
     .publish(e);
 }
 
+pub fn emit_escrow_time_locked(e: &Env, escrow_id: u32, locked_until: u64) {
+    EscrowTimeLocked {
+        escrow_id,
+        locked_until,
+    }
+    .publish(e);
+}
+
 pub fn emit_batch_escrow_created(e: &Env, count: u32, first_id: u32, last_id: u32) {
     BatchEscrowCreated {
         count,
@@ -303,6 +349,44 @@ pub fn emit_protocol_fee_paid(e: &Env, escrow_id: u32, fee_amount: i128, fee_rec
         escrow_id,
         fee_amount,
         fee_recipient,
+    }
+    .publish(e);
+}
+
+pub fn emit_arbiter_fee_paid(e: &Env, escrow_id: u32, arbiter: Address, fee_amount: i128) {
+    ArbiterFeePaid {
+        escrow_id,
+        arbiter,
+        fee_amount,
+    }
+    .publish(e);
+}
+
+pub fn emit_insurance_claimed(e: &Env, escrow_id: u32, claimant: Address, amount: i128) {
+    InsuranceClaimed {
+        escrow_id,
+        claimant,
+        amount,
+    }
+    .publish(e);
+}
+
+pub fn emit_oracle_release_triggered(
+    e: &Env,
+    escrow_id: u32,
+    oracle_price: i128,
+    base: Address,
+    quote: Address,
+    comparison: u32,
+    threshold_price: i128,
+) {
+    OracleReleaseTriggered {
+        escrow_id,
+        oracle_price,
+        base,
+        quote,
+        comparison,
+        threshold_price,
     }
     .publish(e);
 }

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -11,6 +11,8 @@ const DEADLINE_EXTENSION_PROPOSAL_WINDOW: u64 = 24 * 60 * 60;
 const MAX_EVIDENCE_ENTRIES_PER_PARTY: u32 = 5;
 const DEFAULT_DISPUTE_TIMEOUT_SECONDS: u64 = 7 * 24 * 60 * 60;
 const MAX_BATCH_ESCROWS: u32 = 10;
+const DEFAULT_MAX_ORACLE_AGE_SECONDS: u64 = 300;
+const DEFAULT_INSURANCE_TRIGGER_DAYS: u64 = 7;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[contracttype]
@@ -22,6 +24,47 @@ pub enum EscrowStatus {
     Refunded = 4,
     PartiallyReleased = 5,
     PartiallyDisputed = 6,
+}
+
+const ORACLE_COMPARISON_LESS_OR_EQUAL: u32 = 0;
+const ORACLE_COMPARISON_GREATER_OR_EQUAL: u32 = 1;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseCondition {
+    pub base: Address,
+    pub quote: Address,
+    /// 0 = LessOrEqual, 1 = GreaterOrEqual
+    pub comparison: u32,
+    pub threshold_price: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceData {
+    pub price: i128,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowCreateRequest {
+    pub seller: Address,
+    pub arbiter: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub deadline: u64,
+    pub metadata_hash: Option<BytesN<32>>,
+    pub sellers: Vec<(Address, u32)>,
+    pub auto_renew: bool,
+    pub renewal_count: u32,
+    pub buyer_inactivity_secs: u64,
+    pub min_lock_until: Option<u64>,
+    pub release_base: Option<Address>,
+    pub release_quote: Option<Address>,
+    pub release_comparison: Option<u32>,
+    pub release_threshold_price: Option<i128>,
+    pub arbiter_fee_bps: Option<u32>,
 }
 
 #[contracttype]
@@ -38,12 +81,26 @@ pub struct Escrow {
     pub deadline: u64,
     pub metadata_hash: Option<BytesN<32>>,
     pub sellers: Vec<(Address, u32)>, // (address, bps) — multi-party sellers
+    pub extensions: EscrowExtensions,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowExtensions {
     pub auto_renew: bool,
     pub renewal_count: u32,
     pub renewals_remaining: u32,
     pub dispute_timeout_seconds: Option<u64>,
     /// Seconds of buyer inactivity before seller can claim auto-release; 0 = disabled (#150)
-    pub buyer_inactivity_release_seconds: u64,
+    pub buyer_inactivity_secs: u64,
+    /// Earliest ledger timestamp when release/partial release is permitted.
+    pub min_lock_until: Option<u64>,
+    pub release_base: Option<Address>,
+    pub release_quote: Option<Address>,
+    pub release_comparison: Option<u32>,
+    pub release_threshold_price: Option<i128>,
+    /// Optional per-escrow arbiter fee override in basis points.
+    pub arbiter_fee_bps: Option<u32>,
 }
 
 #[contracttype]
@@ -128,11 +185,31 @@ pub enum DataKey {
     Evidence(u32, Address),
     RenewalAllowance(u32),
     DefaultDisputeTimeout,
+    DefaultArbiterFeeBps,
+    OracleAddress,
+    MaxOracleAge,
+    InsurancePool,
+    InsuranceToken,
+    InsuranceTriggerDays,
+    InsuranceAdminConfirmed(u32),
+    InsuranceClaimed(u32),
     /// Last timestamp of any buyer action for inactivity tracking (#150)
     LastBuyerAction(u32),
 }
 
 const MAX_PROTOCOL_FEE_BPS: u32 = 200; // 2%
+const MAX_ARBITER_FEE_BPS: u32 = 1_000; // 10%
+
+mod oracle {
+    use crate::PriceData;
+    use soroban_sdk::{contractclient, Address, Env};
+
+    #[allow(dead_code)]
+    #[contractclient(name = "OracleClient")]
+    pub trait OracleInterface {
+        fn lastprice(env: Env, base: Address, quote: Address) -> Option<PriceData>;
+    }
+}
 
 mod events;
 
@@ -154,6 +231,14 @@ impl AhjoorEscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::DefaultDisputeTimeout, &DEFAULT_DISPUTE_TIMEOUT_SECONDS);
+        env.storage().instance().set(&DataKey::DefaultArbiterFeeBps, &0u32);
+        env.storage().instance().set(&DataKey::InsurancePool, &0i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceTriggerDays, &DEFAULT_INSURANCE_TRIGGER_DAYS);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxOracleAge, &DEFAULT_MAX_ORACLE_AGE_SECONDS);
 
         env.storage()
             .instance()
@@ -174,14 +259,11 @@ impl AhjoorEscrowContract {
         sellers: Vec<(Address, u32)>,
         auto_renew: bool,
         renewal_count: u32,
-        buyer_inactivity_release_seconds: u64,
     ) -> u32 {
         Self::require_not_paused(&env);
         buyer.require_auth();
 
-        Self::create_escrow_core(
-            &env,
-            &buyer,
+        let request = EscrowCreateRequest {
             seller,
             arbiter,
             amount,
@@ -191,8 +273,65 @@ impl AhjoorEscrowContract {
             sellers,
             auto_renew,
             renewal_count,
-            buyer_inactivity_release_seconds,
-        )
+            buyer_inactivity_secs: 0,
+            min_lock_until: None,
+            release_base: None,
+            release_quote: None,
+            release_comparison: None,
+            release_threshold_price: None,
+            arbiter_fee_bps: None,
+        };
+
+        Self::create_escrow_core(&env, &buyer, request)
+    }
+
+    /// Create a new escrow with explicit inactivity release configuration.
+    pub fn create_escrow_with_inactivity(
+        env: Env,
+        buyer: Address,
+        seller: Address,
+        arbiter: Address,
+        amount: i128,
+        token: Address,
+        deadline: u64,
+        metadata_hash: Option<BytesN<32>>,
+        sellers: Vec<(Address, u32)>,
+        renewal_count: u32,
+        buyer_inactivity_secs: u64,
+    ) -> u32 {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        let auto_renew = renewal_count > 0;
+
+        let request = EscrowCreateRequest {
+            seller,
+            arbiter,
+            amount,
+            token,
+            deadline,
+            metadata_hash,
+            sellers,
+            auto_renew,
+            renewal_count,
+            buyer_inactivity_secs,
+            min_lock_until: None,
+            release_base: None,
+            release_quote: None,
+            release_comparison: None,
+            release_threshold_price: None,
+            arbiter_fee_bps: None,
+        };
+
+        Self::create_escrow_core(&env, &buyer, request)
+    }
+
+    /// Create a new escrow with optional lock, oracle condition, and per-escrow arbiter fee.
+    pub fn create_escrow_v2(env: Env, buyer: Address, request: EscrowCreateRequest) -> u32 {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        Self::create_escrow_core(&env, &buyer, request)
     }
 
     /// Create up to 10 escrows in one atomic transaction.
@@ -221,16 +360,24 @@ impl AhjoorEscrowContract {
             let escrow_id = Self::create_escrow_core(
                 &env,
                 &buyer,
-                cfg.seller,
-                cfg.arbiter,
-                cfg.amount,
-                cfg.token,
-                cfg.deadline,
-                cfg.metadata_hash,
-                cfg.sellers,
-                cfg.auto_renew,
-                cfg.renewal_count,
-                0, // buyer_inactivity_release_seconds not supported in batch config
+                EscrowCreateRequest {
+                    seller: cfg.seller,
+                    arbiter: cfg.arbiter,
+                    amount: cfg.amount,
+                    token: cfg.token,
+                    deadline: cfg.deadline,
+                    metadata_hash: cfg.metadata_hash,
+                    sellers: cfg.sellers,
+                    auto_renew: cfg.auto_renew,
+                    renewal_count: cfg.renewal_count,
+                    buyer_inactivity_secs: 0,
+                    min_lock_until: None,
+                    release_base: None,
+                    release_quote: None,
+                    release_comparison: None,
+                    release_threshold_price: None,
+                    arbiter_fee_bps: None,
+                },
             );
 
             if first_id.is_none() {
@@ -250,26 +397,70 @@ impl AhjoorEscrowContract {
         created_ids
     }
 
-    fn create_escrow_core(
-        env: &Env,
-        buyer: &Address,
-        seller: Address,
-        arbiter: Address,
-        amount: i128,
-        token: Address,
-        deadline: u64,
-        metadata_hash: Option<BytesN<32>>,
-        sellers: Vec<(Address, u32)>,
-        auto_renew: bool,
-        renewal_count: u32,
-        buyer_inactivity_release_seconds: u64,
-    ) -> u32 {
+    fn create_escrow_core(env: &Env, buyer: &Address, request: EscrowCreateRequest) -> u32 {
+        let EscrowCreateRequest {
+            seller,
+            arbiter,
+            amount,
+            token,
+            deadline,
+            metadata_hash,
+            sellers,
+            auto_renew,
+            renewal_count,
+            buyer_inactivity_secs,
+            min_lock_until,
+            release_base,
+            release_quote,
+            release_comparison,
+            release_threshold_price,
+            arbiter_fee_bps,
+        } = request;
+
         if amount <= 0 {
             panic!("Escrow amount must be positive");
         }
 
         if deadline <= env.ledger().timestamp() {
             panic!("Deadline must be in the future");
+        }
+
+        if let Some(lock_until) = min_lock_until {
+            if deadline <= lock_until {
+                panic!("Deadline must be after min_lock_until");
+            }
+        }
+
+        if let Some(fee_bps) = arbiter_fee_bps {
+            if fee_bps > MAX_ARBITER_FEE_BPS {
+                panic!("Arbiter fee exceeds maximum of 1000 bps");
+            }
+        }
+
+        let has_any_release_condition = release_base.is_some()
+            || release_quote.is_some()
+            || release_comparison.is_some()
+            || release_threshold_price.is_some();
+        let has_full_release_condition = release_base.is_some()
+            && release_quote.is_some()
+            && release_comparison.is_some()
+            && release_threshold_price.is_some();
+        if has_any_release_condition && !has_full_release_condition {
+            panic!("Incomplete release condition");
+        }
+
+        if let Some(threshold) = release_threshold_price {
+            if threshold <= 0 {
+                panic!("Release condition threshold must be positive");
+            }
+        }
+
+        if let Some(comparison) = release_comparison {
+            if comparison != ORACLE_COMPARISON_LESS_OR_EQUAL
+                && comparison != ORACLE_COMPARISON_GREATER_OR_EQUAL
+            {
+                panic!("Invalid release comparison");
+            }
         }
 
         let is_allowed = env
@@ -329,15 +520,19 @@ impl AhjoorEscrowContract {
             deadline,
             metadata_hash: metadata_hash.clone(),
             sellers: resolved_sellers.clone(),
-            auto_renew,
-            renewal_count,
-            renewals_remaining: if renewal_count == 0 {
-                0
-            } else {
-                renewal_count
+            extensions: EscrowExtensions {
+                auto_renew,
+                renewal_count,
+                renewals_remaining: if renewal_count == 0 { 0 } else { renewal_count },
+                dispute_timeout_seconds: None,
+                buyer_inactivity_secs,
+                min_lock_until,
+                release_base,
+                release_quote,
+                release_comparison,
+                release_threshold_price,
+                arbiter_fee_bps,
             },
-            dispute_timeout_seconds: None,
-            buyer_inactivity_release_seconds,
         };
 
         env.storage()
@@ -350,7 +545,7 @@ impl AhjoorEscrowContract {
         );
 
         // #150: Initialize LastBuyerAction to creation timestamp
-        if buyer_inactivity_release_seconds > 0 {
+        if buyer_inactivity_secs > 0 {
             env.storage()
                 .persistent()
                 .set(&DataKey::LastBuyerAction(escrow_id), &now);
@@ -388,6 +583,10 @@ impl AhjoorEscrowContract {
         // Emit multi-party event if more than one seller
         if resolved_sellers.len() > 1 {
             events::emit_multi_party_escrow_created(env, escrow_id, resolved_sellers.len());
+        }
+
+        if let Some(lock_until) = escrow.extensions.min_lock_until {
+            events::emit_escrow_time_locked(env, escrow_id, lock_until);
         }
 
         env.storage()
@@ -430,7 +629,6 @@ impl AhjoorEscrowContract {
             sellers,
             auto_renew,
             renewal_count,
-            0, // buyer_inactivity_release_seconds; use create_escrow directly if needed
         );
 
         let mut escrow: Escrow = env
@@ -438,7 +636,7 @@ impl AhjoorEscrowContract {
             .persistent()
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
-        escrow.dispute_timeout_seconds = Some(dispute_timeout_seconds);
+        escrow.extensions.dispute_timeout_seconds = Some(dispute_timeout_seconds);
 
         env.storage()
             .persistent()
@@ -473,41 +671,16 @@ impl AhjoorEscrowContract {
             panic!("Only buyer or arbiter can release escrow");
         }
 
+        Self::require_unlocked(&env, &escrow);
+
         // #150: Track buyer activity
         if caller == escrow.buyer {
             Self::update_last_buyer_action(&env, &escrow);
         }
 
-        let client = token::Client::new(&env, &escrow.token);
         let total = escrow.amount;
 
-        if escrow.sellers.len() <= 1 {
-            // Single-seller path
-            client.transfer(
-                &env.current_contract_address(),
-                &escrow.seller,
-                &total,
-            );
-            events::emit_escrow_released(&env, escrow_id, escrow.seller.clone(), total);
-        } else {
-            // Multi-party: distribute proportionally, dust goes to first seller
-            let mut distributed: i128 = 0;
-            for i in 1..escrow.sellers.len() {
-                let (addr, bps) = escrow.sellers.get(i).unwrap();
-                let share = (total * bps as i128) / 10_000;
-                if share > 0 {
-                    client.transfer(&env.current_contract_address(), &addr, &share);
-                }
-                distributed += share;
-            }
-            // First seller gets remainder (handles rounding dust)
-            let first_share = total - distributed;
-            if first_share > 0 {
-                let (first_addr, _) = escrow.sellers.get(0).unwrap();
-                client.transfer(&env.current_contract_address(), &first_addr, &first_share);
-            }
-            events::emit_multi_party_escrow_released(&env, escrow_id, total);
-        }
+        Self::transfer_to_sellers(&env, &escrow, total, escrow_id);
 
         escrow.status = EscrowStatus::Released;
 
@@ -628,7 +801,7 @@ impl AhjoorEscrowContract {
             panic!("Only buyer can set renewal allowance");
         }
 
-        if !escrow.auto_renew {
+        if !escrow.extensions.auto_renew {
             panic!("Auto-renew is not enabled for this escrow");
         }
 
@@ -667,8 +840,8 @@ impl AhjoorEscrowContract {
             panic!("Only buyer can cancel auto-renew");
         }
 
-        escrow.auto_renew = false;
-        escrow.renewals_remaining = 0;
+        escrow.extensions.auto_renew = false;
+        escrow.extensions.renewals_remaining = 0;
 
         env.storage()
             .persistent()
@@ -694,6 +867,8 @@ impl AhjoorEscrowContract {
         if caller != escrow.buyer && caller != escrow.arbiter {
             panic!("Only buyer or arbiter can release escrow");
         }
+
+        Self::require_unlocked(&env, &escrow);
 
         if release_amount <= 0 {
             panic!("Release amount must be positive");
@@ -803,7 +978,7 @@ impl AhjoorEscrowContract {
             created_at: env.ledger().timestamp(),
             resolved: false,
             dispute_amount,
-            timeout_seconds: escrow.dispute_timeout_seconds,
+            timeout_seconds: escrow.extensions.dispute_timeout_seconds,
         };
         env.storage()
             .persistent()
@@ -848,6 +1023,14 @@ impl AhjoorEscrowContract {
 
         let client = token::Client::new(&env, &escrow.token);
 
+        let arbiter_fee_bps = Self::effective_arbiter_fee_bps(&env, &escrow);
+        let arbiter_fee = (escrow.amount * arbiter_fee_bps as i128) / 10_000;
+
+        if arbiter_fee > 0 {
+            client.transfer(&env.current_contract_address(), &arbiter, &arbiter_fee);
+            events::emit_arbiter_fee_paid(&env, escrow_id, arbiter.clone(), arbiter_fee);
+        }
+
         // Compute and deduct protocol fee
         let fee_bps: u32 = env
             .storage()
@@ -870,7 +1053,11 @@ impl AhjoorEscrowContract {
             events::emit_protocol_fee_paid(&env, escrow_id, protocol_fee, fee_recipient);
         }
 
-        let winner_amount = escrow.amount - protocol_fee;
+        let winner_amount = escrow.amount - protocol_fee - arbiter_fee;
+
+        if winner_amount < 0 {
+            panic!("Fee configuration exceeds escrow amount");
+        }
 
         if release_to_seller {
             client.transfer(
@@ -977,6 +1164,246 @@ impl AhjoorEscrowContract {
             .unwrap_or(DEFAULT_DISPUTE_TIMEOUT_SECONDS)
     }
 
+    /// Set the protocol-wide default arbiter fee (bps). Admin only.
+    /// Fee cap is 1000 bps (10%).
+    pub fn set_default_arbiter_fee_bps(env: Env, admin: Address, fee_bps: u32) {
+        Self::require_admin(&env, &admin);
+        if fee_bps > MAX_ARBITER_FEE_BPS {
+            panic!("Arbiter fee exceeds maximum of 1000 bps");
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::DefaultArbiterFeeBps, &fee_bps);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    pub fn get_default_arbiter_fee_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::DefaultArbiterFeeBps)
+            .unwrap_or(0)
+    }
+
+    /// Configure oracle address and max accepted price age (seconds). Admin only.
+    pub fn set_oracle(env: Env, admin: Address, oracle: Address, max_oracle_age: u64) {
+        Self::require_admin(&env, &admin);
+        if max_oracle_age == 0 {
+            panic!("max_oracle_age must be positive");
+        }
+
+        env.storage().instance().set(&DataKey::OracleAddress, &oracle);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxOracleAge, &max_oracle_age);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    pub fn get_oracle_address(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::OracleAddress)
+            .expect("Oracle not configured")
+    }
+
+    pub fn get_max_oracle_age(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxOracleAge)
+            .unwrap_or(DEFAULT_MAX_ORACLE_AGE_SECONDS)
+    }
+
+    /// Configure insurance token and trigger window in days. Admin only.
+    pub fn set_insurance_config(env: Env, admin: Address, token: Address, trigger_days: u64) {
+        Self::require_admin(&env, &admin);
+        if trigger_days == 0 {
+            panic!("insurance_trigger_days must be positive");
+        }
+
+        let is_allowed = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowedToken(token.clone()))
+            .unwrap_or(false);
+        if !is_allowed {
+            panic!("TokenNotAllowed");
+        }
+
+        env.storage().instance().set(&DataKey::InsuranceToken, &token);
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceTriggerDays, &trigger_days);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    pub fn get_insurance_pool(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::InsurancePool)
+            .unwrap_or(0)
+    }
+
+    /// Open contribution flow for the insurance pool.
+    pub fn contribute_to_insurance(env: Env, contributor: Address, amount: i128) {
+        Self::require_not_paused(&env);
+        contributor.require_auth();
+
+        if amount <= 0 {
+            panic!("Insurance contribution must be positive");
+        }
+
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceToken)
+            .expect("Insurance token not configured");
+
+        let client = token::Client::new(&env, &token);
+        client.transfer(&contributor, &env.current_contract_address(), &amount);
+
+        let current_pool: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsurancePool)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::InsurancePool, &(current_pool + amount));
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Admin confirms or clears inactivity confirmation for a disputed escrow.
+    pub fn confirm_insurance_inactivity(
+        env: Env,
+        admin: Address,
+        escrow_id: u32,
+        confirmed: bool,
+    ) {
+        Self::require_admin(&env, &admin);
+        env.storage()
+            .persistent()
+            .set(&DataKey::InsuranceAdminConfirmed(escrow_id), &confirmed);
+        env.storage().persistent().extend_ttl(
+            &DataKey::InsuranceAdminConfirmed(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+
+    /// Claim insurance for unresolved disputes after admin-confirmed inactivity.
+    /// The claim amount is capped at 50% of the disputed amount and pool balance.
+    pub fn claim_insurance(env: Env, claimant: Address, escrow_id: u32) {
+        Self::require_not_paused(&env);
+        claimant.require_auth();
+
+        let escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if claimant != escrow.buyer && claimant != escrow.seller {
+            panic!("Only buyer or seller can claim insurance");
+        }
+
+        if escrow.status != EscrowStatus::Disputed
+            && escrow.status != EscrowStatus::PartiallyDisputed
+        {
+            panic!("Escrow is not disputed");
+        }
+
+        let dispute: Dispute = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Dispute(escrow_id))
+            .expect("Dispute not found");
+        if dispute.resolved {
+            panic!("Dispute already resolved");
+        }
+
+        if env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::InsuranceClaimed(escrow_id))
+            .unwrap_or(false)
+        {
+            panic!("Insurance already claimed");
+        }
+
+        let confirmed: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::InsuranceAdminConfirmed(escrow_id))
+            .unwrap_or(false);
+        if !confirmed {
+            panic!("Admin confirmation required");
+        }
+
+        let trigger_days: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceTriggerDays)
+            .unwrap_or(DEFAULT_INSURANCE_TRIGGER_DAYS);
+        let trigger_seconds = trigger_days.saturating_mul(24 * 60 * 60);
+        let elapsed = env.ledger().timestamp().saturating_sub(dispute.created_at);
+        if elapsed < trigger_seconds {
+            panic!("Insurance trigger period not reached");
+        }
+
+        let insurance_token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceToken)
+            .expect("Insurance token not configured");
+        if insurance_token != escrow.token {
+            panic!("Escrow token not covered by insurance pool");
+        }
+
+        let max_claim = escrow.amount / 2;
+        let pool_balance: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsurancePool)
+            .unwrap_or(0);
+        let claim_amount = if pool_balance < max_claim {
+            pool_balance
+        } else {
+            max_claim
+        };
+
+        if claim_amount <= 0 {
+            panic!("Insurance pool has insufficient balance");
+        }
+
+        let token_client = token::Client::new(&env, &insurance_token);
+        token_client.transfer(&env.current_contract_address(), &claimant, &claim_amount);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::InsurancePool, &(pool_balance - claim_amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::InsuranceClaimed(escrow_id), &true);
+        env.storage().persistent().extend_ttl(
+            &DataKey::InsuranceClaimed(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_insurance_claimed(&env, escrow_id, claimant, claim_amount);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
     /// Set protocol fee in basis points and fee recipient. Admin only.
     /// Max fee is 200 bps (2%).
     pub fn update_protocol_fee(env: Env, admin: Address, fee_bps: u32, fee_recipient: Address) {
@@ -1006,6 +1433,76 @@ impl AhjoorEscrowContract {
         (fee_bps, fee_recipient)
     }
 
+    /// Anyone may trigger release when the escrow's oracle condition is met.
+    pub fn check_and_release_escrow(env: Env, escrow_id: u32) {
+        Self::require_not_paused(&env);
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if !Self::is_open_escrow_status(escrow.status) {
+            panic!("Escrow is not active");
+        }
+
+        let base = escrow
+            .extensions
+            .release_base
+            .clone()
+            .expect("No release condition set");
+        let quote = escrow
+            .extensions
+            .release_quote
+            .clone()
+            .expect("No release condition set");
+        let comparison = escrow
+            .extensions
+            .release_comparison
+            .expect("No release condition set");
+        let threshold_price = escrow
+            .extensions
+            .release_threshold_price
+            .expect("No release condition set");
+
+        let price_data = Self::get_oracle_price(&env, &base, &quote);
+        let condition_met = match comparison {
+            ORACLE_COMPARISON_LESS_OR_EQUAL => price_data.price <= threshold_price,
+            ORACLE_COMPARISON_GREATER_OR_EQUAL => price_data.price >= threshold_price,
+            _ => panic!("Invalid release comparison"),
+        };
+
+        if !condition_met {
+            panic!("Release condition not met");
+        }
+
+        Self::transfer_to_sellers(&env, &escrow, escrow.amount, escrow_id);
+        escrow.status = EscrowStatus::Released;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_oracle_release_triggered(
+            &env,
+            escrow_id,
+            price_data.price,
+            base,
+            quote,
+            comparison,
+            threshold_price,
+        );
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
     /// Auto-release expired escrow (past deadline, undisputed). Can be called by buyer.
     pub fn auto_release_expired(env: Env, escrow_id: u32) {
         Self::require_not_paused(&env);
@@ -1022,6 +1519,8 @@ impl AhjoorEscrowContract {
         if env.ledger().timestamp() <= escrow.deadline {
             panic!("Escrow has not expired yet");
         }
+
+        Self::require_unlocked(&env, &escrow);
 
         escrow.buyer.require_auth();
 
@@ -1533,11 +2032,19 @@ impl AhjoorEscrowContract {
             deadline,
             metadata_hash: None,
             sellers: single_seller,
-            auto_renew: false,
-            renewal_count: 0,
-            renewals_remaining: 0,
-            dispute_timeout_seconds: None,
-            buyer_inactivity_release_seconds: 0,
+            extensions: EscrowExtensions {
+                auto_renew: false,
+                renewal_count: 0,
+                renewals_remaining: 0,
+                dispute_timeout_seconds: None,
+                buyer_inactivity_secs: 0,
+                min_lock_until: None,
+                release_base: None,
+                release_quote: None,
+                release_comparison: None,
+                release_threshold_price: None,
+                arbiter_fee_bps: None,
+            },
         };
 
         env.storage()
@@ -1712,11 +2219,19 @@ impl AhjoorEscrowContract {
             deadline,
             metadata_hash: None,
             sellers: single_seller,
-            auto_renew: false,
-            renewal_count: 0,
-            renewals_remaining: 0,
-            dispute_timeout_seconds: None,
-            buyer_inactivity_release_seconds: 0,
+            extensions: EscrowExtensions {
+                auto_renew: false,
+                renewal_count: 0,
+                renewals_remaining: 0,
+                dispute_timeout_seconds: None,
+                buyer_inactivity_secs: 0,
+                min_lock_until: None,
+                release_base: None,
+                release_quote: None,
+                release_comparison: None,
+                release_threshold_price: None,
+                arbiter_fee_bps: None,
+            },
         };
 
         env.storage()
@@ -1833,7 +2348,7 @@ impl AhjoorEscrowContract {
     // -------------------------------------------------------------------------
 
     /// Claim an inactivity-based release to seller.
-    /// Callable only by the escrow's seller after `buyer_inactivity_release_seconds`
+    /// Callable only by the escrow's seller after `buyer_inactivity_secs`
     /// have elapsed without any buyer action. Disabled when the field is 0.
     pub fn claim_inactivity_release(env: Env, seller: Address, escrow_id: u32) {
         Self::require_not_paused(&env);
@@ -1845,7 +2360,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
 
-        if escrow.buyer_inactivity_release_seconds == 0 {
+        if escrow.extensions.buyer_inactivity_secs == 0 {
             panic!("Inactivity release is not enabled for this escrow");
         }
 
@@ -1866,7 +2381,7 @@ impl AhjoorEscrowContract {
         let now = env.ledger().timestamp();
         let inactivity_seconds = now.saturating_sub(last_action);
 
-        if inactivity_seconds < escrow.buyer_inactivity_release_seconds {
+        if inactivity_seconds < escrow.extensions.buyer_inactivity_secs {
             panic!("Buyer inactivity window has not elapsed");
         }
 
@@ -1935,6 +2450,77 @@ impl AhjoorEscrowContract {
         }
     }
 
+    fn require_unlocked(env: &Env, escrow: &Escrow) {
+        if let Some(lock_until) = escrow.extensions.min_lock_until {
+            if env.ledger().timestamp() < lock_until {
+                panic!("EscrowStillLocked");
+            }
+        }
+    }
+
+    fn transfer_to_sellers(env: &Env, escrow: &Escrow, total: i128, escrow_id: u32) {
+        let client = token::Client::new(env, &escrow.token);
+        if escrow.sellers.len() <= 1 {
+            client.transfer(&env.current_contract_address(), &escrow.seller, &total);
+            events::emit_escrow_released(env, escrow_id, escrow.seller.clone(), total);
+            return;
+        }
+
+        let mut distributed: i128 = 0;
+        for i in 1..escrow.sellers.len() {
+            let (addr, bps) = escrow.sellers.get(i).unwrap();
+            let share = (total * bps as i128) / 10_000;
+            if share > 0 {
+                client.transfer(&env.current_contract_address(), &addr, &share);
+            }
+            distributed += share;
+        }
+
+        let first_share = total - distributed;
+        if first_share > 0 {
+            let (first_addr, _) = escrow.sellers.get(0).unwrap();
+            client.transfer(&env.current_contract_address(), &first_addr, &first_share);
+        }
+        events::emit_multi_party_escrow_released(env, escrow_id, total);
+    }
+
+    fn get_oracle_price(env: &Env, base: &Address, quote: &Address) -> PriceData {
+        let oracle_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::OracleAddress)
+            .expect("Oracle not configured");
+        let max_oracle_age: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxOracleAge)
+            .unwrap_or(DEFAULT_MAX_ORACLE_AGE_SECONDS);
+
+        let oracle_client = oracle::OracleClient::new(env, &oracle_addr);
+        let price_data = oracle_client
+            .lastprice(base, quote)
+            .expect("Oracle price unavailable");
+
+        let age = env.ledger().timestamp().saturating_sub(price_data.timestamp);
+        if age > max_oracle_age {
+            panic!("Oracle price is stale");
+        }
+        if price_data.price <= 0 {
+            panic!("Invalid oracle price");
+        }
+
+        price_data
+    }
+
+    fn effective_arbiter_fee_bps(env: &Env, escrow: &Escrow) -> u32 {
+        escrow.extensions.arbiter_fee_bps.unwrap_or(
+            env.storage()
+                .instance()
+                .get(&DataKey::DefaultArbiterFeeBps)
+                .unwrap_or(0),
+        )
+    }
+
     fn is_open_escrow_status(status: EscrowStatus) -> bool {
         matches!(
             status,
@@ -1964,11 +2550,11 @@ impl AhjoorEscrowContract {
     }
 
     fn try_auto_renew(env: &Env, old_escrow_id: u32, source: &Escrow) {
-        if !source.auto_renew {
+        if !source.extensions.auto_renew {
             return;
         }
 
-        if source.renewal_count != 0 && source.renewals_remaining == 0 {
+        if source.extensions.renewal_count != 0 && source.extensions.renewals_remaining == 0 {
             return;
         }
 
@@ -1996,10 +2582,10 @@ impl AhjoorEscrowContract {
 
         let new_escrow_id = Self::next_escrow_id(env);
         let now = env.ledger().timestamp();
-        let renewals_remaining = if source.renewal_count == 0 {
+        let renewals_remaining = if source.extensions.renewal_count == 0 {
             0
         } else {
-            source.renewals_remaining - 1
+            source.extensions.renewals_remaining - 1
         };
 
         let renewed = Escrow {
@@ -2014,15 +2600,23 @@ impl AhjoorEscrowContract {
             deadline: now + duration,
             metadata_hash: source.metadata_hash.clone(),
             sellers: source.sellers.clone(),
-            auto_renew: source.auto_renew,
-            renewal_count: source.renewal_count,
-            renewals_remaining,
-            dispute_timeout_seconds: source.dispute_timeout_seconds,
-            buyer_inactivity_release_seconds: source.buyer_inactivity_release_seconds,
+            extensions: EscrowExtensions {
+                auto_renew: source.extensions.auto_renew,
+                renewal_count: source.extensions.renewal_count,
+                renewals_remaining,
+                dispute_timeout_seconds: source.extensions.dispute_timeout_seconds,
+                buyer_inactivity_secs: source.extensions.buyer_inactivity_secs,
+                min_lock_until: source.extensions.min_lock_until,
+                release_base: source.extensions.release_base.clone(),
+                release_quote: source.extensions.release_quote.clone(),
+                release_comparison: source.extensions.release_comparison,
+                release_threshold_price: source.extensions.release_threshold_price,
+                arbiter_fee_bps: source.extensions.arbiter_fee_bps,
+            },
         };
 
         // #150: Initialize LastBuyerAction for renewed escrow
-        if source.buyer_inactivity_release_seconds > 0 {
+        if source.extensions.buyer_inactivity_secs > 0 {
             env.storage()
                 .persistent()
                 .set(&DataKey::LastBuyerAction(new_escrow_id), &now);
@@ -2058,7 +2652,7 @@ impl AhjoorEscrowContract {
     /// Update the LastBuyerAction timestamp for inactivity tracking (#150).
     /// Only records when inactivity release is enabled for the escrow.
     fn update_last_buyer_action(env: &Env, escrow: &Escrow) {
-        if escrow.buyer_inactivity_release_seconds == 0 {
+        if escrow.extensions.buyer_inactivity_secs == 0 {
             return;
         }
         let now = env.ledger().timestamp();

--- a/contracts/ahjoor-escrow/src/test.rs
+++ b/contracts/ahjoor-escrow/src/test.rs
@@ -2144,7 +2144,7 @@ fn test_auto_renew_creates_next_escrow_on_release() {
     let renewed = s.client.get_escrow(&next_id);
     assert_eq!(renewed.status, EscrowStatus::Active);
     assert_eq!(renewed.amount, 500);
-    assert_eq!(renewed.renewals_remaining, 1);
+    assert_eq!(renewed.extensions.renewals_remaining, 1);
 }
 
 #[test]
@@ -2374,6 +2374,7 @@ fn test_transfer_buyer_role_new_buyer_inherits_rights_old_buyer_loses_them() {
     s.client.release_escrow(&new_buyer, &escrow_id);
     let escrow = s.client.get_escrow(&escrow_id);
     assert_eq!(escrow.status, EscrowStatus::Released);
+}
 
 fn make_batch_config(
     env: &Env,
@@ -2570,3 +2571,1083 @@ fn test_create_escrows_batch_single_item() {
     assert_eq!(last_id, 0);
 }
 
+
+
+// ===========================================================================
+//  Issue #137: Insurance Pool Tests
+// ===========================================================================
+
+fn setup_insurance<'a>(s: &'a TestSetup<'a>) {
+    s.client.set_insurance_config(&s.admin, &s.token_addr, &7u64);
+}
+
+#[test]
+fn test_insurance_contribute_and_pool_balance() {
+    let s = setup();
+    setup_insurance(&s);
+
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &1000);
+
+    s.client.contribute_to_insurance(&contributor, &500);
+    assert_eq!(s.client.get_insurance_pool(), 500);
+
+    s.client.contribute_to_insurance(&contributor, &300);
+    assert_eq!(s.client.get_insurance_pool(), 800);
+}
+
+#[test]
+fn test_insurance_claim_after_trigger_period() {
+    let s = setup();
+    setup_insurance(&s);
+
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &10_000);
+    s.client.contribute_to_insurance(&contributor, &10_000);
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(1000);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &1000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "stuck"), &1000);
+
+    // Advance past 7-day trigger (7 * 24 * 60 * 60 = 604800 seconds)
+    s.env.ledger().set_timestamp(1000 + 604_801);
+
+    s.client.confirm_insurance_inactivity(&s.admin, &escrow_id, &true);
+    s.client.claim_insurance(&buyer, &escrow_id);
+
+    // Claim is capped at 50% of escrow amount = 500
+    assert_eq!(s.token_client.balance(&buyer), 500);
+    assert_eq!(s.client.get_insurance_pool(), 9_500);
+}
+
+#[test]
+fn test_insurance_claim_capped_at_50_percent() {
+    let s = setup();
+    setup_insurance(&s);
+
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &10_000);
+    s.client.contribute_to_insurance(&contributor, &10_000);
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &2000);
+
+    s.env.ledger().set_timestamp(1000);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &2000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "stuck"), &2000);
+    s.env.ledger().set_timestamp(1000 + 604_801);
+    s.client.confirm_insurance_inactivity(&s.admin, &escrow_id, &true);
+    s.client.claim_insurance(&buyer, &escrow_id);
+
+    // 50% of 2000 = 1000
+    assert_eq!(s.token_client.balance(&buyer), 1000);
+}
+
+#[test]
+fn test_insurance_claim_before_trigger_period_panics() {
+    let s = setup();
+    setup_insurance(&s);
+
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &10_000);
+    s.client.contribute_to_insurance(&contributor, &10_000);
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(1000);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &1000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "stuck"), &1000);
+    // Only 1 day elapsed, not 7
+    s.env.ledger().set_timestamp(1000 + 86_400);
+    s.client.confirm_insurance_inactivity(&s.admin, &escrow_id, &true);
+
+    let result = s.client.try_claim_insurance(&buyer, &escrow_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_insurance_claim_requires_admin_confirmation() {
+    let s = setup();
+    setup_insurance(&s);
+
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &10_000);
+    s.client.contribute_to_insurance(&contributor, &10_000);
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(1000);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &1000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "stuck"), &1000);
+    s.env.ledger().set_timestamp(1000 + 604_801);
+    // No admin confirmation
+
+    let result = s.client.try_claim_insurance(&buyer, &escrow_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_insurance_claim_emits_event() {
+    let s = setup();
+    setup_insurance(&s);
+
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &10_000);
+    s.client.contribute_to_insurance(&contributor, &10_000);
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(1000);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &1000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "stuck"), &1000);
+    s.env.ledger().set_timestamp(1000 + 604_801);
+    s.client.confirm_insurance_inactivity(&s.admin, &escrow_id, &true);
+    s.client.claim_insurance(&buyer, &escrow_id);
+
+    let events = s.env.events().all();
+    let topic = (Symbol::new(&s.env, "insurance_claimed"),).into_val(&s.env);
+    let found = events.iter().any(|e| e.1 == topic);
+    assert!(found, "Expected insurance_claimed event");
+}
+
+#[test]
+fn test_insurance_pool_capped_by_pool_balance() {
+    let s = setup();
+    setup_insurance(&s);
+
+    // Pool only has 100, escrow is 1000 → claim = min(500, 100) = 100
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &100);
+    s.client.contribute_to_insurance(&contributor, &100);
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(1000);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &1000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "stuck"), &1000);
+    s.env.ledger().set_timestamp(1000 + 604_801);
+    s.client.confirm_insurance_inactivity(&s.admin, &escrow_id, &true);
+    s.client.claim_insurance(&buyer, &escrow_id);
+
+    assert_eq!(s.token_client.balance(&buyer), 100);
+    assert_eq!(s.client.get_insurance_pool(), 0);
+}
+
+// ===========================================================================
+//  Issue #138: Arbitration Fee Mechanism Tests
+// ===========================================================================
+
+#[test]
+fn test_arbiter_fee_deducted_from_loser_seller_wins() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    // 500 bps = 5% arbiter fee
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: Some(500u32),
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
+    // Seller wins
+    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+
+    // fee = 1000 * 500 / 10000 = 50; seller gets 950
+    assert_eq!(s.token_client.balance(&arbiter), 50);
+    assert_eq!(s.token_client.balance(&seller), 950);
+    assert_eq!(s.token_client.balance(&buyer), 0);
+}
+
+#[test]
+fn test_arbiter_fee_deducted_from_loser_buyer_wins() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: Some(500u32),
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
+    // Buyer wins
+    s.client.resolve_dispute(&arbiter, &escrow_id, &false);
+
+    // fee = 50; buyer gets 950
+    assert_eq!(s.token_client.balance(&arbiter), 50);
+    assert_eq!(s.token_client.balance(&buyer), 950);
+    assert_eq!(s.token_client.balance(&seller), 0);
+}
+
+#[test]
+fn test_arbiter_fee_zero_is_valid() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: Some(0u32),
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+
+    assert_eq!(s.token_client.balance(&arbiter), 0);
+    assert_eq!(s.token_client.balance(&seller), 1000);
+}
+
+#[test]
+fn test_arbiter_fee_cap_enforced_at_creation() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: Some(1001u32), // exceeds 1000 bps max
+    };
+    let result = s.client.try_create_escrow_v2(&buyer, &request);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_default_arbiter_fee_applies_when_escrow_fee_not_set() {
+    let s = setup();
+
+    // Set protocol-wide default to 200 bps (2%)
+    s.client.set_default_arbiter_fee_bps(&s.admin, &200u32);
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &1000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+
+    // fee = 1000 * 200 / 10000 = 20
+    assert_eq!(s.token_client.balance(&arbiter), 20);
+    assert_eq!(s.token_client.balance(&seller), 980);
+}
+
+#[test]
+fn test_arbiter_fee_emits_event() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: Some(300u32),
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+
+    let events = s.env.events().all();
+    let topic = (Symbol::new(&s.env, "arbiter_fee_paid"),).into_val(&s.env);
+    let found = events.iter().any(|e| e.1 == topic);
+    assert!(found, "Expected arbiter_fee_paid event");
+}
+
+// ===========================================================================
+//  Issue #139: Time-Locked Escrow Tests
+// ===========================================================================
+
+#[test]
+fn test_release_before_min_lock_until_panics() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(1000);
+    let lock_until = 2000u64;
+    let deadline = 3000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 500,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: Some(lock_until),
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    // Still before lock_until
+    s.env.ledger().set_timestamp(1500);
+    let result = s.client.try_release_escrow(&buyer, &escrow_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_release_at_min_lock_until_succeeds() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(1000);
+    let lock_until = 2000u64;
+    let deadline = 3000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 500,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: Some(lock_until),
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    // Exactly at lock_until
+    s.env.ledger().set_timestamp(2000);
+    s.client.release_escrow(&buyer, &escrow_id);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(s.token_client.balance(&seller), 500);
+}
+
+#[test]
+fn test_release_after_min_lock_until_succeeds() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(1000);
+    let lock_until = 2000u64;
+    let deadline = 5000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 500,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: Some(lock_until),
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    s.env.ledger().set_timestamp(2500);
+    s.client.release_escrow(&buyer, &escrow_id);
+
+    assert_eq!(s.token_client.balance(&seller), 500);
+}
+
+#[test]
+fn test_dispute_not_blocked_by_lock() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(1000);
+    let lock_until = 5000u64;
+    let deadline = 6000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 500,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: Some(lock_until),
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    // Still locked, but dispute should work
+    s.env.ledger().set_timestamp(2000);
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "issue"), &500);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Disputed);
+}
+
+#[test]
+fn test_lock_and_deadline_independently_configurable() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    let lock_until = 500u64;
+    let deadline = 1000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 500,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: Some(lock_until),
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.extensions.min_lock_until, Some(lock_until));
+    assert_eq!(escrow.deadline, deadline);
+}
+
+#[test]
+fn test_time_locked_escrow_emits_event() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    let lock_until = 500u64;
+    let deadline = 1000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 500,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: Some(lock_until),
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: None,
+    };
+    s.client.create_escrow_v2(&buyer, &request);
+
+    let events = s.env.events().all();
+    let topic = (Symbol::new(&s.env, "escrow_time_locked"),).into_val(&s.env);
+    let found = events.iter().any(|e| e.1 == topic);
+    assert!(found, "Expected escrow_time_locked event");
+}
+
+#[test]
+fn test_deadline_must_be_after_lock_until() {
+    let s = setup();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    // deadline == lock_until → should panic
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 500,
+        token: s.token_addr.clone(),
+        deadline: 500,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: Some(500u64),
+        release_base: None,
+        release_quote: None,
+        release_comparison: None,
+        release_threshold_price: None,
+        arbiter_fee_bps: None,
+    };
+    let result = s.client.try_create_escrow_v2(&buyer, &request);
+    assert!(result.is_err());
+}
+
+// ===========================================================================
+//  Issue #140: Oracle-Conditional Escrow Release Tests
+// ===========================================================================
+
+/// Mock oracle for escrow oracle-release tests.
+mod escrow_mock_oracle {
+    use crate::PriceData;
+    use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+    #[contracttype]
+    enum OracleKey {
+        Price,
+        Ts,
+    }
+
+    #[contract]
+    pub struct EscrowMockOracle;
+
+    #[contractimpl]
+    impl EscrowMockOracle {
+        pub fn set_price(env: Env, price: i128, timestamp: u64) {
+            env.storage().instance().set(&OracleKey::Price, &price);
+            env.storage().instance().set(&OracleKey::Ts, &timestamp);
+        }
+
+        pub fn lastprice(env: Env, _base: Address, _quote: Address) -> Option<PriceData> {
+            let price: i128 = env.storage().instance().get(&OracleKey::Price)?;
+            let timestamp: u64 = env.storage().instance().get(&OracleKey::Ts)?;
+            Some(PriceData { price, timestamp })
+        }
+    }
+}
+
+use escrow_mock_oracle::EscrowMockOracle;
+
+struct OracleEscrowSetup<'a> {
+    env: Env,
+    client: AhjoorEscrowContractClient<'a>,
+    admin: Address,
+    token_addr: Address,
+    token_client: TokenClient<'a>,
+    token_admin_client: TokenAdminClient<'a>,
+    oracle_addr: Address,
+    base: Address,
+    quote: Address,
+}
+
+fn setup_oracle_escrow<'a>() -> OracleEscrowSetup<'a> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AhjoorEscrowContract, ());
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_client = TokenClient::new(&env, &token_addr);
+    let token_admin_client = TokenAdminClient::new(&env, &token_addr);
+
+    let oracle_addr = env.register(EscrowMockOracle, ());
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.add_allowed_token(&admin, &token_addr);
+    client.set_oracle(&admin, &oracle_addr, &300u64);
+
+    OracleEscrowSetup {
+        env,
+        client,
+        admin,
+        token_addr,
+        token_client,
+        token_admin_client,
+        oracle_addr,
+        base,
+        quote,
+    }
+}
+
+fn set_escrow_oracle_price(s: &OracleEscrowSetup, price: i128, ts: u64) {
+    use escrow_mock_oracle::EscrowMockOracleClient;
+    let oc = EscrowMockOracleClient::new(&s.env, &s.oracle_addr);
+    oc.set_price(&price, &ts);
+    s.env.ledger().set_timestamp(ts);
+}
+
+#[test]
+fn test_oracle_release_triggers_when_price_below_threshold() {
+    let s = setup_oracle_escrow();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    let deadline = 5000u64;
+
+    // LessOrEqual condition: release when price <= 500
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: Some(s.base.clone()),
+        release_quote: Some(s.quote.clone()),
+        release_comparison: Some(0u32), // LessOrEqual
+        release_threshold_price: Some(500),
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    // Price = 400 <= 500 → condition met
+    set_escrow_oracle_price(&s, 400, 200);
+    s.client.check_and_release_escrow(&escrow_id);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(s.token_client.balance(&seller), 1000);
+}
+
+#[test]
+fn test_oracle_release_does_not_trigger_when_price_above_threshold() {
+    let s = setup_oracle_escrow();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    let deadline = 5000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: Some(s.base.clone()),
+        release_quote: Some(s.quote.clone()),
+        release_comparison: Some(0u32), // LessOrEqual
+        release_threshold_price: Some(500),
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    // Price = 600 > 500 → condition NOT met
+    set_escrow_oracle_price(&s, 600, 200);
+    let result = s.client.try_check_and_release_escrow(&escrow_id);
+    assert!(result.is_err());
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Active);
+}
+
+#[test]
+fn test_oracle_release_triggers_when_price_at_threshold() {
+    let s = setup_oracle_escrow();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    let deadline = 5000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: Some(s.base.clone()),
+        release_quote: Some(s.quote.clone()),
+        release_comparison: Some(0u32), // LessOrEqual
+        release_threshold_price: Some(500),
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    // Price exactly at threshold = 500 → condition met (<=)
+    set_escrow_oracle_price(&s, 500, 200);
+    s.client.check_and_release_escrow(&escrow_id);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+}
+
+#[test]
+fn test_oracle_release_greater_or_equal_condition() {
+    let s = setup_oracle_escrow();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    let deadline = 5000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: Some(s.base.clone()),
+        release_quote: Some(s.quote.clone()),
+        release_comparison: Some(1u32), // GreaterOrEqual
+        release_threshold_price: Some(1000),
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    // Price = 1200 >= 1000 → condition met
+    set_escrow_oracle_price(&s, 1200, 200);
+    s.client.check_and_release_escrow(&escrow_id);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+}
+
+#[test]
+fn test_oracle_stale_price_blocks_release() {
+    let s = setup_oracle_escrow();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    let deadline = 5000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: Some(s.base.clone()),
+        release_quote: Some(s.quote.clone()),
+        release_comparison: Some(0u32),
+        release_threshold_price: Some(500),
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    // Set price at ts=0, advance ledger to ts=500 → age=500 > max_oracle_age(300)
+    use escrow_mock_oracle::EscrowMockOracleClient;
+    let oc = EscrowMockOracleClient::new(&s.env, &s.oracle_addr);
+    oc.set_price(&400, &0u64);
+    s.env.ledger().set_timestamp(500);
+
+    let result = s.client.try_check_and_release_escrow(&escrow_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_manual_release_works_regardless_of_oracle_condition() {
+    let s = setup_oracle_escrow();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    let deadline = 5000u64;
+
+    // Oracle condition: price <= 500, but we won't set a price that meets it
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: Some(s.base.clone()),
+        release_quote: Some(s.quote.clone()),
+        release_comparison: Some(0u32),
+        release_threshold_price: Some(500),
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    // Manual release by buyer still works regardless of oracle
+    s.client.release_escrow(&buyer, &escrow_id);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(s.token_client.balance(&seller), 1000);
+}
+
+#[test]
+fn test_oracle_release_emits_event() {
+    let s = setup_oracle_escrow();
+
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    s.env.ledger().set_timestamp(100);
+    let deadline = 5000u64;
+
+    let request = EscrowCreateRequest {
+        seller: seller.clone(),
+        arbiter: arbiter.clone(),
+        amount: 1000,
+        token: s.token_addr.clone(),
+        deadline,
+        metadata_hash: None,
+        sellers: Vec::new(&s.env),
+        auto_renew: false,
+        renewal_count: 0,
+        buyer_inactivity_secs: 0,
+        min_lock_until: None,
+        release_base: Some(s.base.clone()),
+        release_quote: Some(s.quote.clone()),
+        release_comparison: Some(0u32),
+        release_threshold_price: Some(500),
+        arbiter_fee_bps: None,
+    };
+    let escrow_id = s.client.create_escrow_v2(&buyer, &request);
+
+    set_escrow_oracle_price(&s, 300, 200);
+    s.client.check_and_release_escrow(&escrow_id);
+
+    let events = s.env.events().all();
+    let topic = (Symbol::new(&s.env, "oracle_release_triggered"),).into_val(&s.env);
+    let found = events.iter().any(|e| e.1 == topic);
+    assert!(found, "Expected oracle_release_triggered event");
+}

--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -12,7 +12,7 @@ const PERSISTENT_BUMP_AMOUNT: u32 = 120_000;
 // Minimal payment contract client — only the fields we need from get_payment.
 // ---------------------------------------------------------------------------
 mod payment_contract {
-    use soroban_sdk::{contractclient, contracttype, Address, Env, Map, String};
+    use soroban_sdk::{contractclient, contracttype, Address, Env, Map, String, Vec};
 
     #[contracttype]
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -22,6 +22,14 @@ mod payment_contract {
         Refunded = 2,
         Disputed = 3,
         Expired = 4,
+        ScheduledPending = 5,
+    }
+
+    #[contracttype]
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct SplitRecipient {
+        pub recipient: Address,
+        pub bps: u32,
     }
 
     #[contracttype]
@@ -38,6 +46,8 @@ mod payment_contract {
         pub refunded_amount: i128,
         pub reference: Option<String>,
         pub metadata: Option<Map<String, String>>,
+        pub split_recipients: Option<Vec<SplitRecipient>>,
+        pub execute_after: u64,
     }
 
     #[allow(dead_code)]
@@ -150,29 +160,54 @@ pub enum DataKey {
 
 mod events;
 
+/// Optional extended configuration for `initialize`.
+/// Groups the extra parameters that would otherwise exceed Soroban's 10-parameter limit.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefundInitConfig {
+    pub escrow_contract: Option<Address>,
+    pub refund_fee_bps: u32,
+    pub fee_recipient: Option<Address>,
+    pub auto_reject_window_seconds: u64,
+    pub appeal_window_seconds: u64,
+    pub refund_tiers: Option<Vec<(u64, u32)>>,
+    pub refund_cooldown_seconds: u64,
+    pub customer_cancel_window_seconds: u64,
+}
+
 #[contract]
 pub struct AhjoorRefundContract;
 
 #[contractimpl]
 impl AhjoorRefundContract {
-    /// Initialize the refund contract with an admin, the payment contract address, a
-    /// `dispute_window` (in seconds), optional escrow contract address, refund fee parameters,
-    /// auto-reject window, appeal window, refund tiers, cooldown seconds (#166), and
-    /// customer cancel window (#168).
+    /// Initialize the refund contract.
+    /// `config` bundles optional extended settings to stay within Soroban's 10-parameter limit.
+    /// Pass `None` for `config` to use all defaults (zero fees, no cooldown, etc.).
     pub fn initialize(
         env: Env,
         admin: Address,
         payment_contract: Address,
         dispute_window: u64,
-        escrow_contract: Option<Address>,
-        refund_fee_bps: u32,
-        fee_recipient: Option<Address>,
-        auto_reject_window_seconds: u64,
-        appeal_window_seconds: u64,
-        refund_tiers: Option<Vec<(u64, u32)>>,
-        refund_cooldown_seconds: u64,
-        customer_cancel_window_seconds: u64,
+        config: Option<RefundInitConfig>,
     ) {
+        let cfg = config.unwrap_or(RefundInitConfig {
+            escrow_contract: None,
+            refund_fee_bps: 0,
+            fee_recipient: None,
+            auto_reject_window_seconds: 0,
+            appeal_window_seconds: 0,
+            refund_tiers: None,
+            refund_cooldown_seconds: 0,
+            customer_cancel_window_seconds: 0,
+        });
+        let escrow_contract = cfg.escrow_contract;
+        let refund_fee_bps = cfg.refund_fee_bps;
+        let fee_recipient = cfg.fee_recipient;
+        let auto_reject_window_seconds = cfg.auto_reject_window_seconds;
+        let appeal_window_seconds = cfg.appeal_window_seconds;
+        let refund_tiers = cfg.refund_tiers;
+        let refund_cooldown_seconds = cfg.refund_cooldown_seconds;
+        let customer_cancel_window_seconds = cfg.customer_cancel_window_seconds;
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("Already initialized");
         }
@@ -685,9 +720,11 @@ impl AhjoorRefundContract {
             token: payment.token.clone(),
             status: RefundStatus::Processed,
             reason: String::from_str(&env, "merchant_initiated"),
+            reason_code: 4, // "Other" — merchant-initiated
             requested_at: now,
             approved_at: Some(now),
             processed_at: Some(now),
+            rejected_at: None,
             auto_approved_source: Some(String::from_str(&env, "merchant_direct")),
             escrow_id: None,
             fee_amount: None,

--- a/contracts/ahjoor-refund/src/test.rs
+++ b/contracts/ahjoor-refund/src/test.rs
@@ -52,7 +52,7 @@ fn setup<'a>() -> TestSetup<'a> {
 
     // Initialize both contracts — 86400 s (1 day) dispute window
     payment_client.initialize(&admin, &admin, &0u32);
-    refund_client.initialize(&admin, &payment_id, &86_400u64, &None, &0u32, &None, &None);
+    refund_client.initialize(&admin, &payment_id, &86_400u64, &None);
 
     TestSetup {
         env,
@@ -100,7 +100,7 @@ fn test_initialize() {
 fn test_initialize_twice_panics() {
     let s = setup();
     s.refund_client
-        .initialize(&s.admin, &s.payment_client.address, &86_400u64, &None, &0u32, &None, &None);
+        .initialize(&s.admin, &s.payment_client.address, &86_400u64, &None);
 }
 
 // ===========================================================================
@@ -122,6 +122,7 @@ fn test_request_refund_against_completed_payment() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     assert_eq!(refund_id, 0);
@@ -153,6 +154,7 @@ fn test_request_refund_against_pending_payment_panics() {
         &pid,
         &100,
         &String::from_str(&s.env, "Pending payment"),
+        &0u32,
     );
 }
 
@@ -168,6 +170,7 @@ fn test_request_refund_nonexistent_payment_panics() {
         &9999,
         &100,
         &String::from_str(&s.env, "No such payment"),
+        &0u32,
     );
 }
 
@@ -183,7 +186,7 @@ fn test_request_refund_exceeds_payment_amount_panics() {
     // Try to refund more than the payment amount
     s.token_admin_client.mint(&customer, &200);
     s.refund_client
-        .request_refund(&customer, &pid, &200, &String::from_str(&s.env, "Too much"));
+        .request_refund(&customer, &pid, &200, &String::from_str(&s.env, "Too much"), &0u32);
 }
 
 #[test]
@@ -196,7 +199,7 @@ fn test_request_refund_zero_amount_panics() {
     let pid = create_completed_payment(&s, &customer, &merchant, 100);
 
     s.refund_client
-        .request_refund(&customer, &pid, &0, &String::from_str(&s.env, "Invalid"));
+        .request_refund(&customer, &pid, &0, &String::from_str(&s.env, "Invalid"), &0u32);
 }
 
 // ===========================================================================
@@ -216,6 +219,7 @@ fn test_approve_refund() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &refund_id);
@@ -226,7 +230,7 @@ fn test_approve_refund() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can approve refunds")]
+#[should_panic(expected = "Only admin or merchant delegate can approve refunds")]
 fn test_approve_refund_by_non_admin_panics() {
     let s = setup();
     let customer = Address::generate(&s.env);
@@ -240,6 +244,7 @@ fn test_approve_refund_by_non_admin_panics() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&non_admin, &refund_id);
@@ -259,6 +264,7 @@ fn test_approve_already_approved_refund_panics() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &refund_id);
@@ -282,6 +288,7 @@ fn test_reject_refund() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.reject_refund(
@@ -295,7 +302,7 @@ fn test_reject_refund() {
 }
 
 #[test]
-#[should_panic(expected = "Only admin can reject refunds")]
+#[should_panic(expected = "Only admin or merchant delegate can reject refunds")]
 fn test_reject_refund_by_non_admin_panics() {
     let s = setup();
     let customer = Address::generate(&s.env);
@@ -309,6 +316,7 @@ fn test_reject_refund_by_non_admin_panics() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.reject_refund(
@@ -335,6 +343,7 @@ fn test_process_refund() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &refund_id);
@@ -360,6 +369,7 @@ fn test_process_refund_by_non_admin_panics() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &refund_id);
@@ -380,6 +390,7 @@ fn test_process_unapproved_refund_panics() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.process_refund(&s.admin, &refund_id);
@@ -404,6 +415,7 @@ fn test_token_transfer_on_process_refund() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &refund_id);
@@ -426,6 +438,7 @@ fn test_contract_holds_no_balance_after_process() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &refund_id);
@@ -452,6 +465,7 @@ fn test_full_refund_lifecycle_approved() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
     assert_eq!(
         s.refund_client.get_refund(&refund_id).status,
@@ -484,6 +498,7 @@ fn test_full_refund_lifecycle_rejected() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.reject_refund(
@@ -514,6 +529,7 @@ fn test_refund_requested_emits_event() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     assert!(!s.env.events().all().is_empty());
@@ -532,6 +548,7 @@ fn test_refund_approved_emits_event() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &refund_id);
@@ -551,6 +568,7 @@ fn test_refund_processed_emits_event() {
         &pid,
         &250,
         &String::from_str(&s.env, "Item not received"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &refund_id);
@@ -577,12 +595,14 @@ fn test_refund_counter_increments() {
         &pid1,
         &100,
         &String::from_str(&s.env, "Reason 1"),
+        &0u32,
     );
     s.refund_client.request_refund(
         &customer,
         &pid2,
         &200,
         &String::from_str(&s.env, "Reason 2"),
+        &0u32,
     );
 
     assert_eq!(s.refund_client.get_refund_counter(), 2);
@@ -689,6 +709,7 @@ fn test_write_operations_blocked_when_paused() {
         &pid,
         &100,
         &String::from_str(&s.env, "reason"),
+        &0u32,
     );
     assert!(res.is_err());
     assert_eq!(s.refund_client.get_refund_counter(), 0);
@@ -712,6 +733,7 @@ fn test_recovery_after_resume() {
         &pid,
         &100,
         &String::from_str(&s.env, "post-resume"),
+        &0u32,
     );
     assert_eq!(refund_id, 0);
     assert_eq!(s.refund_client.get_refund_counter(), 1);
@@ -735,6 +757,7 @@ fn test_boundary_amount_i128_max_rejected_without_balance() {
         &pid,
         &i128::MAX,
         &String::from_str(&s.env, "too large"),
+        &0u32,
     );
     assert!(res.is_err());
 }
@@ -752,7 +775,7 @@ fn test_auth_required_for_admin_approve_refund() {
     let refund_id_addr = env.register(AhjoorRefundContract, ());
     let client = AhjoorRefundContractClient::new(&env, &refund_id_addr);
     let admin = Address::generate(&env);
-    client.initialize(&admin, &payment_id_addr, &86_400u64, &None, &0u32, &None, &None);
+    client.initialize(&admin, &payment_id_addr, &86_400u64, &None);
 
     let res = client.try_approve_refund(&admin, &0);
     assert!(res.is_err());
@@ -805,6 +828,7 @@ fn request_n_refunds<'a>(
             &pid,
             &10,
             &String::from_str(&s.env, "reason"),
+        &0u32,
         );
         ids.push_back(rid);
     }
@@ -956,7 +980,7 @@ fn test_get_refunds_by_payment_single() {
     s.token_admin_client.mint(&customer, &10);
     let rid =
         s.refund_client
-            .request_refund(&customer, &pid, &10, &String::from_str(&s.env, "reason"));
+            .request_refund(&customer, &pid, &10, &String::from_str(&s.env, "reason"), &0u32);
 
     let result = s.refund_client.get_refunds_by_payment(&pid);
     assert_eq!(result.len(), 1);
@@ -974,10 +998,10 @@ fn test_get_refunds_by_payment_multiple_refunds_same_payment() {
     s.token_admin_client.mint(&customer, &20);
     let rid0 =
         s.refund_client
-            .request_refund(&customer, &pid, &10, &String::from_str(&s.env, "first"));
+            .request_refund(&customer, &pid, &10, &String::from_str(&s.env, "first"), &0u32);
     let rid1 =
         s.refund_client
-            .request_refund(&customer, &pid, &10, &String::from_str(&s.env, "second"));
+            .request_refund(&customer, &pid, &10, &String::from_str(&s.env, "second"), &0u32);
 
     let result = s.refund_client.get_refunds_by_payment(&pid);
     assert_eq!(result.len(), 2);
@@ -997,7 +1021,7 @@ fn test_indexes_consistent_across_all_three_dimensions() {
     s.token_admin_client.mint(&customer, &10);
     let rid =
         s.refund_client
-            .request_refund(&customer, &pid, &10, &String::from_str(&s.env, "reason"));
+            .request_refund(&customer, &pid, &10, &String::from_str(&s.env, "reason"), &0u32);
 
     assert_eq!(
         s.refund_client
@@ -1029,12 +1053,12 @@ fn test_different_customers_indexes_are_isolated() {
     let pid_a = create_completed_payment(&s, &customer_a, &merchant, 100);
     s.token_admin_client.mint(&customer_a, &10);
     s.refund_client
-        .request_refund(&customer_a, &pid_a, &10, &String::from_str(&s.env, "a"));
+        .request_refund(&customer_a, &pid_a, &10, &String::from_str(&s.env, "a"), &0u32);
 
     let pid_b = create_completed_payment(&s, &customer_b, &merchant, 100);
     s.token_admin_client.mint(&customer_b, &10);
     s.refund_client
-        .request_refund(&customer_b, &pid_b, &10, &String::from_str(&s.env, "b"));
+        .request_refund(&customer_b, &pid_b, &10, &String::from_str(&s.env, "b"), &0u32);
 
     assert_eq!(
         s.refund_client
@@ -1074,7 +1098,7 @@ fn test_get_refundable_remaining_decreases_after_processed_refund() {
     s.token_admin_client.mint(&customer, &100);
     let rid = s
         .refund_client
-        .request_refund(&customer, &pid, &100, &String::from_str(&s.env, "r1"));
+        .request_refund(&customer, &pid, &100, &String::from_str(&s.env, "r1"), &0u32);
     s.refund_client.approve_refund(&s.admin, &rid);
     s.refund_client.process_refund(&s.admin, &rid);
 
@@ -1101,7 +1125,7 @@ fn test_three_partial_refunds_exhaust_payment() {
         };
         let rid = s
             .refund_client
-            .request_refund(&customer, &pid, &100, &reason);
+            .request_refund(&customer, &pid, &100, &reason, &0u32);
         s.refund_client.approve_refund(&s.admin, &rid);
         s.refund_client.process_refund(&s.admin, &rid);
     }
@@ -1121,7 +1145,7 @@ fn test_cumulative_over_refund_rejected() {
     s.token_admin_client.mint(&customer, &150);
     let rid = s
         .refund_client
-        .request_refund(&customer, &pid, &150, &String::from_str(&s.env, "partial"));
+        .request_refund(&customer, &pid, &150, &String::from_str(&s.env, "partial"), &0u32);
     s.refund_client.approve_refund(&s.admin, &rid);
     s.refund_client.process_refund(&s.admin, &rid);
 
@@ -1132,6 +1156,7 @@ fn test_cumulative_over_refund_rejected() {
         &pid,
         &100,
         &String::from_str(&s.env, "over-refund"),
+        &0u32,
     );
     assert!(result.is_err());
     assert_eq!(s.refund_client.get_refundable_remaining(&pid), 50);
@@ -1149,7 +1174,7 @@ fn test_multiple_partial_refunds_accumulate_correctly() {
     s.token_admin_client.mint(&customer, &100);
     let rid1 = s
         .refund_client
-        .request_refund(&customer, &pid, &100, &String::from_str(&s.env, "r1"));
+        .request_refund(&customer, &pid, &100, &String::from_str(&s.env, "r1"), &0u32);
     s.refund_client.approve_refund(&s.admin, &rid1);
     s.refund_client.process_refund(&s.admin, &rid1);
     assert_eq!(s.refund_client.get_refundable_remaining(&pid), 400);
@@ -1158,7 +1183,7 @@ fn test_multiple_partial_refunds_accumulate_correctly() {
     s.token_admin_client.mint(&customer, &150);
     let rid2 = s
         .refund_client
-        .request_refund(&customer, &pid, &150, &String::from_str(&s.env, "r2"));
+        .request_refund(&customer, &pid, &150, &String::from_str(&s.env, "r2"), &0u32);
     s.refund_client.approve_refund(&s.admin, &rid2);
     s.refund_client.process_refund(&s.admin, &rid2);
     assert_eq!(s.refund_client.get_refundable_remaining(&pid), 250);
@@ -1167,7 +1192,7 @@ fn test_multiple_partial_refunds_accumulate_correctly() {
     s.token_admin_client.mint(&customer, &250);
     let rid3 = s
         .refund_client
-        .request_refund(&customer, &pid, &250, &String::from_str(&s.env, "r3"));
+        .request_refund(&customer, &pid, &250, &String::from_str(&s.env, "r3"), &0u32);
     s.refund_client.approve_refund(&s.admin, &rid3);
     s.refund_client.process_refund(&s.admin, &rid3);
     assert_eq!(s.refund_client.get_refundable_remaining(&pid), 0);
@@ -1184,7 +1209,7 @@ fn test_cap_event_emitted_when_remaining_near_zero() {
     s.token_admin_client.mint(&customer, &95);
     let rid = s
         .refund_client
-        .request_refund(&customer, &pid, &95, &String::from_str(&s.env, "near-cap"));
+        .request_refund(&customer, &pid, &95, &String::from_str(&s.env, "near-cap"), &0u32);
     s.refund_client.approve_refund(&s.admin, &rid);
     s.refund_client.process_refund(&s.admin, &rid);
 
@@ -1214,6 +1239,7 @@ fn test_write_functions_blocked_when_paused_reads_still_work() {
         &pid,
         &100,
         &String::from_str(&s.env, "snapshot"),
+        &0u32,
     );
 
     let events = s.env.events().all();
@@ -1245,7 +1271,7 @@ fn setup_with_dispute_window<'a>(dispute_window: u64) -> TestSetup<'a> {
     let token_admin_client = TokenAdminClient::new(&env, &token_addr);
 
     payment_client.initialize(&admin, &admin, &0u32);
-    refund_client.initialize(&admin, &payment_id, &dispute_window, &None, &0u32, &None, &None);
+    refund_client.initialize(&admin, &payment_id, &dispute_window, &None);
 
     TestSetup {
         env,
@@ -1280,6 +1306,7 @@ fn test_auto_approve_early_panics() {
         &pid,
         &100,
         &String::from_str(&s.env, "missing item"),
+        &0u32,
     );
 
     // Only 1 hour has passed — window is 1 day
@@ -1302,6 +1329,7 @@ fn test_auto_approve_after_merchant_approved_panics() {
         &pid,
         &100,
         &String::from_str(&s.env, "broken"),
+        &0u32,
     );
 
     // Admin approves before the window elapses
@@ -1328,6 +1356,7 @@ fn test_auto_approve_after_merchant_rejected_panics() {
         &pid,
         &100,
         &String::from_str(&s.env, "broken"),
+        &0u32,
     );
 
     // Admin rejects before the window elapses
@@ -1356,6 +1385,7 @@ fn test_auto_approve_after_window_transfers_tokens_and_sets_processed() {
         &pid,
         &100,
         &String::from_str(&s.env, "no response"),
+        &0u32,
     );
 
     // Verify tokens are in escrow
@@ -1387,6 +1417,7 @@ fn test_auto_approve_emits_event() {
         &pid,
         &50,
         &String::from_str(&s.env, "auto"),
+        &0u32,
     );
 
     s.env.ledger().set_timestamp(3601);
@@ -1416,6 +1447,7 @@ fn test_refund_tiers_cap_amount_and_expire_after_all_windows() {
         &pid_a,
         &300,
         &String::from_str(&s.env, "tier-a"),
+        &0u32,
     );
     let refund_a = s.refund_client.get_refund(&rid_a);
     assert_eq!(refund_a.amount, 200);
@@ -1428,6 +1460,7 @@ fn test_refund_tiers_cap_amount_and_expire_after_all_windows() {
         &pid_b,
         &180,
         &String::from_str(&s.env, "tier-b"),
+        &0u32,
     );
     let refund_b = s.refund_client.get_refund(&rid_b);
     assert_eq!(refund_b.amount, 100);
@@ -1440,6 +1473,7 @@ fn test_refund_tiers_cap_amount_and_expire_after_all_windows() {
         &pid_c,
         &50,
         &String::from_str(&s.env, "expired"),
+        &0u32,
     );
     assert!(expired.is_err());
 }
@@ -1497,12 +1531,14 @@ fn test_bulk_process_refunds_success_and_stats_update() {
         &pid_a,
         &100,
         &String::from_str(&s.env, "bulk-a"),
+        &0u32,
     );
     let rid_b = s.refund_client.request_refund(
         &customer_b,
         &pid_b,
         &150,
         &String::from_str(&s.env, "bulk-b"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &rid_a);
@@ -1534,12 +1570,14 @@ fn test_bulk_process_refunds_mixed_status_fails_atomically() {
         &pid_a,
         &50,
         &String::from_str(&s.env, "mix-a"),
+        &0u32,
     );
     let rid_b = s.refund_client.request_refund(
         &customer,
         &pid_b,
         &60,
         &String::from_str(&s.env, "mix-b"),
+        &0u32,
     );
 
     s.refund_client.approve_refund(&s.admin, &rid_a);


### PR DESCRIPTION


**PR: Implement Insurance Pool, Arbiter Fee, Time Lock, and Oracle-Conditional Escrow Release**

Closes #137, #138, #139, #140

This PR implements four escrow feature enhancements on the `ahjoor-escrow` contract:

** Closes #137 — Insurance Pool for Default Protection**
Added `InsurancePool` to instance storage with `contribute_to_insurance()`, `confirm_insurance_inactivity()`, and `claim_insurance()`. Claims are capped at 50% of the stuck escrow amount and require admin confirmation + trigger period elapsed. Emits `InsuranceClaimed` event.

** Closes #138 — Arbitration Fee Mechanism**
Added `arbiter_fee_bps` to `EscrowCreateRequest` and `EscrowExtensions`. Fee is computed on `resolve_dispute()` and deducted from the losing party's portion. Protocol-wide default via `set_default_arbiter_fee_bps()`. Capped at 10% (1000 bps). Emits `ArbiterFeePaid` event.

** Closes #139 — Time-Locked Escrow**
Added `min_lock_until: Option<u64>` to escrow creation. `release_escrow()` and `partial_release()` are gated by `require_unlocked()`. Disputes are not blocked by the lock. Emits `EscrowTimeLocked` event.

** Closes #140 — Oracle-Conditional Escrow Release**
Added `release_base/quote/comparison/threshold_price` fields to escrow. `check_and_release_escrow()` queries the Reflector oracle and releases when the condition is met. Stale prices are rejected. Manual release by buyer still works unconditionally. Emits `OracleReleaseTriggered` event.

---

**Checklist:**

- [x] Insurance claim only possible after trigger period elapses
- [x] Claim does not exceed 50% of the stuck escrow amount
- [x] Admin confirmation required before insurance disbursement
- [x] Pool balance updates correctly after each claim
- [x] Fee is deducted from losing party, not winning party
- [x] Fee cap enforced (max 10%)
- [x] Zero fee is valid for pro-bono arbitration
- [x] Protocol-wide default applies when escrow-level fee is not set
- [x] Release before `min_lock_until` returns `EscrowStillLocked` error
- [x] Disputes are not blocked by the lock
- [x] Lock and deadline are independently configurable
- [x] Auto-release only triggers when oracle price satisfies condition
- [x] Stale prices block release
- [x] Manual release by buyer still works regardless of oracle condition
- [x] All 117 tests pass