### PR TITLE
feat(payments,escrow): subscription trial periods + milestone-based escrow release

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -48,6 +48,15 @@ pub struct PartialReleased {
     pub remaining_amount: i128,
 }
 
+/// Event: Milestone approved and amount released to seller (#136)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MilestoneApproved {
+    pub escrow_id: u32,
+    pub milestone_index: u32,
+    pub amount_released: i128,
+}
+
 /// Event: Escrow disputed
 #[contractevent]
 #[derive(Clone, Debug)]
@@ -295,6 +304,20 @@ pub fn emit_partial_released(
         escrow_id,
         released_amount,
         remaining_amount,
+    }
+    .publish(e);
+}
+
+pub fn emit_milestone_approved(
+    e: &Env,
+    escrow_id: u32,
+    milestone_index: u32,
+    amount_released: i128,
+) {
+    MilestoneApproved {
+        escrow_id,
+        milestone_index,
+        amount_released,
     }
     .publish(e);
 }

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -147,6 +147,26 @@ pub struct EscrowTemplate {
     pub active: bool,
 }
 
+/// Status of a milestone in a milestone-based escrow (#136).
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MilestoneStatus {
+    Pending = 0,
+    Approved = 1,
+    Disputed = 2,
+}
+
+/// Single milestone in a milestone-based escrow (#136).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Milestone {
+    pub description_hash: BytesN<32>,
+    pub amount: i128,
+    pub status: MilestoneStatus,
+}
+
+const MAX_MILESTONES: u32 = 20;
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowBatchConfig {
@@ -195,6 +215,8 @@ pub enum DataKey {
     InsuranceClaimed(u32),
     /// Last timestamp of any buyer action for inactivity tracking (#150)
     LastBuyerAction(u32),
+    /// Optional milestone schedule attached to an escrow (#136)
+    EscrowMilestones(u32),
 }
 
 const MAX_PROTOCOL_FEE_BPS: u32 = 200; // 2%
@@ -906,6 +928,178 @@ impl AhjoorEscrowContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    // --- Milestone-based escrow release (#136) ---
+
+    /// Create a milestone-based escrow.
+    ///
+    /// `milestones[i].amount` must be positive and the sum of all milestone
+    /// amounts must equal `total_amount`. Tokens for `total_amount` are
+    /// transferred from `buyer` into the contract up front; each milestone is
+    /// released independently via `approve_milestone`. When all milestones are
+    /// approved, the escrow transitions automatically to `Released`.
+    pub fn create_milestone_escrow(
+        env: Env,
+        buyer: Address,
+        seller: Address,
+        arbiter: Address,
+        token: Address,
+        deadline: u64,
+        milestones: Vec<Milestone>,
+    ) -> u32 {
+        buyer.require_auth();
+
+        if milestones.is_empty() {
+            panic!("At least one milestone required");
+        }
+        if milestones.len() > MAX_MILESTONES {
+            panic!("Too many milestones");
+        }
+
+        let mut total_amount: i128 = 0;
+        for i in 0..milestones.len() {
+            let m = milestones.get(i).unwrap();
+            if m.amount <= 0 {
+                panic!("Milestone amount must be positive");
+            }
+            if m.status != MilestoneStatus::Pending {
+                panic!("New milestones must start as Pending");
+            }
+            total_amount += m.amount;
+        }
+
+        let request = EscrowCreateRequest {
+            seller,
+            arbiter,
+            amount: total_amount,
+            token,
+            deadline,
+            metadata_hash: None,
+            sellers: Vec::new(&env),
+            auto_renew: false,
+            renewal_count: 0,
+            buyer_inactivity_secs: 0,
+            min_lock_until: None,
+            release_base: None,
+            release_quote: None,
+            release_comparison: None,
+            release_threshold_price: None,
+            arbiter_fee_bps: None,
+        };
+        let escrow_id = Self::create_escrow_core(&env, &buyer, request);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowMilestones(escrow_id), &milestones);
+        env.storage().persistent().extend_ttl(
+            &DataKey::EscrowMilestones(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        escrow_id
+    }
+
+    /// Approve a single milestone, releasing its `amount` to the seller.
+    ///
+    /// Callable by buyer or arbiter. The targeted milestone must be `Pending`.
+    /// Disputed milestones do not block other milestones from being approved.
+    /// When every milestone reaches a terminal state and at least one was
+    /// approved, the escrow auto-transitions to `Released`.
+    pub fn approve_milestone(
+        env: Env,
+        caller: Address,
+        escrow_id: u32,
+        milestone_index: u32,
+    ) {
+        caller.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.status == EscrowStatus::Released
+            || escrow.status == EscrowStatus::Refunded
+            || escrow.status == EscrowStatus::Resolved
+        {
+            panic!("Escrow already terminal");
+        }
+
+        if caller != escrow.buyer && caller != escrow.arbiter {
+            panic!("Only buyer or arbiter can approve milestones");
+        }
+
+        let mut milestones: Vec<Milestone> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EscrowMilestones(escrow_id))
+            .expect("Escrow has no milestones");
+
+        if milestone_index >= milestones.len() {
+            panic!("Milestone index out of range");
+        }
+
+        let mut milestone = milestones.get(milestone_index).unwrap();
+        if milestone.status != MilestoneStatus::Pending {
+            panic!("Milestone not pending");
+        }
+
+        let client = token::Client::new(&env, &escrow.token);
+        client.transfer(&env.current_contract_address(), &escrow.seller, &milestone.amount);
+
+        let amount_released = milestone.amount;
+        milestone.status = MilestoneStatus::Approved;
+        milestones.set(milestone_index, milestone);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowMilestones(escrow_id), &milestones);
+        env.storage().persistent().extend_ttl(
+            &DataKey::EscrowMilestones(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        // Auto-transition to Released when every milestone is in a terminal
+        // state and at least one was approved.
+        let mut all_terminal = true;
+        let mut any_approved = false;
+        for i in 0..milestones.len() {
+            let m = milestones.get(i).unwrap();
+            match m.status {
+                MilestoneStatus::Pending => all_terminal = false,
+                MilestoneStatus::Approved => any_approved = true,
+                MilestoneStatus::Disputed => {}
+            }
+        }
+        if all_terminal && any_approved && escrow.status == EscrowStatus::Active {
+            escrow.status = EscrowStatus::Released;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Escrow(escrow_id), &escrow);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Escrow(escrow_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        }
+
+        events::emit_milestone_approved(&env, escrow_id, milestone_index, amount_released);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Read the current milestone schedule for a milestone-based escrow.
+    pub fn get_milestones(env: Env, escrow_id: u32) -> Vec<Milestone> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::EscrowMilestones(escrow_id))
+            .expect("Escrow has no milestones")
     }
 
     /// Dispute an escrow. Can be called by buyer or seller.

--- a/contracts/ahjoor-escrow/src/test.rs
+++ b/contracts/ahjoor-escrow/src/test.rs
@@ -3651,3 +3651,205 @@ fn test_oracle_release_emits_event() {
     let found = events.iter().any(|e| e.1 == topic);
     assert!(found, "Expected oracle_release_triggered event");
 }
+
+// ===========================================================================
+//  #136 — Milestone-Based Escrow Release
+// ===========================================================================
+
+fn make_milestones(env: &Env, amounts: &[i128]) -> soroban_sdk::Vec<Milestone> {
+    let mut v = soroban_sdk::Vec::new(env);
+    for amt in amounts.iter() {
+        v.push_back(Milestone {
+            description_hash: BytesN::from_array(env, &[0u8; 32]),
+            amount: *amt,
+            status: MilestoneStatus::Pending,
+        });
+    }
+    v
+}
+
+#[test]
+fn test_create_milestone_escrow_locks_total() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &s.token_addr,
+        &deadline,
+        &make_milestones(&s.env, &[100, 200, 300]),
+    );
+
+    assert_eq!(s.token_client.balance(&buyer), 400);
+    let milestones = s.client.get_milestones(&escrow_id);
+    assert_eq!(milestones.len(), 3);
+    assert_eq!(milestones.get(0).unwrap().amount, 100);
+    assert_eq!(milestones.get(1).unwrap().status, MilestoneStatus::Pending);
+}
+
+#[test]
+fn test_milestone_partial_release_pays_seller() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &s.token_addr,
+        &deadline,
+        &make_milestones(&s.env, &[100, 200, 300]),
+    );
+
+    s.client.approve_milestone(&buyer, &escrow_id, &0);
+
+    assert_eq!(s.token_client.balance(&seller), 100);
+    let m = s.client.get_milestones(&escrow_id);
+    assert_eq!(m.get(0).unwrap().status, MilestoneStatus::Approved);
+    assert_eq!(m.get(1).unwrap().status, MilestoneStatus::Pending);
+    assert_eq!(s.client.get_escrow(&escrow_id).status, EscrowStatus::Active);
+}
+
+#[test]
+fn test_milestone_full_release_transitions_to_released() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &s.token_addr,
+        &deadline,
+        &make_milestones(&s.env, &[100, 200, 300]),
+    );
+
+    s.client.approve_milestone(&buyer, &escrow_id, &0);
+    s.client.approve_milestone(&buyer, &escrow_id, &1);
+    s.client.approve_milestone(&arbiter, &escrow_id, &2);
+
+    assert_eq!(s.token_client.balance(&seller), 600);
+    assert_eq!(s.token_client.balance(&s.client.address), 0);
+    assert_eq!(s.client.get_escrow(&escrow_id).status, EscrowStatus::Released);
+}
+
+#[test]
+#[should_panic(expected = "Milestone not pending")]
+fn test_double_approve_milestone_panics() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &s.token_addr,
+        &deadline,
+        &make_milestones(&s.env, &[100, 200, 300]),
+    );
+
+    s.client.approve_milestone(&buyer, &escrow_id, &0);
+    s.client.approve_milestone(&buyer, &escrow_id, &0);
+}
+
+#[test]
+#[should_panic(expected = "Only buyer or arbiter can approve milestones")]
+fn test_seller_cannot_approve_own_milestone() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &s.token_addr,
+        &deadline,
+        &make_milestones(&s.env, &[100, 200, 300]),
+    );
+
+    s.client.approve_milestone(&seller, &escrow_id, &0);
+}
+
+#[test]
+#[should_panic(expected = "Milestone amount must be positive")]
+fn test_zero_milestone_amount_rejected() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    s.client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &s.token_addr,
+        &deadline,
+        &make_milestones(&s.env, &[0, 100]),
+    );
+}
+
+#[test]
+#[should_panic(expected = "At least one milestone required")]
+fn test_empty_milestones_rejected() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    s.client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &s.token_addr,
+        &deadline,
+        &make_milestones(&s.env, &[]),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Milestone index out of range")]
+fn test_milestone_out_of_range_rejected() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id = s.client.create_milestone_escrow(
+        &buyer,
+        &seller,
+        &arbiter,
+        &s.token_addr,
+        &deadline,
+        &make_milestones(&s.env, &[100, 200]),
+    );
+
+    s.client.approve_milestone(&buyer, &escrow_id, &5);
+}

--- a/contracts/ahjoor-payments/src/events.rs
+++ b/contracts/ahjoor-payments/src/events.rs
@@ -158,6 +158,21 @@ pub struct SubscriptionCancelled {
     pub cancelled_by: Address,
 }
 
+/// Event: Subscription created with a trial period (#133)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct SubscriptionTrialStarted {
+    pub subscription_id: u32,
+    pub trial_ends_at: u64,
+}
+
+/// Event: Subscription trial ended on first successful charge (#133)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct SubscriptionTrialEnded {
+    pub subscription_id: u32,
+}
+
 /// Event: Merchant settlement batch processed.
 #[contractevent]
 #[derive(Clone, Debug)]
@@ -393,6 +408,18 @@ pub fn emit_subscription_cancelled(e: &Env, subscription_id: u32, cancelled_by: 
         cancelled_by,
     }
     .publish(e);
+}
+
+pub fn emit_subscription_trial_started(e: &Env, subscription_id: u32, trial_ends_at: u64) {
+    SubscriptionTrialStarted {
+        subscription_id,
+        trial_ends_at,
+    }
+    .publish(e);
+}
+
+pub fn emit_subscription_trial_ended(e: &Env, subscription_id: u32) {
+    SubscriptionTrialEnded { subscription_id }.publish(e);
 }
 
 pub fn emit_batch_settlement_processed(

--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -84,6 +84,8 @@ pub enum Error {
     RateLimitExceeded = 1,
     SubscriptionPaused = 2,
     OracleConditionNotMet = 3,
+    /// Subscription's trial period has not elapsed; charging is deferred (#133)
+    SubscriptionInTrial = 4,
 }
 
 /// Direction for oracle price condition (#125)
@@ -248,6 +250,9 @@ pub struct Subscription {
     pub paused: bool,
     /// Ledger timestamp when the subscription was paused (#124)
     pub paused_at: u64,
+    /// Ledger timestamp at which the trial ends and the first charge becomes
+    /// available. 0 = no trial (immediate first charge). (#133)
+    pub trial_ends_at: u64,
 }
 
 #[contracttype]
@@ -2179,6 +2184,35 @@ impl AhjoorPaymentsContract {
         interval_seconds: u64,
         max_charges: u32,
     ) -> u32 {
+        Self::create_subscription_with_trial(
+            env,
+            subscriber,
+            merchant,
+            amount,
+            token,
+            interval_seconds,
+            max_charges,
+            None,
+        )
+    }
+
+    /// Subscriber creates a recurring payment with an optional trial period (#133).
+    ///
+    /// When `trial_period_seconds` is `Some(n)` (n > 0), the first charge is
+    /// deferred until `created_at + n`. Charging during the trial returns
+    /// `Error::SubscriptionInTrial`. A trial of `0` or `None` behaves like the
+    /// historical `create_subscription` (immediate first charge available).
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_subscription_with_trial(
+        env: Env,
+        subscriber: Address,
+        merchant: Address,
+        amount: i128,
+        token: Address,
+        interval_seconds: u64,
+        max_charges: u32,
+        trial_period_seconds: Option<u64>,
+    ) -> u32 {
         Self::require_not_paused(&env);
         subscriber.require_auth();
         if amount <= 0 {
@@ -2201,10 +2235,14 @@ impl AhjoorPaymentsContract {
             .instance()
             .set(&DataKey::SubscriptionCounter, &counter);
 
+        let now = env.ledger().timestamp();
+        let trial_seconds = trial_period_seconds.unwrap_or(0);
+        let trial_ends_at = if trial_seconds > 0 { now + trial_seconds } else { 0 };
+
         let sub = Subscription {
             id: sub_id,
-            subscriber,
-            merchant,
+            subscriber: subscriber.clone(),
+            merchant: merchant.clone(),
             amount,
             token,
             interval_seconds,
@@ -2214,6 +2252,7 @@ impl AhjoorPaymentsContract {
             active: true,
             paused: false,
             paused_at: 0,
+            trial_ends_at,
         };
 
         env.storage()
@@ -2227,7 +2266,27 @@ impl AhjoorPaymentsContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        if trial_ends_at > 0 {
+            events::emit_subscription_trial_started(&env, sub_id, trial_ends_at);
+        }
         sub_id
+    }
+
+    /// Returns the remaining seconds in the subscription's trial period (#133).
+    /// Returns 0 if there is no trial or the trial has already ended.
+    pub fn get_trial_remaining(env: Env, subscription_id: u32) -> u64 {
+        let sub: Subscription = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Subscription(subscription_id))
+            .expect("Subscription not found");
+        let now = env.ledger().timestamp();
+        if sub.trial_ends_at == 0 || sub.trial_ends_at <= now {
+            0
+        } else {
+            sub.trial_ends_at - now
+        }
     }
 
     /// Charge a subscription. Callable by anyone when the interval has elapsed.
@@ -2250,9 +2309,13 @@ impl AhjoorPaymentsContract {
         }
 
         let now = env.ledger().timestamp();
+        if sub.charges_count == 0 && sub.trial_ends_at > now {
+            panic_with_error!(&env, Error::SubscriptionInTrial);
+        }
         if sub.last_charged_at > 0 && now < sub.last_charged_at + sub.interval_seconds {
             panic!("Interval has not elapsed");
         }
+        let trial_just_ended = sub.charges_count == 0 && sub.trial_ends_at > 0;
 
         let client = token::Client::new(&env, &sub.token);
         client.transfer(
@@ -2282,6 +2345,9 @@ impl AhjoorPaymentsContract {
             sub.amount,
             now,
         );
+        if trial_just_ended {
+            events::emit_subscription_trial_ended(&env, subscription_id);
+        }
 
         env.storage()
             .instance()

--- a/contracts/ahjoor-payments/src/test.rs
+++ b/contracts/ahjoor-payments/src/test.rs
@@ -5186,3 +5186,112 @@ fn test_invoice_hash_consistency() {
     let hash2 = s.client.get_invoice_hash(&payment_id2).unwrap();
     assert_eq!(hash1, hash2);
 }
+
+// ===========================================================================
+//  #133 — Subscription Trial Period
+// ===========================================================================
+
+#[test]
+fn test_subscription_without_trial_charges_immediately() {
+    let s = setup();
+    s.init();
+    let subscriber = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+    s.token_admin_client.mint(&subscriber, &10_000);
+
+    let sub_id = s.client.create_subscription_with_trial(
+        &subscriber, &merchant, &100, &s.token_addr, &60, &10, &None,
+    );
+
+    s.client.charge_subscription(&sub_id);
+    let sub = s.client.get_subscription(&sub_id);
+    assert_eq!(sub.charges_count, 1);
+    assert_eq!(s.token_client.balance(&merchant), 100);
+}
+
+#[test]
+fn test_subscription_with_zero_trial_charges_immediately() {
+    let s = setup();
+    s.init();
+    let subscriber = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+    s.token_admin_client.mint(&subscriber, &10_000);
+
+    let sub_id = s.client.create_subscription_with_trial(
+        &subscriber, &merchant, &100, &s.token_addr, &60, &10, &Some(0),
+    );
+
+    s.client.charge_subscription(&sub_id);
+    assert_eq!(s.client.get_subscription(&sub_id).charges_count, 1);
+}
+
+#[test]
+#[should_panic]
+fn test_charge_during_trial_panics() {
+    let s = setup();
+    s.init();
+    let subscriber = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+    s.token_admin_client.mint(&subscriber, &10_000);
+
+    let sub_id = s.client.create_subscription_with_trial(
+        &subscriber, &merchant, &100, &s.token_addr, &60, &10, &Some(86_400),
+    );
+
+    s.client.charge_subscription(&sub_id);
+}
+
+#[test]
+fn test_charge_after_trial_succeeds() {
+    let s = setup();
+    s.init();
+    let subscriber = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+    s.token_admin_client.mint(&subscriber, &10_000);
+
+    let sub_id = s.client.create_subscription_with_trial(
+        &subscriber, &merchant, &100, &s.token_addr, &60, &10, &Some(86_400),
+    );
+
+    s.env.ledger().with_mut(|l| l.timestamp += 86_400 + 1);
+
+    s.client.charge_subscription(&sub_id);
+    assert_eq!(s.client.get_subscription(&sub_id).charges_count, 1);
+    assert_eq!(s.token_client.balance(&merchant), 100);
+}
+
+#[test]
+fn test_get_trial_remaining_during_and_after_trial() {
+    let s = setup();
+    s.init();
+    let subscriber = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+    s.token_admin_client.mint(&subscriber, &10_000);
+
+    let sub_id = s.client.create_subscription_with_trial(
+        &subscriber, &merchant, &100, &s.token_addr, &60, &10, &Some(3600),
+    );
+
+    assert_eq!(s.client.get_trial_remaining(&sub_id), 3600);
+
+    s.env.ledger().with_mut(|l| l.timestamp += 1800);
+    assert_eq!(s.client.get_trial_remaining(&sub_id), 1800);
+
+    s.env.ledger().with_mut(|l| l.timestamp += 1800);
+    assert_eq!(s.client.get_trial_remaining(&sub_id), 0);
+}
+
+#[test]
+fn test_subscription_without_trial_reports_zero_remaining() {
+    let s = setup();
+    s.init();
+    let subscriber = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+    s.token_admin_client.mint(&subscriber, &10_000);
+
+    let sub_id = s.client.create_subscription_with_trial(
+        &subscriber, &merchant, &100, &s.token_addr, &60, &10, &None,
+    );
+
+    assert_eq!(s.client.get_trial_remaining(&sub_id), 0);
+}


### PR DESCRIPTION
## Summary

Two related contract features in one PR.

### #133 — Subscription Trial Period (payments contract)
- New `create_subscription_with_trial(subscriber, merchant, amount, token, interval_seconds, max_charges, trial_period_seconds: Option<u64>)`
- `Subscription.trial_ends_at: u64` (0 = no trial)
- `Error::SubscriptionInTrial` returned when `charge_subscription` is called before `trial_ends_at`
- `get_trial_remaining(sub_id)` returns seconds until trial ends (0 once elapsed or no trial)
- `SubscriptionTrialStarted { sub_id, trial_ends_at }` emitted at creation when a non-zero trial is configured
- `SubscriptionTrialEnded { sub_id }` emitted on the first post-trial charge
- The historical `create_subscription(...)` delegates with `trial_period_seconds=None` — no behavioural change for existing callers
- Trial of `0` is valid and behaves like no trial

### #136 — Milestone-Based Escrow Release (escrow contract)
- New types: `Milestone { description_hash: BytesN<32>, amount: i128, status: MilestoneStatus }` and `MilestoneStatus { Pending, Approved, Disputed }`
- `create_milestone_escrow(buyer, seller, arbiter, token, deadline, milestones: Vec<Milestone>)`:
  - Each `amount > 0`, each `status == Pending`, `1..=20` milestones
  - Total escrow amount = sum of milestone amounts (transferred from buyer up front via existing `create_escrow_core`)
  - Milestones stored under `DataKey::EscrowMilestones(escrow_id)` — leaves the existing `Escrow` struct shape untouched
- `approve_milestone(caller, escrow_id, milestone_index)`:
  - Callable by buyer or arbiter
  - Releases that milestone's `amount` to the seller
  - Marks the milestone `Approved`
  - Auto-transitions the escrow to `Released` once every milestone is in a terminal state and at least one was approved (disputed milestones do not block others)
- `get_milestones(escrow_id)` query + `MilestoneApproved { escrow_id, milestone_index, amount_released }` event

Closes #133
Closes #136

## Test plan
- [x] `cargo check -p ahjoor-payments` — green
- [x] `cargo check -p ahjoor-escrow` — green
- [x] 14 new unit tests added (6 subscription-trial + 8 milestone) covering: no-trial immediate charge, zero-trial immediate, charge-during-trial reject, charge-after-trial, `get_trial_remaining` decay, no-trial reports zero remaining; milestone lockup, partial release, full release transitions to Released, double-approve reject, seller cannot self-approve, zero/empty milestones rejected, out-of-range index rejected
- [ ] Reviewer to confirm the milestone schedule is stored separately from `Escrow` (no migration needed for existing escrows)

## Pre-existing issues (out of scope, also noted in #194)
- `cargo test -p ahjoor-payments --lib` fails on `main` independently of this PR with a `TryFrom<&Option<OracleCondition>>` trait bound error. My new tests compile fine in isolation; the underlying workspace build issue blocks running them via `cargo test`.
- `cargo check -p ahjoor-rosca` fails on `main` with a brace mismatch (unrelated).