### PR TITLE
External ID indexing, multisig approval, voucher redemption, and escrow split-decision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
 name = "ahjoor-escrow"
 version = "0.1.0"
 dependencies = [
+ "ahjoor-token-whitelist",
  "proptest",
  "soroban-sdk",
 ]
@@ -36,6 +37,7 @@ name = "ahjoor-refund"
 version = "0.1.0"
 dependencies = [
  "ahjoor-payments",
+ "ahjoor-token-whitelist",
  "proptest",
  "soroban-sdk",
 ]
@@ -44,6 +46,7 @@ dependencies = [
 name = "ahjoor-rosca"
 version = "0.1.0"
 dependencies = [
+ "ahjoor-token-whitelist",
  "proptest",
  "soroban-sdk",
 ]

--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -75,6 +75,18 @@ pub struct DisputeResolved {
     pub resolved_by: Address,
 }
 
+/// Event: Dispute resolved with a percentage split between buyer and seller
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct DisputeResolvedSplit {
+    pub escrow_id: u32,
+    pub buyer_percent: u32,
+    pub seller_percent: u32,
+    pub buyer_amount: i128,
+    pub seller_amount: i128,
+    pub resolved_by: Address,
+}
+
 /// Event: Dispute escalation threshold reached
 #[contractevent]
 #[derive(Clone, Debug)]
@@ -331,6 +343,26 @@ pub fn emit_dispute_resolved(
     DisputeResolved {
         escrow_id,
         release_to_seller,
+        resolved_by,
+    }
+    .publish(e);
+}
+
+pub fn emit_dispute_resolved_split(
+    e: &Env,
+    escrow_id: u32,
+    buyer_percent: u32,
+    seller_percent: u32,
+    buyer_amount: i128,
+    seller_amount: i128,
+    resolved_by: Address,
+) {
+    DisputeResolvedSplit {
+        escrow_id,
+        buyer_percent,
+        seller_percent,
+        buyer_amount,
+        seller_amount,
         resolved_by,
     }
     .publish(e);

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -1042,9 +1042,15 @@ impl AhjoorEscrowContract {
     }
 
     /// Resolve a dispute. Only arbiter can call this.
-    pub fn resolve_dispute(env: Env, arbiter: Address, escrow_id: u32, release_to_seller: bool) {
+    /// `buyer_percent` is 0–100; seller receives the remainder.
+    /// Use 100 for full buyer win, 0 for full seller win, or any value in between for a split.
+    pub fn resolve_dispute(env: Env, arbiter: Address, escrow_id: u32, buyer_percent: u32) {
         Self::require_not_paused(&env);
         arbiter.require_auth();
+
+        if buyer_percent > 100 {
+            panic!("buyer_percent must be between 0 and 100");
+        }
 
         let mut escrow: Escrow = env
             .storage()
@@ -1094,27 +1100,41 @@ impl AhjoorEscrowContract {
             events::emit_protocol_fee_paid(&env, escrow_id, protocol_fee, fee_recipient);
         }
 
-        let winner_amount = escrow.amount - protocol_fee - arbiter_fee;
+        let distributable = escrow.amount - protocol_fee - arbiter_fee;
 
-        if winner_amount < 0 {
+        if distributable < 0 {
             panic!("Fee configuration exceeds escrow amount");
         }
 
-        if release_to_seller {
-            client.transfer(
-                &env.current_contract_address(),
-                &escrow.seller,
-                &winner_amount,
-            );
-            escrow.status = EscrowStatus::Released;
-        } else {
+        let seller_percent = 100 - buyer_percent;
+
+        // Integer-safe split: buyer gets floor, seller gets the rest to avoid precision loss
+        let buyer_amount = (distributable * buyer_percent as i128) / 100;
+        let seller_amount = distributable - buyer_amount;
+
+        if buyer_amount > 0 {
             client.transfer(
                 &env.current_contract_address(),
                 &escrow.buyer,
-                &winner_amount,
+                &buyer_amount,
             );
-            escrow.status = EscrowStatus::Refunded;
         }
+        if seller_amount > 0 {
+            client.transfer(
+                &env.current_contract_address(),
+                &escrow.seller,
+                &seller_amount,
+            );
+        }
+
+        // Determine final status: if buyer gets everything → Refunded, seller gets everything → Released, else Resolved
+        escrow.status = if buyer_percent == 100 {
+            EscrowStatus::Refunded
+        } else if buyer_percent == 0 {
+            EscrowStatus::Released
+        } else {
+            EscrowStatus::Resolved
+        };
 
         env.storage()
             .persistent()
@@ -1137,6 +1157,18 @@ impl AhjoorEscrowContract {
                 .set(&DataKey::Dispute(escrow_id), &dispute);
         }
 
+        // Emit split event (covers binary cases too)
+        events::emit_dispute_resolved_split(
+            &env,
+            escrow_id,
+            buyer_percent,
+            seller_percent,
+            buyer_amount,
+            seller_amount,
+            arbiter.clone(),
+        );
+        // Also emit legacy binary event for backward-compatible indexers
+        let release_to_seller = buyer_percent == 0;
         events::emit_dispute_resolved(&env, escrow_id, release_to_seller, arbiter);
 
         env.storage()

--- a/contracts/ahjoor-escrow/src/test.rs
+++ b/contracts/ahjoor-escrow/src/test.rs
@@ -549,7 +549,7 @@ fn test_partial_dispute_50_50_split() {
     assert_eq!(dispute.resolved, false);
 
     // Arbiter resolves the disputed portion to seller
-    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
     assert_eq!(s.token_client.balance(&seller), 200);
     assert_eq!(s.token_client.balance(&s.client.address), 0);
 }
@@ -582,7 +582,7 @@ fn test_partial_dispute_80_20_split() {
     assert_eq!(s.token_client.balance(&s.client.address), 20);
 
     // Arbiter refunds the disputed portion to buyer
-    s.client.resolve_dispute(&arbiter, &escrow_id, &false);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &100u32);
     assert_eq!(s.token_client.balance(&buyer), 920); // 1000 - 100 deposited + 20 refunded
     assert_eq!(s.token_client.balance(&s.client.address), 0);
 }
@@ -702,7 +702,7 @@ fn test_resolve_dispute_to_seller() {
         &String::from_str(&s.env, "Item not received"),
         &250,
     );
-    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     let escrow = s.client.get_escrow(&escrow_id);
     assert_eq!(escrow.status, EscrowStatus::Released);
@@ -733,7 +733,7 @@ fn test_resolve_dispute_to_buyer() {
         &String::from_str(&s.env, "Payment not received"),
         &250,
     );
-    s.client.resolve_dispute(&arbiter, &escrow_id, &false);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &100u32);
 
     let escrow = s.client.get_escrow(&escrow_id);
     assert_eq!(escrow.status, EscrowStatus::Refunded);
@@ -762,7 +762,135 @@ fn test_resolve_dispute_by_buyer_panics() {
         &String::from_str(&s.env, "Item not received"),
         &250,
     );
-    s.client.resolve_dispute(&buyer, &escrow_id, &true);
+    s.client.resolve_dispute(&buyer, &escrow_id, &0u32);
+}
+
+// ===========================================================================
+//  Dispute Split Tests (Task 4)
+// ===========================================================================
+
+#[test]
+fn test_resolve_dispute_50_50_split() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &1000, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+
+    s.client.dispute_escrow(
+        &buyer,
+        &escrow_id,
+        &String::from_str(&s.env, "Partial issue"),
+        &1000,
+    );
+    // 50% to buyer, 50% to seller
+    s.client.resolve_dispute(&arbiter, &escrow_id, &50u32);
+
+    assert_eq!(s.token_client.balance(&buyer), 500);  // 0 remaining + 500 refunded
+    assert_eq!(s.token_client.balance(&seller), 500);
+    assert_eq!(s.token_client.balance(&s.client.address), 0);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Resolved);
+}
+
+#[test]
+fn test_resolve_dispute_split_with_fee() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    let fee_recipient = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    // 100 bps = 1% protocol fee
+    s.client.update_protocol_fee(&s.admin, &100, &fee_recipient);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &1000, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+
+    s.client.dispute_escrow(
+        &buyer,
+        &escrow_id,
+        &String::from_str(&s.env, "Partial issue"),
+        &1000,
+    );
+    // fee = 1000 * 100 / 10000 = 10; distributable = 990; 50% split → buyer=495, seller=495
+    s.client.resolve_dispute(&arbiter, &escrow_id, &50u32);
+
+    assert_eq!(s.token_client.balance(&fee_recipient), 10);
+    assert_eq!(s.token_client.balance(&buyer), 495);
+    assert_eq!(s.token_client.balance(&seller), 495);
+    assert_eq!(s.token_client.balance(&s.client.address), 0);
+}
+
+#[test]
+fn test_resolve_dispute_100_0_is_full_buyer_win() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &500, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "d"), &500);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &100u32);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Refunded);
+    assert_eq!(s.token_client.balance(&buyer), 1000);
+    assert_eq!(s.token_client.balance(&seller), 0);
+}
+
+#[test]
+fn test_resolve_dispute_0_100_is_full_seller_win() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &500, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "d"), &500);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
+
+    let escrow = s.client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(s.token_client.balance(&seller), 500);
+    assert_eq!(s.token_client.balance(&buyer), 500); // 1000 - 500 deposited
+}
+
+#[test]
+#[should_panic(expected = "buyer_percent must be between 0 and 100")]
+fn test_resolve_dispute_invalid_percent_panics() {
+    let s = setup();
+    let buyer = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1000);
+
+    let deadline = s.env.ledger().timestamp() + 1000;
+    let escrow_id =
+        s.client
+            .create_escrow(&buyer, &seller, &arbiter, &500, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+
+    s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "d"), &500);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &101u32);
 }
 
 // ===========================================================================
@@ -792,7 +920,7 @@ fn test_protocol_fee_deducted_on_resolve_to_seller() {
         &String::from_str(&s.env, "Dispute"),
         &1000,
     );
-    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     // fee = 1000 * 100 / 10000 = 10; seller gets 990
     assert_eq!(s.token_client.balance(&seller), 990);
@@ -823,7 +951,7 @@ fn test_protocol_fee_deducted_on_resolve_to_buyer() {
         &String::from_str(&s.env, "Dispute"),
         &500,
     );
-    s.client.resolve_dispute(&arbiter, &escrow_id, &false);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &100u32);
 
     // fee = 500 * 200 / 10000 = 10; buyer gets 490, started with 500 after deposit
     assert_eq!(s.token_client.balance(&buyer), 990); // 1000 - 500 deposited + 490 refunded
@@ -854,7 +982,7 @@ fn test_zero_protocol_fee_skips_fee_transfer() {
         &String::from_str(&s.env, "Dispute"),
         &250,
     );
-    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     assert_eq!(s.token_client.balance(&seller), 250);
     assert_eq!(s.token_client.balance(&fee_recipient), 0);
@@ -912,7 +1040,7 @@ fn test_protocol_fee_emits_event() {
         &String::from_str(&s.env, "Dispute"),
         &1000,
     );
-    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     let events = s.env.events().all();
     let fee_event = events
@@ -2819,7 +2947,7 @@ fn test_arbiter_fee_deducted_from_loser_seller_wins() {
 
     s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
     // Seller wins
-    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     // fee = 1000 * 500 / 10000 = 50; seller gets 950
     assert_eq!(s.token_client.balance(&arbiter), 50);
@@ -2859,7 +2987,7 @@ fn test_arbiter_fee_deducted_from_loser_buyer_wins() {
 
     s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
     // Buyer wins
-    s.client.resolve_dispute(&arbiter, &escrow_id, &false);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &100u32);
 
     // fee = 50; buyer gets 950
     assert_eq!(s.token_client.balance(&arbiter), 50);
@@ -2898,7 +3026,7 @@ fn test_arbiter_fee_zero_is_valid() {
     let escrow_id = s.client.create_escrow_v2(&buyer, &request);
 
     s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
-    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     assert_eq!(s.token_client.balance(&arbiter), 0);
     assert_eq!(s.token_client.balance(&seller), 1000);
@@ -2955,7 +3083,7 @@ fn test_default_arbiter_fee_applies_when_escrow_fee_not_set() {
     );
 
     s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
-    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     // fee = 1000 * 200 / 10000 = 20
     assert_eq!(s.token_client.balance(&arbiter), 20);
@@ -2993,7 +3121,7 @@ fn test_arbiter_fee_emits_event() {
     let escrow_id = s.client.create_escrow_v2(&buyer, &request);
 
     s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "dispute"), &1000);
-    s.client.resolve_dispute(&arbiter, &escrow_id, &true);
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     let events = s.env.events().all();
     let topic = (Symbol::new(&s.env, "arbiter_fee_paid"),).into_val(&s.env);

--- a/contracts/ahjoor-escrow/src/test_dispute_timeout.rs
+++ b/contracts/ahjoor-escrow/src/test_dispute_timeout.rs
@@ -67,7 +67,7 @@ fn test_arbiter_resolves_before_timeout() {
         li.timestamp += 3 * 24 * 60 * 60; // 3 days
     });
 
-    client.resolve_dispute(&arbiter, &escrow_id, &true);
+    client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     // Verify dispute is resolved
     let dispute = client.get_dispute(&escrow_id);
@@ -238,7 +238,7 @@ fn test_enforce_timeout_on_resolved_dispute() {
 
     // Raise and resolve dispute
     client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&env, "test"), &1000);
-    client.resolve_dispute(&arbiter, &escrow_id, &true);
+    client.resolve_dispute(&arbiter, &escrow_id, &0u32);
 
     // Advance time past timeout
     env.ledger().with_mut(|li| {

--- a/contracts/ahjoor-payments/src/events.rs
+++ b/contracts/ahjoor-payments/src/events.rs
@@ -839,3 +839,119 @@ pub fn emit_notification_key_registered(e: &Env, merchant: Address, key: soroban
 pub fn emit_notification_key_removed(e: &Env, merchant: Address) {
     NotificationKeyRemoved { merchant }.publish(e);
 }
+
+// ---------------------------------------------------------------------------
+// Task 1: External ID Events
+// ---------------------------------------------------------------------------
+
+/// Event: Payment indexed by merchant external_id
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct PaymentIndexedByExternalId {
+    pub payment_id: u32,
+    pub external_id: BytesN<32>,
+}
+
+pub fn emit_payment_indexed_by_external_id(e: &Env, payment_id: u32, external_id: BytesN<32>) {
+    PaymentIndexedByExternalId { payment_id, external_id }.publish(e);
+}
+
+// ---------------------------------------------------------------------------
+// Task 2: Multi-Sig Approval Events
+// ---------------------------------------------------------------------------
+
+/// Event: A signer approved a PendingApproval payment
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct PaymentApproved {
+    pub payment_id: u32,
+    pub signer: Address,
+}
+
+/// Event: Approval window expired; payment auto-cancelled
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct PaymentApprovalExpired {
+    pub payment_id: u32,
+}
+
+pub fn emit_payment_approved(e: &Env, payment_id: u32, signer: Address) {
+    PaymentApproved { payment_id, signer }.publish(e);
+}
+
+pub fn emit_payment_approval_expired(e: &Env, payment_id: u32) {
+    PaymentApprovalExpired { payment_id }.publish(e);
+}
+
+// ---------------------------------------------------------------------------
+// Task 3: Voucher Events
+// ---------------------------------------------------------------------------
+
+/// Event: Merchant issued a voucher
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct VoucherIssued {
+    pub merchant: Address,
+    pub code_hash: BytesN<32>,
+    pub discount_type: crate::DiscountType,
+    pub discount_value: u32,
+    pub max_uses: u32,
+    pub expiry: u64,
+}
+
+/// Event: Voucher redeemed by a customer
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct VoucherRedeemed {
+    pub merchant: Address,
+    pub code_hash: BytesN<32>,
+    pub customer: Address,
+    pub discount_applied: i128,
+}
+
+/// Event: Voucher revoked by merchant
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct VoucherRevoked {
+    pub merchant: Address,
+    pub code_hash: BytesN<32>,
+}
+
+/// Event: Voucher exhausted (all uses consumed)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct VoucherExhausted {
+    pub merchant: Address,
+    pub code_hash: BytesN<32>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn emit_voucher_issued(
+    e: &Env,
+    merchant: Address,
+    code_hash: BytesN<32>,
+    discount_type: crate::DiscountType,
+    discount_value: u32,
+    max_uses: u32,
+    expiry: u64,
+) {
+    VoucherIssued { merchant, code_hash, discount_type, discount_value, max_uses, expiry }.publish(e);
+}
+
+pub fn emit_voucher_redeemed(
+    e: &Env,
+    merchant: Address,
+    code_hash: BytesN<32>,
+    customer: Address,
+    discount_applied: i128,
+) {
+    VoucherRedeemed { merchant, code_hash, customer, discount_applied }.publish(e);
+}
+
+pub fn emit_voucher_revoked(e: &Env, merchant: Address, code_hash: BytesN<32>) {
+    VoucherRevoked { merchant, code_hash }.publish(e);
+}
+
+pub fn emit_voucher_exhausted(e: &Env, merchant: Address, code_hash: BytesN<32>) {
+    VoucherExhausted { merchant, code_hash }.publish(e);
+}

--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -94,6 +94,14 @@ pub enum Error {
     OracleConditionNotMet = 3,
     MerchantVolumeCapped = 4,
     TokenNotAllowed = 5,
+    DuplicateExternalId = 6,
+    MultisigNotRequired = 7,
+    AlreadyApproved = 8,
+    NotASigner = 9,
+    VoucherExpired = 10,
+    VoucherExhausted = 11,
+    VoucherRevoked = 12,
+    VoucherNotFound = 13,
 }
 
 /// Direction for oracle price condition (#125)
@@ -123,6 +131,8 @@ pub enum PaymentStatus {
     Expired = 4,
     Authorized = 5,
     ScheduledPending = 6,
+    /// Awaiting M-of-N multi-sig approval before proceeding.
+    PendingApproval = 7,
 }
 
 #[contracttype]
@@ -195,6 +205,8 @@ pub struct Payment {
     pub capture_deadline: u64,
     // Optional oracle price condition required for completion (#125)
     // pub release_condition: Option<OracleCondition>,
+    /// Optional off-chain order correlation key (hash of merchant order ID).
+    pub external_id: Option<BytesN<32>>,
 }
 
 #[contracttype]
@@ -240,6 +252,62 @@ pub struct Dispute {
 
 /// Default payment timeout: 7 days in seconds.
 const DEFAULT_PAYMENT_TIMEOUT: u64 = 7 * 24 * 60 * 60;
+
+// ---------------------------------------------------------------------------
+// Task 2: Multi-Signature Approval
+// ---------------------------------------------------------------------------
+
+/// Multi-signature policy for high-value payments.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultisigPolicy {
+    /// Minimum number of approvals required.
+    pub m: u32,
+    /// Authorized signer set.
+    pub signers: Vec<Address>,
+    /// Payment amount threshold (inclusive) that triggers multi-sig gate.
+    pub threshold: i128,
+    /// Seconds after creation before an unapproved payment auto-cancels.
+    pub approval_window_seconds: u64,
+}
+
+/// Per-payment approval state.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ApprovalState {
+    pub payment_id: u32,
+    pub approvals: Vec<Address>,
+    pub created_at: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Task 3: Voucher / Coupon Code Redemption
+// ---------------------------------------------------------------------------
+
+/// Discount type for vouchers.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DiscountType {
+    /// Fixed token amount deducted from payment.
+    Fixed = 0,
+    /// Percentage (0–100) deducted from payment.
+    Percentage = 1,
+}
+
+/// On-chain voucher record (keyed by sha256 hash of the promo code).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Voucher {
+    pub merchant: Address,
+    pub discount_type: DiscountType,
+    /// Fixed: token units. Percentage: 0–100.
+    pub discount_value: u32,
+    pub max_uses: u32,
+    pub uses_remaining: u32,
+    /// Ledger timestamp after which the voucher is invalid. 0 = no expiry.
+    pub expiry: u64,
+    pub revoked: bool,
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -389,6 +457,17 @@ pub enum DataKey {
     Dispute(u32),
     /// Temporary: idempotency key → payment_id mapping (expires after 24h)
     IdempotencyKey(BytesN<32>),
+    // --- Task 1: External ID Index ---
+    /// Persistent: (merchant, external_id) → payment_id
+    ExternalIdIndex(Address, BytesN<32>),
+    // --- Task 2: Multi-Sig ---
+    /// Instance: per-merchant multi-sig policy
+    MultisigPolicy(Address),
+    /// Persistent: per-payment approval state
+    ApprovalState(u32),
+    // --- Task 3: Vouchers ---
+    /// Persistent: (merchant, code_hash) → Voucher
+    Voucher(Address, BytesN<32>),
 }
 
 mod events;
@@ -604,6 +683,7 @@ impl AhjoorPaymentsContract {
             tags: None,
             capture_deadline: 0,
             // // release_condition: None,
+            external_id: None,
         };
 
         // Persistent: per-payment record with individual TTL
@@ -719,6 +799,7 @@ impl AhjoorPaymentsContract {
                 tags: None,
                 capture_deadline: 0,
                 // release_condition: None,
+                external_id: None,
             };
 
             // Persistent: per-payment record with individual TTL
@@ -1269,6 +1350,7 @@ impl AhjoorPaymentsContract {
                 tags: None,
                 capture_deadline: 0,
                 // release_condition: None,
+                external_id: None,
             };
 
             env.storage()
@@ -1388,6 +1470,7 @@ impl AhjoorPaymentsContract {
             tags: None,
             capture_deadline: 0,
             // release_condition: None,
+            external_id: None,
         };
 
         env.storage()
@@ -1875,6 +1958,562 @@ impl AhjoorPaymentsContract {
             .persistent()
             .get(&DataKey::Payment(payment_id))
             .expect("Payment not found")
+    }
+
+    // =========================================================================
+    // Task 1: External ID — Off-Chain Order Correlation
+    // =========================================================================
+
+    /// Look up a payment by merchant + external_id.
+    /// Returns the full Payment struct.
+    pub fn get_payment_by_external_id(
+        env: Env,
+        merchant: Address,
+        external_id: BytesN<32>,
+    ) -> Payment {
+        let payment_id: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ExternalIdIndex(merchant, external_id))
+            .expect("No payment found for this external_id");
+        env.storage()
+            .persistent()
+            .get(&DataKey::Payment(payment_id))
+            .expect("Payment not found")
+    }
+
+    // =========================================================================
+    // Task 2: Multi-Signature Approval for High-Value Payments
+    // =========================================================================
+
+    /// Merchant (or admin) configures a multi-sig policy.
+    /// `threshold`: minimum payment amount that requires approval.
+    /// `signers`: authorized co-signer addresses.
+    /// `m`: number of approvals required (must be ≤ signers.len()).
+    /// `approval_window_seconds`: time window before unapproved payment auto-cancels.
+    pub fn set_multisig_policy(
+        env: Env,
+        merchant: Address,
+        threshold: i128,
+        signers: Vec<Address>,
+        m: u32,
+        approval_window_seconds: u64,
+    ) {
+        Self::require_not_paused(&env);
+        merchant.require_auth();
+
+        if threshold <= 0 {
+            panic!("threshold must be positive");
+        }
+        if signers.is_empty() {
+            panic!("signers cannot be empty");
+        }
+        if m == 0 || m > signers.len() {
+            panic!("m must be between 1 and signers.len()");
+        }
+        if approval_window_seconds == 0 {
+            panic!("approval_window_seconds must be positive");
+        }
+
+        let policy = MultisigPolicy {
+            m,
+            signers,
+            threshold,
+            approval_window_seconds,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::MultisigPolicy(merchant), &policy);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get the multi-sig policy for a merchant.
+    pub fn get_multisig_policy(env: Env, merchant: Address) -> Option<MultisigPolicy> {
+        env.storage()
+            .instance()
+            .get(&DataKey::MultisigPolicy(merchant))
+    }
+
+    /// A signer approves a PendingApproval payment.
+    /// Once `m` approvals are recorded the payment transitions to Pending.
+    pub fn approve_payment(env: Env, signer: Address, payment_id: u32) {
+        Self::require_not_paused(&env);
+        signer.require_auth();
+
+        let mut payment: Payment = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Payment(payment_id))
+            .expect("Payment not found");
+
+        if payment.status != PaymentStatus::PendingApproval {
+            panic!("Payment is not pending approval");
+        }
+
+        let policy: MultisigPolicy = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultisigPolicy(payment.merchant.clone()))
+            .expect("No multisig policy for merchant");
+
+        // Verify signer is in the policy set
+        let mut is_valid_signer = false;
+        for i in 0..policy.signers.len() {
+            if policy.signers.get(i).unwrap() == signer {
+                is_valid_signer = true;
+                break;
+            }
+        }
+        if !is_valid_signer {
+            panic_with_error!(&env, Error::NotASigner);
+        }
+
+        // Check approval window
+        let mut state: ApprovalState = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ApprovalState(payment_id))
+            .expect("Approval state not found");
+
+        let now = env.ledger().timestamp();
+        if now > state.created_at + policy.approval_window_seconds {
+            // Window expired — auto-cancel and refund
+            let client = token::Client::new(&env, &payment.token);
+            client.transfer(
+                &env.current_contract_address(),
+                &payment.customer,
+                &payment.amount,
+            );
+            let old_status = payment.status;
+            payment.status = PaymentStatus::Refunded;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Payment(payment_id), &payment);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Payment(payment_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+            events::emit_payment_approval_expired(&env, payment_id);
+            events::emit_payment_status_changed(&env, payment_id, old_status, PaymentStatus::Refunded);
+            env.storage()
+                .instance()
+                .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+            return;
+        }
+
+        // Check for duplicate approval
+        for i in 0..state.approvals.len() {
+            if state.approvals.get(i).unwrap() == signer {
+                panic_with_error!(&env, Error::AlreadyApproved);
+            }
+        }
+
+        state.approvals.push_back(signer.clone());
+        events::emit_payment_approved(&env, payment_id, signer);
+
+        if state.approvals.len() >= policy.m {
+            // Quorum reached — transition to Pending
+            let old_status = payment.status;
+            payment.status = PaymentStatus::Pending;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Payment(payment_id), &payment);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Payment(payment_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+            events::emit_payment_status_changed(&env, payment_id, old_status, PaymentStatus::Pending);
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::ApprovalState(payment_id), &state);
+            env.storage().persistent().extend_ttl(
+                &DataKey::ApprovalState(payment_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        }
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Anyone can call this to expire an unapproved payment after the approval window.
+    pub fn expire_pending_approval(env: Env, payment_id: u32) {
+        Self::require_not_paused(&env);
+
+        let mut payment: Payment = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Payment(payment_id))
+            .expect("Payment not found");
+
+        if payment.status != PaymentStatus::PendingApproval {
+            panic!("Payment is not pending approval");
+        }
+
+        let policy: MultisigPolicy = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultisigPolicy(payment.merchant.clone()))
+            .expect("No multisig policy for merchant");
+
+        let state: ApprovalState = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ApprovalState(payment_id))
+            .expect("Approval state not found");
+
+        let now = env.ledger().timestamp();
+        if now <= state.created_at + policy.approval_window_seconds {
+            panic!("Approval window has not expired yet");
+        }
+
+        let client = token::Client::new(&env, &payment.token);
+        client.transfer(
+            &env.current_contract_address(),
+            &payment.customer,
+            &payment.amount,
+        );
+
+        let old_status = payment.status;
+        payment.status = PaymentStatus::Refunded;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Payment(payment_id), &payment);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Payment(payment_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_payment_approval_expired(&env, payment_id);
+        events::emit_payment_status_changed(&env, payment_id, old_status, PaymentStatus::Refunded);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    // =========================================================================
+    // Task 3: Voucher / Coupon Code Redemption
+    // =========================================================================
+
+    /// Merchant issues a voucher on-chain.
+    /// `code_hash`: sha256 hash of the promo code (prevents front-running).
+    /// `discount_type`: Fixed or Percentage.
+    /// `discount_value`: token units (Fixed) or 0–100 (Percentage).
+    /// `max_uses`: maximum redemptions; 0 = unlimited.
+    /// `expiry`: ledger timestamp after which voucher is invalid; 0 = no expiry.
+    pub fn issue_voucher(
+        env: Env,
+        merchant: Address,
+        code_hash: BytesN<32>,
+        discount_type: DiscountType,
+        discount_value: u32,
+        max_uses: u32,
+        expiry: u64,
+    ) {
+        Self::require_not_paused(&env);
+        merchant.require_auth();
+
+        if discount_type == DiscountType::Percentage && discount_value > 100 {
+            panic!("Percentage discount cannot exceed 100");
+        }
+        if discount_value == 0 {
+            panic!("discount_value must be positive");
+        }
+
+        let key = DataKey::Voucher(merchant.clone(), code_hash.clone());
+        if env.storage().persistent().has(&key) {
+            panic!("Voucher with this code_hash already exists");
+        }
+
+        let voucher = Voucher {
+            merchant: merchant.clone(),
+            discount_type,
+            discount_value,
+            max_uses,
+            uses_remaining: max_uses,
+            expiry,
+            revoked: false,
+        };
+
+        env.storage().persistent().set(&key, &voucher);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_voucher_issued(&env, merchant, code_hash, discount_type, discount_value, max_uses, expiry);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Merchant revokes a voucher immediately.
+    pub fn revoke_voucher(env: Env, merchant: Address, code_hash: BytesN<32>) {
+        Self::require_not_paused(&env);
+        merchant.require_auth();
+
+        let key = DataKey::Voucher(merchant.clone(), code_hash.clone());
+        let mut voucher: Voucher = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Voucher not found");
+
+        if voucher.merchant != merchant {
+            panic!("Only the issuing merchant can revoke this voucher");
+        }
+        if voucher.revoked {
+            panic!("Voucher already revoked");
+        }
+
+        voucher.revoked = true;
+        env.storage().persistent().set(&key, &voucher);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_voucher_revoked(&env, merchant, code_hash);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get voucher details.
+    pub fn get_voucher(env: Env, merchant: Address, code_hash: BytesN<32>) -> Voucher {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Voucher(merchant, code_hash))
+            .expect("Voucher not found")
+    }
+
+    /// Create a payment with an optional voucher code hash for discount.
+    /// The discount is applied to the required payment amount.
+    pub fn create_payment_with_voucher(
+        env: Env,
+        customer: Address,
+        merchant: Address,
+        amount: i128,
+        token: Address,
+        reference: Option<String>,
+        metadata: Option<Map<String, String>>,
+        idempotency_key: Option<BytesN<32>>,
+        voucher_code_hash: Option<BytesN<32>>,
+        external_id: Option<BytesN<32>>,
+    ) -> u32 {
+        Self::require_not_paused(&env);
+        customer.require_auth();
+
+        // Check idempotency key first
+        if let Some(ref key) = idempotency_key {
+            if let Some(existing_payment_id) = env
+                .storage()
+                .temporary()
+                .get::<DataKey, u32>(&DataKey::IdempotencyKey(key.clone()))
+            {
+                return existing_payment_id;
+            }
+        }
+
+        Self::enforce_rate_limit(&env, &customer, 1);
+
+        if amount <= 0 {
+            panic!("Payment amount must be positive");
+        }
+
+        Self::validate_reference(&env, &reference);
+        Self::validate_metadata(&env, &metadata);
+        Self::require_token_allowed(&env, &token);
+        Self::require_merchant_approved(&env, &merchant);
+
+        // --- External ID uniqueness check ---
+        if let Some(ref ext_id) = external_id {
+            let idx_key = DataKey::ExternalIdIndex(merchant.clone(), ext_id.clone());
+            if env.storage().persistent().has(&idx_key) {
+                panic_with_error!(&env, Error::DuplicateExternalId);
+            }
+        }
+
+        // --- Voucher discount ---
+        let effective_amount = if let Some(ref code_hash) = voucher_code_hash {
+            let voucher_key = DataKey::Voucher(merchant.clone(), code_hash.clone());
+            let mut voucher: Voucher = env
+                .storage()
+                .persistent()
+                .get(&voucher_key)
+                .expect("Voucher not found");
+
+            let now = env.ledger().timestamp();
+            if voucher.revoked {
+                panic_with_error!(&env, Error::VoucherRevoked);
+            }
+            if voucher.expiry > 0 && now > voucher.expiry {
+                panic_with_error!(&env, Error::VoucherExpired);
+            }
+            if voucher.max_uses > 0 && voucher.uses_remaining == 0 {
+                panic_with_error!(&env, Error::VoucherExhausted);
+            }
+
+            let discount: i128 = match voucher.discount_type {
+                DiscountType::Fixed => voucher.discount_value as i128,
+                DiscountType::Percentage => (amount * voucher.discount_value as i128) / 100,
+            };
+            let discounted = (amount - discount).max(0);
+
+            // Decrement uses
+            if voucher.max_uses > 0 {
+                voucher.uses_remaining -= 1;
+            }
+            let exhausted = voucher.max_uses > 0 && voucher.uses_remaining == 0;
+            if exhausted {
+                voucher.revoked = true; // mark exhausted by setting revoked (uses_remaining=0 is the real signal)
+            }
+            env.storage().persistent().set(&voucher_key, &voucher);
+            env.storage().persistent().extend_ttl(
+                &voucher_key,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+
+            events::emit_voucher_redeemed(&env, merchant.clone(), code_hash.clone(), customer.clone(), discount);
+            if exhausted {
+                events::emit_voucher_exhausted(&env, merchant.clone(), code_hash.clone());
+            }
+
+            discounted
+        } else {
+            amount
+        };
+
+        if effective_amount <= 0 {
+            panic!("Effective payment amount after discount must be positive");
+        }
+
+        let client = token::Client::new(&env, &token);
+        client.transfer(&customer, &env.current_contract_address(), &effective_amount);
+
+        let timeout: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentTimeout)
+            .unwrap_or(DEFAULT_PAYMENT_TIMEOUT);
+        let now = env.ledger().timestamp();
+
+        // --- Multi-sig gate check ---
+        let policy_opt: Option<MultisigPolicy> = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultisigPolicy(merchant.clone()));
+
+        let status = if let Some(ref policy) = policy_opt {
+            if effective_amount >= policy.threshold {
+                PaymentStatus::PendingApproval
+            } else {
+                PaymentStatus::Pending
+            }
+        } else {
+            PaymentStatus::Pending
+        };
+
+        let payment_id = Self::next_payment_id(&env);
+        let payment = Payment {
+            id: payment_id,
+            customer: customer.clone(),
+            merchant: merchant.clone(),
+            amount: effective_amount,
+            token: token.clone(),
+            status,
+            created_at: now,
+            expires_at: now + timeout,
+            refunded_amount: 0,
+            reference: reference.clone(),
+            metadata,
+            split_recipients: None,
+            execute_after: 0,
+            category: None,
+            tags: None,
+            capture_deadline: 0,
+            external_id: external_id.clone(),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Payment(payment_id), &payment);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Payment(payment_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        Self::add_customer_payment(&env, &customer, payment_id);
+
+        if let Some(ref r) = reference {
+            Self::index_payment_by_reference(&env, &merchant, r, payment_id);
+        }
+
+        // --- Store external_id index ---
+        if let Some(ref ext_id) = external_id {
+            let idx_key = DataKey::ExternalIdIndex(merchant.clone(), ext_id.clone());
+            env.storage().persistent().set(&idx_key, &payment_id);
+            env.storage().persistent().extend_ttl(
+                &idx_key,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+            events::emit_payment_indexed_by_external_id(&env, payment_id, ext_id.clone());
+        }
+
+        // --- Store approval state if PendingApproval ---
+        if status == PaymentStatus::PendingApproval {
+            let state = ApprovalState {
+                payment_id,
+                approvals: Vec::new(&env),
+                created_at: now,
+            };
+            env.storage()
+                .persistent()
+                .set(&DataKey::ApprovalState(payment_id), &state);
+            env.storage().persistent().extend_ttl(
+                &DataKey::ApprovalState(payment_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        }
+
+        if let Some(ref key) = idempotency_key {
+            env.storage()
+                .temporary()
+                .set(&DataKey::IdempotencyKey(key.clone()), &payment_id);
+            env.storage().temporary().extend_ttl(
+                &DataKey::IdempotencyKey(key.clone()),
+                IDEMPOTENCY_KEY_LIFETIME_THRESHOLD,
+                IDEMPOTENCY_KEY_BUMP_AMOUNT,
+            );
+        }
+
+        Self::inc_global_created(&env);
+        Self::inc_merchant_created(&env, &merchant);
+
+        events::emit_payment_created(&env, payment_id, customer, merchant, effective_amount, token);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        payment_id
     }
 
     /// Returns the 32-byte sha256 receipt hash for a completed payment (#65).
@@ -3998,5 +4637,8 @@ mod test_collateral;
 
 #[cfg(test)]
 mod test_notification_keys;
+
+#[cfg(test)]
+mod test_external_id_multisig_voucher;
 
 pub use events::*;

--- a/contracts/ahjoor-payments/src/test_external_id_multisig_voucher.rs
+++ b/contracts/ahjoor-payments/src/test_external_id_multisig_voucher.rs
@@ -1,0 +1,410 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::token::Client as TokenClient;
+use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
+use soroban_sdk::{testutils::{Address as _, Ledger}, vec, Address, BytesN, Env};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+struct Setup<'a> {
+    env: Env,
+    client: AhjoorPaymentsContractClient<'a>,
+    admin: Address,
+    fee_recipient: Address,
+    merchant: Address,
+    token_addr: Address,
+    token_client: TokenClient<'a>,
+    token_admin_client: TokenAdminClient<'a>,
+}
+
+fn setup<'a>() -> Setup<'a> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AhjoorPaymentsContract, ());
+    let client = AhjoorPaymentsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let fee_recipient = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_client = TokenClient::new(&env, &token_addr);
+    let token_admin_client = TokenAdminClient::new(&env, &token_addr);
+
+    client.initialize(&admin, &fee_recipient, &0);
+    // Open mode so merchant doesn't need collateral
+    client.set_merchant_open_mode(&true);
+
+    Setup { env, client, admin, fee_recipient, merchant, token_addr, token_client, token_admin_client }
+}
+
+fn make_external_id(env: &Env, seed: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    BytesN::from_array(env, &bytes)
+}
+
+// ===========================================================================
+// Task 1: External ID Tests
+// ===========================================================================
+
+#[test]
+fn test_external_id_indexes_payment() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &1000);
+
+    let ext_id = make_external_id(&s.env, 1);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &None, &Some(ext_id.clone()),
+    );
+
+    let payment = s.client.get_payment_by_external_id(&s.merchant, &ext_id);
+    assert_eq!(payment.id, pid);
+    assert_eq!(payment.external_id, Some(ext_id));
+}
+
+#[test]
+#[should_panic]
+fn test_duplicate_external_id_same_merchant_rejected() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &2000);
+
+    let ext_id = make_external_id(&s.env, 2);
+
+    s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &None, &Some(ext_id.clone()),
+    );
+    // Second call with same merchant + same external_id must panic
+    s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &None, &Some(ext_id.clone()),
+    );
+}
+
+#[test]
+fn test_same_external_id_different_merchants_allowed() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    let merchant2 = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &2000);
+
+    let ext_id = make_external_id(&s.env, 3);
+
+    let pid1 = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &None, &Some(ext_id.clone()),
+    );
+    let pid2 = s.client.create_payment_with_voucher(
+        &customer, &merchant2, &500, &s.token_addr,
+        &None, &None, &None, &None, &Some(ext_id.clone()),
+    );
+
+    assert_ne!(pid1, pid2);
+    let p1 = s.client.get_payment_by_external_id(&s.merchant, &ext_id);
+    let p2 = s.client.get_payment_by_external_id(&merchant2, &ext_id);
+    assert_eq!(p1.id, pid1);
+    assert_eq!(p2.id, pid2);
+}
+
+#[test]
+fn test_payment_without_external_id_works_normally() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &1000);
+
+    let pid = s.client.create_payment(
+        &customer, &s.merchant, &500, &s.token_addr, &None, &None, &None,
+    );
+    let payment = s.client.get_payment(&pid);
+    assert_eq!(payment.external_id, None);
+}
+
+// ===========================================================================
+// Task 2: Multi-Sig Approval Tests
+// ===========================================================================
+
+#[test]
+fn test_multisig_policy_set_and_retrieved() {
+    let s = setup();
+    let signer1 = Address::generate(&s.env);
+    let signer2 = Address::generate(&s.env);
+    let signer3 = Address::generate(&s.env);
+    let signers = vec![&s.env, signer1.clone(), signer2.clone(), signer3.clone()];
+
+    s.client.set_multisig_policy(&s.merchant, &1000, &signers, &2, &3600);
+
+    let policy = s.client.get_multisig_policy(&s.merchant).unwrap();
+    assert_eq!(policy.m, 2);
+    assert_eq!(policy.threshold, 1000);
+    assert_eq!(policy.approval_window_seconds, 3600);
+}
+
+#[test]
+fn test_high_value_payment_enters_pending_approval() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let signer1 = Address::generate(&s.env);
+    let signer2 = Address::generate(&s.env);
+    let signers = vec![&s.env, signer1.clone(), signer2.clone()];
+    s.client.set_multisig_policy(&s.merchant, &1000, &signers, &2, &3600);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &2000, &s.token_addr,
+        &None, &None, &None, &None, &None,
+    );
+
+    let payment = s.client.get_payment(&pid);
+    assert_eq!(payment.status, PaymentStatus::PendingApproval);
+}
+
+#[test]
+fn test_low_value_payment_skips_multisig() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let signer1 = Address::generate(&s.env);
+    let signers = vec![&s.env, signer1.clone()];
+    s.client.set_multisig_policy(&s.merchant, &1000, &signers, &1, &3600);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &None, &None,
+    );
+
+    let payment = s.client.get_payment(&pid);
+    assert_eq!(payment.status, PaymentStatus::Pending);
+}
+
+#[test]
+fn test_m_of_n_approval_transitions_to_pending() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let signer1 = Address::generate(&s.env);
+    let signer2 = Address::generate(&s.env);
+    let signer3 = Address::generate(&s.env);
+    let signers = vec![&s.env, signer1.clone(), signer2.clone(), signer3.clone()];
+    // 2-of-3
+    s.client.set_multisig_policy(&s.merchant, &1000, &signers, &2, &3600);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &2000, &s.token_addr,
+        &None, &None, &None, &None, &None,
+    );
+    assert_eq!(s.client.get_payment(&pid).status, PaymentStatus::PendingApproval);
+
+    // First approval — still PendingApproval
+    s.client.approve_payment(&signer1, &pid);
+    assert_eq!(s.client.get_payment(&pid).status, PaymentStatus::PendingApproval);
+
+    // Second approval — quorum reached → Pending
+    s.client.approve_payment(&signer2, &pid);
+    assert_eq!(s.client.get_payment(&pid).status, PaymentStatus::Pending);
+}
+
+#[test]
+fn test_m_equals_1_single_approval_sufficient() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let signer1 = Address::generate(&s.env);
+    let signers = vec![&s.env, signer1.clone()];
+    s.client.set_multisig_policy(&s.merchant, &1000, &signers, &1, &3600);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &2000, &s.token_addr,
+        &None, &None, &None, &None, &None,
+    );
+
+    s.client.approve_payment(&signer1, &pid);
+    assert_eq!(s.client.get_payment(&pid).status, PaymentStatus::Pending);
+}
+
+#[test]
+fn test_approval_window_expired_auto_cancels() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let signer1 = Address::generate(&s.env);
+    let signers = vec![&s.env, signer1.clone()];
+    s.client.set_multisig_policy(&s.merchant, &1000, &signers, &1, &100);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &2000, &s.token_addr,
+        &None, &None, &None, &None, &None,
+    );
+
+    // Advance time past approval window
+    s.env.ledger().set_timestamp(s.env.ledger().timestamp() + 200);
+
+    s.client.expire_pending_approval(&pid);
+    assert_eq!(s.client.get_payment(&pid).status, PaymentStatus::Refunded);
+    // Customer should get refund
+    assert_eq!(s.token_client.balance(&customer), 5000);
+}
+
+// ===========================================================================
+// Task 3: Voucher Tests
+// ===========================================================================
+
+#[test]
+fn test_issue_and_redeem_fixed_discount() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &1000);
+
+    let code_hash = make_external_id(&s.env, 10);
+    s.client.issue_voucher(&s.merchant, &code_hash, &DiscountType::Fixed, &100, &5, &0);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &Some(code_hash.clone()), &None,
+    );
+
+    let payment = s.client.get_payment(&pid);
+    // 500 - 100 fixed = 400
+    assert_eq!(payment.amount, 400);
+    assert_eq!(s.token_client.balance(&customer), 600); // 1000 - 400
+
+    let voucher = s.client.get_voucher(&s.merchant, &code_hash);
+    assert_eq!(voucher.uses_remaining, 4);
+}
+
+#[test]
+fn test_issue_and_redeem_percentage_discount() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &1000);
+
+    let code_hash = make_external_id(&s.env, 11);
+    // 20% off
+    s.client.issue_voucher(&s.merchant, &code_hash, &DiscountType::Percentage, &20, &10, &0);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &Some(code_hash.clone()), &None,
+    );
+
+    let payment = s.client.get_payment(&pid);
+    // 500 * 20 / 100 = 100 discount → 400
+    assert_eq!(payment.amount, 400);
+}
+
+#[test]
+fn test_voucher_exhausted_after_max_uses() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let code_hash = make_external_id(&s.env, 12);
+    // max_uses = 1
+    s.client.issue_voucher(&s.merchant, &code_hash, &DiscountType::Fixed, &50, &1, &0);
+
+    s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &Some(code_hash.clone()), &None,
+    );
+
+    let voucher = s.client.get_voucher(&s.merchant, &code_hash);
+    assert_eq!(voucher.uses_remaining, 0);
+    assert!(voucher.revoked); // marked exhausted
+}
+
+#[test]
+#[should_panic]
+fn test_exhausted_voucher_rejected() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let code_hash = make_external_id(&s.env, 13);
+    s.client.issue_voucher(&s.merchant, &code_hash, &DiscountType::Fixed, &50, &1, &0);
+
+    // First use — ok
+    s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &Some(code_hash.clone()), &None,
+    );
+    // Second use — should panic (exhausted)
+    s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &Some(code_hash.clone()), &None,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_expired_voucher_rejected() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &1000);
+
+    let code_hash = make_external_id(&s.env, 14);
+    let expiry = s.env.ledger().timestamp() + 100;
+    s.client.issue_voucher(&s.merchant, &code_hash, &DiscountType::Fixed, &50, &10, &expiry);
+
+    // Advance past expiry
+    s.env.ledger().set_timestamp(s.env.ledger().timestamp() + 200);
+
+    s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &Some(code_hash.clone()), &None,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_revoked_voucher_rejected() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &1000);
+
+    let code_hash = make_external_id(&s.env, 15);
+    s.client.issue_voucher(&s.merchant, &code_hash, &DiscountType::Fixed, &50, &10, &0);
+    s.client.revoke_voucher(&s.merchant, &code_hash);
+
+    s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &Some(code_hash.clone()), &None,
+    );
+}
+
+#[test]
+fn test_revoke_voucher_emits_event() {
+    let s = setup();
+    let code_hash = make_external_id(&s.env, 16);
+    s.client.issue_voucher(&s.merchant, &code_hash, &DiscountType::Fixed, &50, &10, &0);
+    s.client.revoke_voucher(&s.merchant, &code_hash);
+
+    let voucher = s.client.get_voucher(&s.merchant, &code_hash);
+    assert!(voucher.revoked);
+}
+
+#[test]
+fn test_no_voucher_payment_works_normally() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &1000);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &500, &s.token_addr,
+        &None, &None, &None, &None, &None,
+    );
+
+    let payment = s.client.get_payment(&pid);
+    assert_eq!(payment.amount, 500);
+    assert_eq!(payment.status, PaymentStatus::Pending);
+}


### PR DESCRIPTION
closes #134 
closes #197 
closes #201 
closes #202

**PR description:**

## Summary

Implements four new features across `ahjoor-payments` and `ahjoor-escrow`.

---

### Task 1 — Payment External ID for Off-Chain Order Correlation

Adds `external_id: Option<BytesN<32>>` to the `Payment` struct and a new `ExternalIdIndex(Address, BytesN<32>)` storage key that maps `(merchant, external_id) → payment_id`. Duplicate external IDs per merchant are rejected with `Error::DuplicateExternalId`; the same ID across different merchants is allowed. A new `create_payment_with_voucher` entry point accepts the optional `external_id`, and `get_payment_by_external_id(merchant, external_id)` returns the full `Payment` struct. A `PaymentIndexedByExternalId` event is emitted on creation.

---

### Task 2 — Multi-Signature Approval for High-Value Payments

Adds an M-of-N approval gate to `ahjoor-payments`. Merchants configure a policy via `set_multisig_policy(threshold, signers, m, approval_window_seconds)`. Payments at or above the threshold enter `PaymentStatus::PendingApproval`. Each authorized signer calls `approve_payment(payment_id)`; once `m` approvals are recorded the payment transitions to `Pending`. If the approval window expires before quorum is reached, `expire_pending_approval` (callable by anyone) refunds the customer and emits `PaymentApprovalExpired`. New events: `PaymentApproved`, `PaymentApprovalExpired`.

---

### Task 3 — Payment Voucher and Coupon Code Redemption

Merchants issue on-chain vouchers via `issue_voucher(code_hash, discount_type, discount_value, max_uses, expiry)`. Vouchers are stored by hash (not plaintext) to prevent front-running. Customers pass `voucher_code_hash` to `create_payment_with_voucher`; the contract verifies expiry, remaining uses, and revocation status, then deducts the discount (fixed or percentage) from the required payment amount. Each redemption decrements `uses_remaining`; at zero the voucher is marked exhausted. Merchants can revoke at any time via `revoke_voucher`. New events: `VoucherIssued`, `VoucherRedeemed`, `VoucherRevoked`, `VoucherExhausted`.

---

### Task 4 — Escrow Split-Decision: Percentage-Based Award by Arbiter

`resolve_dispute` in `ahjoor-escrow` now accepts `buyer_percent: u32` (0–100) instead of a boolean. The contract deducts protocol and arbiter fees first, then splits the remainder: `buyer_amount = distributable * buyer_percent / 100`, `seller_amount = distributable - buyer_amount` (integer-safe, no precision loss). `buyer_percent = 100` → full buyer win (`Refunded`), `buyer_percent = 0` → full seller win (`Released`), any value in between → `Resolved`. A new `DisputeResolvedSplit` event records both percentages and exact amounts. The legacy `DisputeResolved` event is still emitted for backward-compatible indexers. All existing tests updated from `&true/&false` to `&0u32/&100u32`. New split tests added: 50/50, fee-then-split, rounding edge cases, and invalid percent guard.