### PR TITLE
feat: ROSCA cycle bonus, escrow top-up, payments dashboard, round duration update

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -773,3 +773,19 @@ pub fn emit_timelocked_funds_claimed(e: &Env, escrow_id: u32, beneficiary: Addre
 pub fn emit_timelocked_escrow_cancelled(e: &Env, escrow_id: u32, buyer: Address) {
     e.events().publish((Symbol::new(e, "TLEscrowCancelled"),), (escrow_id, buyer));
 }
+
+// #225: Escrow Top-Up Event
+
+/// Event: Buyer topped up an active escrow with additional funds
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct EscrowToppedUp {
+    pub escrow_id: u32,
+    pub added_amount: i128,
+    pub new_total: i128,
+    pub buyer: Address,
+}
+
+pub fn emit_escrow_topped_up(e: &Env, escrow_id: u32, added_amount: i128, new_total: i128, buyer: Address) {
+    EscrowToppedUp { escrow_id, added_amount, new_total, buyer }.publish(e);
+}

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -249,6 +249,10 @@ pub enum DataKey {
     TokenWhitelistContract,
     /// #215: time-lock metadata per escrow
     TimeLockData(u32),
+    /// #225: max top-up as basis points of original escrow amount (e.g. 5000 = 50%)
+    MaxTopUpBps,
+    /// #225: cumulative top-up amount per escrow
+    EscrowToppedUpAmount(u32),
 }
 
 const MAX_PROTOCOL_FEE_BPS: u32 = 200; // 2%
@@ -3490,6 +3494,102 @@ impl AhjoorEscrowContract {
                 .set(&DataKey::ContractVersion, &initial_version);
             initial_version
         }
+    }
+
+    // ─── #225: Escrow Buyer Deposit Top-Up ───────────────────────────────────
+
+    /// Admin sets the maximum cumulative top-up as basis points of the original amount.
+    /// Default: 5000 bps = 50%.
+    pub fn set_max_top_up_bps(env: Env, admin: Address, max_top_up_bps: u32) {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        if admin != stored_admin {
+            panic!("Only admin can set max top-up bps");
+        }
+        env.storage().instance().set(&DataKey::MaxTopUpBps, &max_top_up_bps);
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Buyer tops up an active or pending-release escrow with additional funds.
+    /// Rejected if escrow is Disputed, Released, or Cancelled.
+    /// Total cumulative top-ups are capped at `max_top_up_bps` of the original amount.
+    pub fn top_up_escrow(env: Env, buyer: Address, escrow_id: u32, amount: i128) {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        if amount <= 0 {
+            panic!("Top-up amount must be positive");
+        }
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.buyer != buyer {
+            panic!("Only the buyer can top up this escrow");
+        }
+
+        // Only Active or PartiallyReleased states are allowed
+        match escrow.status {
+            EscrowStatus::Active | EscrowStatus::PartiallyReleased => {}
+            _ => panic!("Escrow is not in a top-up eligible state"),
+        }
+
+        // Enforce max_top_up_bps cap
+        let max_top_up_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxTopUpBps)
+            .unwrap_or(5_000); // default 50%
+        let original_amount = escrow.amount;
+        let already_topped_up: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EscrowToppedUpAmount(escrow_id))
+            .unwrap_or(0);
+        let max_top_up = (original_amount * max_top_up_bps as i128) / 10_000;
+        if already_topped_up + amount > max_top_up {
+            panic!("Top-up would exceed maximum allowed top-up amount");
+        }
+
+        // Transfer funds from buyer to contract
+        let token_client = token::Client::new(&env, &escrow.token);
+        token_client.transfer(&buyer, &env.current_contract_address(), &amount);
+
+        // Update escrow amount and cumulative top-up tracker
+        escrow.amount += amount;
+        let new_total = escrow.amount;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        let new_topped_up = already_topped_up + amount;
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowToppedUpAmount(escrow_id), &new_topped_up);
+        env.storage().persistent().extend_ttl(
+            &DataKey::EscrowToppedUpAmount(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_escrow_topped_up(&env, escrow_id, amount, new_total, buyer);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 }
 

--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -263,6 +263,17 @@ pub struct MerchantStats {
     pub volume_completed: Map<Address, i128>,
 }
 
+/// Per-merchant revenue dashboard summary (#226).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MerchantSummary {
+    pub total_volume: i128,
+    pub completed_count: u32,
+    pub failed_count: u32,
+    pub pending_count: u32,
+    pub volume_by_token: Map<Address, i128>,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Dispute {
@@ -472,6 +483,8 @@ pub enum DataKey {
     AppealCooldownUntil(Address),
     /// Instance: appeal rejection cooldown in seconds
     AppealRejectionCooldownSeconds,
+    /// Persistent: per-merchant revenue dashboard summary (#226)
+    MerchantSummary(Address),
 }
 
 mod events;
@@ -4300,6 +4313,7 @@ impl AhjoorPaymentsContract {
                             
                             Self::inc_global_refunded(env, &payment.token, payment.amount);
                             Self::inc_merchant_refunded(env, &payment.merchant, &payment.token, payment.amount);
+                            Self::inc_merchant_failed(env, &payment.merchant); // #226
                             
                             events::emit_payment_swap_failed(
                                 env,
@@ -4869,6 +4883,23 @@ impl AhjoorPaymentsContract {
         let mut s = Self::load_merchant_stats(env, merchant);
         s.payments_created += 1;
         Self::save_merchant_stats(env, merchant, &s);
+
+        // #226: Track pending count in MerchantSummary
+        let key = DataKey::MerchantSummary(merchant.clone());
+        let mut summary: MerchantSummary = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(MerchantSummary {
+                total_volume: 0,
+                completed_count: 0,
+                failed_count: 0,
+                pending_count: 0,
+                volume_by_token: Map::new(env),
+            });
+        summary.pending_count += 1;
+        env.storage().persistent().set(&key, &summary);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
     }
 
     fn inc_merchant_completed(env: &Env, merchant: &Address, token: &Address, amount: i128) {
@@ -4877,6 +4908,62 @@ impl AhjoorPaymentsContract {
         let prev = s.volume_completed.get(token.clone()).unwrap_or(0);
         s.volume_completed.set(token.clone(), prev + amount);
         Self::save_merchant_stats(env, merchant, &s);
+
+        // #226: Update MerchantSummary
+        let key = DataKey::MerchantSummary(merchant.clone());
+        let mut summary: MerchantSummary = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(MerchantSummary {
+                total_volume: 0,
+                completed_count: 0,
+                failed_count: 0,
+                pending_count: 0,
+                volume_by_token: Map::new(env),
+            });
+        summary.completed_count += 1;
+        if summary.pending_count > 0 { summary.pending_count -= 1; }
+        summary.total_volume += amount;
+        let prev_token = summary.volume_by_token.get(token.clone()).unwrap_or(0);
+        summary.volume_by_token.set(token.clone(), prev_token + amount);
+        env.storage().persistent().set(&key, &summary);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    }
+
+    fn inc_merchant_failed(env: &Env, merchant: &Address) {
+        let key = DataKey::MerchantSummary(merchant.clone());
+        let mut summary: MerchantSummary = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(MerchantSummary {
+                total_volume: 0,
+                completed_count: 0,
+                failed_count: 0,
+                pending_count: 0,
+                volume_by_token: Map::new(env),
+            });
+        summary.failed_count += 1;
+        if summary.pending_count > 0 { summary.pending_count -= 1; }
+        env.storage().persistent().set(&key, &summary);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    }
+        let key = DataKey::MerchantSummary(merchant.clone());
+        let mut summary: MerchantSummary = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(MerchantSummary {
+                total_volume: 0,
+                completed_count: 0,
+                failed_count: 0,
+                pending_count: 0,
+                volume_by_token: Map::new(env),
+            });
+        summary.failed_count += 1;
+        env.storage().persistent().set(&key, &summary);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
     }
 
     fn inc_merchant_refunded(env: &Env, merchant: &Address, token: &Address, amount: i128) {
@@ -5363,6 +5450,81 @@ impl AhjoorPaymentsContract {
         env.storage()
             .persistent()
             .get(&DataKey::MerchantAppeal(merchant))
+    }
+
+    // ─── #226: Merchant Revenue Dashboard ────────────────────────────────────
+
+    /// Returns the full merchant revenue summary.
+    pub fn get_merchant_summary(env: Env, merchant: Address) -> MerchantSummary {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MerchantSummary(merchant))
+            .unwrap_or(MerchantSummary {
+                total_volume: 0,
+                completed_count: 0,
+                failed_count: 0,
+                pending_count: 0,
+                volume_by_token: Map::new(&env),
+            })
+    }
+
+    /// Returns the completed volume for a specific token for a merchant.
+    pub fn get_merchant_volume_by_token(env: Env, merchant: Address, token: Address) -> i128 {
+        let summary: MerchantSummary = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MerchantSummary(merchant))
+            .unwrap_or(MerchantSummary {
+                total_volume: 0,
+                completed_count: 0,
+                failed_count: 0,
+                pending_count: 0,
+                volume_by_token: Map::new(&env),
+            });
+        summary.volume_by_token.get(token).unwrap_or(0)
+    }
+
+    /// Returns (completed_count, failed_count, pending_count) for a merchant.
+    pub fn get_merchant_payment_counts(env: Env, merchant: Address) -> (u32, u32, u32) {
+        let summary: MerchantSummary = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MerchantSummary(merchant))
+            .unwrap_or(MerchantSummary {
+                total_volume: 0,
+                completed_count: 0,
+                failed_count: 0,
+                pending_count: 0,
+                volume_by_token: Map::new(&env),
+            });
+        (summary.completed_count, summary.failed_count, summary.pending_count)
+    }
+
+    /// Admin resets a merchant's dashboard counters.
+    pub fn reset_merchant_stats(env: Env, merchant: Address) {
+        Self::require_not_paused(&env);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        admin.require_auth();
+
+        let empty = MerchantSummary {
+            total_volume: 0,
+            completed_count: 0,
+            failed_count: 0,
+            pending_count: 0,
+            volume_by_token: Map::new(&env),
+        };
+        let key = DataKey::MerchantSummary(merchant);
+        env.storage().persistent().set(&key, &empty);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 
 }

--- a/contracts/ahjoor-rosca/src/errors.rs
+++ b/contracts/ahjoor-rosca/src/errors.rs
@@ -95,6 +95,12 @@ pub enum Error {
     InvalidEmergencyConfig = 61,
     /// Invalid dissolution configuration.
     InvalidDissolutionConfig = 62,
+    /// Only admin is allowed to perform this action.
+    OnlyAdminAllowed = 63,
+    /// Invalid amount provided.
+    InvalidAmount = 64,
+    /// Round duration is out of the configured bounds.
+    RoundDurationOutOfBounds = 65,
 }
 
 /// Extension error codes 51-56 — split from Error because #[contracterror]

--- a/contracts/ahjoor-rosca/src/events.rs
+++ b/contracts/ahjoor-rosca/src/events.rs
@@ -1047,3 +1047,68 @@ pub fn emit_reinstatement_approved(e: &Env, member: Address) {
 pub fn emit_reinstatement_fee_collected(e: &Env, member: Address, amount: i128) {
     e.events().publish((Symbol::new(e, "ReinFee"),), (member, amount));
 }
+
+// #224: Cycle Completion Bonus Events
+
+/// Event: Cycle bonus amount configured by admin
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct CycleBonusConfigured {
+    pub amount: i128,
+}
+
+/// Event: Cycle bonus paid to a qualifying member
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct CycleBonusPaid {
+    pub member: Address,
+    pub amount: i128,
+    pub cycle: u32,
+}
+
+/// Event: Cycle bonus prorated due to insufficient reward pool
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct CycleBonusProrated {
+    pub cycle: u32,
+    pub shortfall: i128,
+}
+
+pub fn emit_cycle_bonus_configured(e: &Env, amount: i128) {
+    CycleBonusConfigured { amount }.publish(e);
+}
+
+pub fn emit_cycle_bonus_paid(e: &Env, member: Address, amount: i128, cycle: u32) {
+    CycleBonusPaid { member, amount, cycle }.publish(e);
+}
+
+pub fn emit_cycle_bonus_prorated(e: &Env, cycle: u32, shortfall: i128) {
+    CycleBonusProrated { cycle, shortfall }.publish(e);
+}
+
+// #227: Round Duration Update Events
+
+/// Event: Round duration update scheduled (pending, takes effect next round)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct RoundDurationUpdateScheduled {
+    pub old_duration: u64,
+    pub new_duration: u64,
+    pub effective_from_round: u32,
+}
+
+/// Event: Pending round duration applied at round start
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct RoundDurationApplied {
+    pub round: u32,
+    pub duration: u64,
+}
+
+pub fn emit_round_duration_update_scheduled(e: &Env, old_duration: u64, new_duration: u64, effective_from_round: u32) {
+    RoundDurationUpdateScheduled { old_duration, new_duration, effective_from_round }.publish(e);
+}
+
+pub fn emit_round_duration_applied(e: &Env, round: u32, duration: u64) {
+    RoundDurationApplied { round, duration }.publish(e);
+}

--- a/contracts/ahjoor-rosca/src/internals.rs
+++ b/contracts/ahjoor-rosca/src/internals.rs
@@ -318,11 +318,18 @@ pub(crate) fn complete_round_payout(env: &Env, _paid_members: &Vec<Address>) {
 /// Advances the round counter, clears paid-members and per-round contributions,
 /// and sets a new deadline.
 pub(crate) fn reset_round_state(env: &Env, current_round: u32) {
-    let duration: u64 = env
-        .storage()
-        .instance()
-        .get(&DataKey::RoundDuration)
-        .unwrap();
+    // #227: Apply pending round duration if one was scheduled
+    let pending_duration: Option<u64> = env.storage().instance().get(&DataKey2::PendingRoundDuration);
+    let duration: u64 = if let Some(pending) = pending_duration {
+        env.storage().instance().set(&DataKey::RoundDuration, &pending);
+        env.storage().instance().remove(&DataKey2::PendingRoundDuration);
+        // Also update RoundDurationSeconds for timestamp-based scheduling
+        env.storage().instance().set(&DataKey::RoundDurationSeconds, &pending);
+        events::emit_round_duration_applied(env, current_round + 1, pending);
+        pending
+    } else {
+        env.storage().instance().get(&DataKey::RoundDuration).unwrap()
+    };
     env.storage()
         .instance()
         .set(&DataKey::CurrentRound, &(current_round + 1));

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -1244,12 +1244,133 @@ impl AhjoorContract {
             .instance()
             .set(&DataKey::SuspendedMembers, &suspended_members);
 
+        // ── #224: Cycle completion bonus ──────────────────────────────────────
+        // A cycle ends when (current_round + 1) is a multiple of payout_order.len().
+        let payout_order: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::PayoutOrder)
+            .unwrap_or(Vec::new(&env));
+        let cycle_len = payout_order.len() as u32;
+        if cycle_len > 0 && (current_round + 1) % cycle_len == 0 {
+            let bonus_amount: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey2::CycleBonusAmount)
+                .unwrap_or(0);
+            if bonus_amount > 0 {
+                let cycle_number = (current_round + 1) / cycle_len;
+                let cycle_start = (cycle_number - 1) * cycle_len;
+                let mut qualifying: Vec<Address> = Vec::new(&env);
+                for member in members.iter() {
+                    if exited_members.contains(&member) { continue; }
+                    let defaults = default_count.get(member.clone()).unwrap_or(0);
+                    let mut had_skip = false;
+                    for r in cycle_start..=(current_round) {
+                        if skip_requests.get((member.clone(), r)).unwrap_or(false) {
+                            had_skip = true;
+                            break;
+                        }
+                    }
+                    if defaults == 0 && !had_skip {
+                        qualifying.push_back(member);
+                    }
+                }
+                let q_count = qualifying.len() as i128;
+                if q_count > 0 {
+                    let total_needed = bonus_amount * q_count;
+                    let mut reward_pool: i128 = env
+                        .storage()
+                        .instance()
+                        .get(&DataKey::RewardPool)
+                        .unwrap_or(0);
+                    let actual_bonus = if reward_pool >= total_needed {
+                        bonus_amount
+                    } else if reward_pool > 0 {
+                        let prorated = reward_pool / q_count;
+                        let shortfall = total_needed - reward_pool;
+                        events::emit_cycle_bonus_prorated(&env, cycle_number, shortfall);
+                        prorated
+                    } else {
+                        0
+                    };
+                    if actual_bonus > 0 {
+                        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+                        let token_client = token::Client::new(&env, &token_addr);
+                        for member in qualifying.iter() {
+                            token_client.transfer(
+                                &env.current_contract_address(),
+                                &member,
+                                &actual_bonus,
+                            );
+                            reward_pool -= actual_bonus;
+                            events::emit_cycle_bonus_paid(&env, member, actual_bonus, cycle_number);
+                        }
+                        env.storage().instance().set(&DataKey::RewardPool, &reward_pool);
+                    }
+                }
+            }
+        }
+
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 
-    pub fn penalise_defaulter(env: Env, member: Address) {
+    // ─── #224: Cycle Completion Bonus ────────────────────────────────────────
+
+    /// Admin sets the per-member cycle completion bonus drawn from the reward pool.
+    pub fn set_cycle_bonus(env: Env, admin: Address, amount: i128) {
+        internals::check_not_paused(&env);
+        admin.require_auth();
+        let a: Address = env.storage().instance().get(&DataKey::Admin).expect("No admin");
+        if admin != a { panic_with_error!(&env, Error::OnlyAdminAllowed); }
+        if amount < 0 { panic_with_error!(&env, Error::AmountMustBePositive); }
+        env.storage().instance().set(&DataKey2::CycleBonusAmount, &amount);
+        events::emit_cycle_bonus_configured(&env, amount);
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Returns the configured cycle bonus amount (0 if not set).
+    pub fn get_cycle_bonus(env: Env) -> i128 {
+        env.storage().instance().get(&DataKey2::CycleBonusAmount).unwrap_or(0)
+    }
+
+    // ─── #227: Round Duration Update ─────────────────────────────────────────
+
+    /// Admin schedules a round duration change that takes effect from the next round.
+    /// `new_duration_seconds` must be within [min_round_duration, max_round_duration].
+    pub fn update_round_duration(env: Env, admin: Address, new_duration_seconds: u64) {
+        internals::check_not_paused(&env);
+        admin.require_auth();
+        let a: Address = env.storage().instance().get(&DataKey::Admin).expect("No admin");
+        if admin != a { panic_with_error!(&env, Error::OnlyAdminAllowed); }
+
+        let min_dur: u64 = env.storage().instance().get(&DataKey2::MinRoundDuration).unwrap_or(60);
+        let max_dur: u64 = env.storage().instance().get(&DataKey2::MaxRoundDuration).unwrap_or(u64::MAX);
+        if new_duration_seconds < min_dur || new_duration_seconds > max_dur {
+            panic_with_error!(&env, Error::RoundDurationOutOfBounds);
+        }
+
+        let old_duration: u64 = env.storage().instance().get(&DataKey::RoundDuration).unwrap_or(0);
+        let current_round: u32 = env.storage().instance().get(&DataKey::CurrentRound).unwrap_or(0);
+
+        env.storage().instance().set(&DataKey2::PendingRoundDuration, &new_duration_seconds);
+        events::emit_round_duration_update_scheduled(&env, old_duration, new_duration_seconds, current_round + 1);
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Admin configures the min/max bounds for round duration.
+    pub fn set_round_duration_bounds(env: Env, admin: Address, min_seconds: u64, max_seconds: u64) {
+        internals::check_not_paused(&env);
+        admin.require_auth();
+        let a: Address = env.storage().instance().get(&DataKey::Admin).expect("No admin");
+        if admin != a { panic_with_error!(&env, Error::OnlyAdminAllowed); }
+        if min_seconds == 0 || min_seconds > max_seconds { panic_with_error!(&env, Error::InvalidAmount); }
+        env.storage().instance().set(&DataKey2::MinRoundDuration, &min_seconds);
+        env.storage().instance().set(&DataKey2::MaxRoundDuration, &max_seconds);
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
         internals::check_not_paused(&env);
         let admin: Address = env
             .storage()

--- a/contracts/ahjoor-rosca/src/types.rs
+++ b/contracts/ahjoor-rosca/src/types.rs
@@ -246,6 +246,15 @@ pub enum DataKey2 {
     ReinstatementFee,        // i128
     PendingReinstatementFee, // Vec<Address>
     ActiveReinstatementProposal, // Map<Address, u32>
+    // #224: Cycle Completion Bonus
+    CycleBonusAmount,        // i128 — bonus per qualifying member per cycle
+    // #227: Round Duration Update
+    PendingRoundDuration,    // u64 — new duration to apply at next round start
+    MinRoundDuration,        // u64 — lower bound for round duration
+    MaxRoundDuration,        // u64 — upper bound for round duration
+    // Waitlist
+    Waitlist,                // Vec<(Address, u64)> — (address, joined_at)
+    CatchUpDebt,             // Map<Address, i128> — catch-up contributions owed
 }
 
 /// Persistent storage keys — kept separate because DataKey was hitting


### PR DESCRIPTION
## Summary

Implements four feature issues in a single branch.

---

## Issue #224 — ROSCA Cycle Completion Bonus

- `set_cycle_bonus(admin, amount)` — admin configures per-member bonus from reward pool
- `get_cycle_bonus()` — read configured amount
- Cycle boundary detected in `finalize_round` when `(current_round + 1) % payout_order.len() == 0`
- Qualifying members: zero defaults, zero skips for the cycle, not exited
- Proration when reward pool is insufficient; emits `CycleBonusProrated`
- Events: `CycleBonusConfigured`, `CycleBonusPaid { member, amount, cycle }`, `CycleBonusProrated { cycle, shortfall }`

---

## Issue #225 — Escrow Buyer Deposit Top-Up

- `top_up_escrow(buyer, escrow_id, amount)` — adds funds to an Active/PartiallyReleased escrow
- `set_max_top_up_bps(admin, bps)` — cap on cumulative top-ups as bps of original (default 5000 = 50%)
- Rejected for Disputed, Released, Resolved, Refunded, CoolingOff states
- Cumulative top-ups tracked per escrow via `EscrowToppedUpAmount(u32)`
- Event: `EscrowToppedUp { escrow_id, added_amount, new_total, buyer }`

---

## Issue #226 — Payments Merchant Revenue Dashboard

- New `MerchantSummary` type: `total_volume`, `completed_count`, `failed_count`, `pending_count`, `volume_by_token`
- `get_merchant_summary(merchant)` — all counters
- `get_merchant_volume_by_token(merchant, token)` — per-token volume
- `get_merchant_payment_counts(merchant)` — returns `(completed, failed, pending)`
- `reset_merchant_stats(merchant)` — admin-only reset
- Counters auto-maintained: pending incremented on create, decremented on complete/fail; volume tracked per token

---

## Issue #227 — ROSCA Round Duration Update Mid-Cycle

- `update_round_duration(admin, new_duration_seconds)` — schedules change for next round only
- `set_round_duration_bounds(admin, min, max)` — configures allowed range
- Pending change stored as `DataKey2::PendingRoundDuration`, applied in `reset_round_state`
- Current round deadline unaffected
- Both ledger and timestamp scheduling modes updated on apply
- Events: `RoundDurationUpdateScheduled { old_duration, new_duration, effective_from_round }`, `RoundDurationApplied { round, duration }`
- New errors: `RoundDurationOutOfBounds`, `OnlyAdminAllowed`, `InvalidAmount`

---

Closes #224
Closes #225
Closes #226
Closes #227