### PR TITLE
feat: implement #228 refund threshold, #229 escrow cancellation, #230 ROSCA merge, #231 withdrawal rate limit

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -773,3 +773,17 @@ pub fn emit_timelocked_funds_claimed(e: &Env, escrow_id: u32, beneficiary: Addre
 pub fn emit_timelocked_escrow_cancelled(e: &Env, escrow_id: u32, buyer: Address) {
     e.events().publish((Symbol::new(e, "TLEscrowCancelled"),), (escrow_id, buyer));
 }
+
+// #229: Mutual Cancellation events
+pub fn emit_cancellation_requested(e: &Env, escrow_id: u32, initiator: Address, expires_at: u64) {
+    e.events().publish((Symbol::new(e, "CancelRequested"),), (escrow_id, initiator, expires_at));
+}
+pub fn emit_cancellation_accepted(e: &Env, escrow_id: u32, buyer: Address, amount_returned: i128, penalty: i128) {
+    e.events().publish((Symbol::new(e, "CancelAccepted"),), (escrow_id, buyer, amount_returned, penalty));
+}
+pub fn emit_cancellation_rejected(e: &Env, escrow_id: u32, rejector: Address) {
+    e.events().publish((Symbol::new(e, "CancelRejected"),), (escrow_id, rejector));
+}
+pub fn emit_cancellation_expired(e: &Env, escrow_id: u32) {
+    e.events().publish((Symbol::new(e, "CancelExpired"),), (escrow_id,));
+}

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -27,6 +27,8 @@ pub enum EscrowStatus {
     PartiallyDisputed = 6,
     /// Arbiter has recorded a verdict; funds held pending cooling-off window.
     CoolingOff = 7,
+    /// Mutual cancellation requested; awaiting counterparty response (#229).
+    CancellationPending = 8,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -144,6 +146,16 @@ pub struct TimeLockData {
     pub claimed: bool,
 }
 
+/// #229: Mutual cancellation request record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CancellationRequest {
+    pub initiator: Address,
+    pub reason_hash: BytesN<32>,
+    pub requested_at: u64,
+    pub expires_at: u64,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeadlineProposal {
@@ -249,6 +261,12 @@ pub enum DataKey {
     TokenWhitelistContract,
     /// #215: time-lock metadata per escrow
     TimeLockData(u32),
+    /// #229: cancellation request per escrow
+    CancellationRequest(u32),
+    /// #229: admin-configurable cancellation penalty in basis points
+    CancellationPenaltyBps,
+    /// #229: admin-configurable cancellation response window in seconds
+    CancellationResponseWindow,
 }
 
 const MAX_PROTOCOL_FEE_BPS: u32 = 200; // 2%
@@ -3198,6 +3216,310 @@ impl AhjoorEscrowContract {
         );
 
         events::emit_inactivity_release_triggered(&env, escrow_id, seller, inactivity_seconds);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    // -------------------------------------------------------------------------
+    // #229: Escrow Mutual Cancellation with Configurable Penalty
+    // -------------------------------------------------------------------------
+
+    /// Admin sets the cancellation penalty in basis points (applied to initiator's share).
+    pub fn set_cancellation_penalty_bps(env: Env, admin: Address, penalty_bps: u32) {
+        Self::require_not_paused(&env);
+        Self::require_or_bootstrap_admin(&env, &admin);
+        if penalty_bps > 10_000 {
+            panic!("Penalty cannot exceed 10000 bps");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::CancellationPenaltyBps, &penalty_bps);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Admin sets the response window in seconds for cancellation requests.
+    pub fn set_cancellation_response_window(env: Env, admin: Address, window_seconds: u64) {
+        Self::require_not_paused(&env);
+        Self::require_or_bootstrap_admin(&env, &admin);
+        if window_seconds == 0 {
+            panic!("Response window must be positive");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::CancellationResponseWindow, &window_seconds);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Either party (buyer or seller) requests mutual cancellation of an active escrow.
+    pub fn request_cancellation(env: Env, caller: Address, escrow_id: u32, reason_hash: BytesN<32>) {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if !Self::is_open_escrow_status(escrow.status) {
+            panic!("Escrow is not active");
+        }
+
+        if caller != escrow.buyer && caller != escrow.seller {
+            panic!("Only buyer or seller can request cancellation");
+        }
+
+        let window: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CancellationResponseWindow)
+            .unwrap_or(7 * 24 * 60 * 60); // default 7 days
+
+        let now = env.ledger().timestamp();
+        let expires_at = now + window;
+
+        let request = CancellationRequest {
+            initiator: caller.clone(),
+            reason_hash,
+            requested_at: now,
+            expires_at,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::CancellationRequest(escrow_id), &request);
+        env.storage().persistent().extend_ttl(
+            &DataKey::CancellationRequest(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        escrow.status = EscrowStatus::CancellationPending;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_cancellation_requested(&env, escrow_id, caller, expires_at);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// The counterparty accepts the cancellation request.
+    /// Full escrow amount minus penalty (applied to initiator) is returned to buyer.
+    /// Penalty goes to fee collector.
+    pub fn accept_cancellation(env: Env, caller: Address, escrow_id: u32) {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::CancellationPending {
+            panic!("No pending cancellation for this escrow");
+        }
+
+        let request: CancellationRequest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CancellationRequest(escrow_id))
+            .expect("Cancellation request not found");
+
+        let now = env.ledger().timestamp();
+
+        // Check if request has expired — auto-restore Active
+        if now > request.expires_at {
+            escrow.status = EscrowStatus::Active;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Escrow(escrow_id), &escrow);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Escrow(escrow_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+            env.storage()
+                .persistent()
+                .remove(&DataKey::CancellationRequest(escrow_id));
+            events::emit_cancellation_expired(&env, escrow_id);
+            return;
+        }
+
+        // Caller must be the counterparty (not the initiator)
+        if caller == request.initiator {
+            panic!("Initiator cannot accept their own cancellation request");
+        }
+        if caller != escrow.buyer && caller != escrow.seller {
+            panic!("Only buyer or seller can accept cancellation");
+        }
+
+        let penalty_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CancellationPenaltyBps)
+            .unwrap_or(0);
+
+        let penalty_amount = if penalty_bps > 0 {
+            (escrow.amount as u128 * penalty_bps as u128 / 10_000) as i128
+        } else {
+            0
+        };
+
+        let return_amount = escrow.amount - penalty_amount;
+
+        let token_client = token::Client::new(&env, &escrow.token);
+
+        // Return funds to buyer
+        if return_amount > 0 {
+            token_client.transfer(
+                &env.current_contract_address(),
+                &escrow.buyer,
+                &return_amount,
+            );
+        }
+
+        // Send penalty to fee collector if configured
+        if penalty_amount > 0 {
+            if let Some(fee_recipient) = env
+                .storage()
+                .instance()
+                .get::<DataKey, Address>(&DataKey::FeeRecipient)
+            {
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &fee_recipient,
+                    &penalty_amount,
+                );
+            } else {
+                // No fee recipient — return penalty to buyer too
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &escrow.buyer,
+                    &penalty_amount,
+                );
+            }
+        }
+
+        escrow.status = EscrowStatus::Refunded;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage()
+            .persistent()
+            .remove(&DataKey::CancellationRequest(escrow_id));
+
+        events::emit_cancellation_accepted(&env, escrow_id, escrow.buyer, return_amount, penalty_amount);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// The counterparty rejects the cancellation request; escrow resumes Active state.
+    pub fn reject_cancellation(env: Env, caller: Address, escrow_id: u32) {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::CancellationPending {
+            panic!("No pending cancellation for this escrow");
+        }
+
+        let request: CancellationRequest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CancellationRequest(escrow_id))
+            .expect("Cancellation request not found");
+
+        if caller == request.initiator {
+            panic!("Initiator cannot reject their own cancellation request");
+        }
+        if caller != escrow.buyer && caller != escrow.seller {
+            panic!("Only buyer or seller can reject cancellation");
+        }
+
+        escrow.status = EscrowStatus::Active;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage()
+            .persistent()
+            .remove(&DataKey::CancellationRequest(escrow_id));
+
+        events::emit_cancellation_rejected(&env, escrow_id, caller);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Expire a stale cancellation request and restore Active state.
+    /// Callable by anyone after the response window has elapsed.
+    pub fn expire_cancellation(env: Env, escrow_id: u32) {
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::CancellationPending {
+            panic!("No pending cancellation for this escrow");
+        }
+
+        let request: CancellationRequest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CancellationRequest(escrow_id))
+            .expect("Cancellation request not found");
+
+        if env.ledger().timestamp() <= request.expires_at {
+            panic!("Response window has not elapsed");
+        }
+
+        escrow.status = EscrowStatus::Active;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage()
+            .persistent()
+            .remove(&DataKey::CancellationRequest(escrow_id));
+
+        events::emit_cancellation_expired(&env, escrow_id);
 
         env.storage()
             .instance()

--- a/contracts/ahjoor-payments/src/events.rs
+++ b/contracts/ahjoor-payments/src/events.rs
@@ -1034,3 +1034,11 @@ pub fn emit_appeal_approved(e: &Env, merchant: Address) {
 pub fn emit_appeal_rejected(e: &Env, merchant: Address) {
     AppealRejected { merchant }.publish(e);
 }
+
+// #231: Withdrawal Rate Limiting Events
+pub fn emit_withdrawal_rate_limit_set(e: &Env, merchant: Address, window_seconds: u64, cap: i128) {
+    e.events().publish((soroban_sdk::Symbol::new(e, "WdrlLimitSet"),), (merchant, window_seconds, cap));
+}
+pub fn emit_withdrawal_rate_limit_exceeded(e: &Env, merchant: Address, attempted: i128, cap: i128) {
+    e.events().publish((soroban_sdk::Symbol::new(e, "WdrlLimitExceeded"),), (merchant, attempted, cap));
+}

--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -104,6 +104,23 @@ pub enum Error {
     VoucherExhausted = 11,
     VoucherRevoked = 12,
     VoucherNotFound = 13,
+    WithdrawalRateLimitExceeded = 14,
+}
+
+/// Per-merchant withdrawal rate limit config (#231).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WithdrawalLimit {
+    pub window_seconds: u64,
+    pub cap: i128,
+}
+
+/// Tracks cumulative withdrawals within the current window (#231).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WithdrawalWindowState {
+    pub window_start: u64,
+    pub withdrawn: i128,
 }
 
 /// Direction for oracle price condition (#125)
@@ -472,6 +489,14 @@ pub enum DataKey {
     AppealCooldownUntil(Address),
     /// Instance: appeal rejection cooldown in seconds
     AppealRejectionCooldownSeconds,
+    /// Instance: global default withdrawal window in seconds (#231)
+    WithdrawalWindowSeconds,
+    /// Instance: global default withdrawal cap per window (#231)
+    WithdrawalWindowCap,
+    /// Persistent: per-merchant withdrawal limit override (#231)
+    MerchantWithdrawalLimit(Address),
+    /// Persistent: per-merchant withdrawal tracker for current window (#231)
+    MerchantWithdrawalWindow(Address),
 }
 
 mod events;
@@ -1028,6 +1053,9 @@ impl AhjoorPaymentsContract {
         let net_amount = total_amount
             .checked_sub(fee_collected)
             .expect("Settlement fee exceeds amount");
+
+        // #231: Enforce withdrawal rate limit
+        Self::check_and_update_withdrawal_rate_limit(&env, &merchant, net_amount);
 
         let token_client = token::Client::new(&env, &settlement_token);
         token_client.transfer(&env.current_contract_address(), &merchant, &net_amount);
@@ -4012,6 +4040,163 @@ impl AhjoorPaymentsContract {
         {
             panic!("Contract is paused");
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // #231: Merchant Withdrawal Rate Limiting
+    // -------------------------------------------------------------------------
+
+    /// Admin sets global default withdrawal window and cap.
+    pub fn set_withdrawal_window(env: Env, admin: Address, window_seconds: u64, cap: i128) {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        if admin != stored_admin {
+            panic!("Only admin can set withdrawal window");
+        }
+        if window_seconds == 0 {
+            panic!("Window must be positive");
+        }
+        if cap <= 0 {
+            panic!("Cap must be positive");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::WithdrawalWindowSeconds, &window_seconds);
+        env.storage()
+            .instance()
+            .set(&DataKey::WithdrawalWindowCap, &cap);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Merchant sets a personal (stricter) withdrawal limit.
+    pub fn set_withdrawal_limit(env: Env, merchant: Address, window_seconds: u64, cap: i128) {
+        Self::require_not_paused(&env);
+        merchant.require_auth();
+        if window_seconds == 0 {
+            panic!("Window must be positive");
+        }
+        if cap <= 0 {
+            panic!("Cap must be positive");
+        }
+        let limit = WithdrawalLimit { window_seconds, cap };
+        env.storage()
+            .persistent()
+            .set(&DataKey::MerchantWithdrawalLimit(merchant.clone()), &limit);
+        env.storage().persistent().extend_ttl(
+            &DataKey::MerchantWithdrawalLimit(merchant.clone()),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        events::emit_withdrawal_rate_limit_set(&env, merchant, window_seconds, cap);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Admin overrides a merchant's withdrawal cap (emergency override).
+    pub fn override_withdrawal_limit(env: Env, admin: Address, merchant: Address, cap: i128) {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        if admin != stored_admin {
+            panic!("Only admin can override withdrawal limit");
+        }
+        if cap <= 0 {
+            panic!("Cap must be positive");
+        }
+        // Preserve existing window or use global default
+        let window_seconds: u64 = env
+            .storage()
+            .persistent()
+            .get::<DataKey, WithdrawalLimit>(&DataKey::MerchantWithdrawalLimit(merchant.clone()))
+            .map(|l| l.window_seconds)
+            .unwrap_or_else(|| {
+                env.storage()
+                    .instance()
+                    .get(&DataKey::WithdrawalWindowSeconds)
+                    .unwrap_or(24 * 60 * 60)
+            });
+        let limit = WithdrawalLimit { window_seconds, cap };
+        env.storage()
+            .persistent()
+            .set(&DataKey::MerchantWithdrawalLimit(merchant.clone()), &limit);
+        env.storage().persistent().extend_ttl(
+            &DataKey::MerchantWithdrawalLimit(merchant.clone()),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        events::emit_withdrawal_rate_limit_set(&env, merchant, window_seconds, cap);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Internal: check and update the rolling withdrawal window for a merchant.
+    /// Panics with WithdrawalRateLimitExceeded if the cap would be exceeded.
+    fn check_and_update_withdrawal_rate_limit(env: &Env, merchant: &Address, amount: i128) {
+        // Determine effective limit: merchant-specific > global default > no limit
+        let (window_seconds, cap) = if let Some(limit) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, WithdrawalLimit>(&DataKey::MerchantWithdrawalLimit(merchant.clone()))
+        {
+            (limit.window_seconds, limit.cap)
+        } else if let (Some(w), Some(c)) = (
+            env.storage()
+                .instance()
+                .get::<DataKey, u64>(&DataKey::WithdrawalWindowSeconds),
+            env.storage()
+                .instance()
+                .get::<DataKey, i128>(&DataKey::WithdrawalWindowCap),
+        ) {
+            (w, c)
+        } else {
+            // No rate limit configured — allow
+            return;
+        };
+
+        let now = env.ledger().timestamp();
+        let state_key = DataKey::MerchantWithdrawalWindow(merchant.clone());
+
+        let mut state: WithdrawalWindowState = env
+            .storage()
+            .persistent()
+            .get(&state_key)
+            .unwrap_or(WithdrawalWindowState {
+                window_start: now,
+                withdrawn: 0,
+            });
+
+        // Reset window if it has elapsed
+        if now >= state.window_start + window_seconds {
+            state.window_start = now;
+            state.withdrawn = 0;
+        }
+
+        let new_total = state.withdrawn.checked_add(amount).expect("Overflow");
+        if new_total > cap {
+            events::emit_withdrawal_rate_limit_exceeded(env, merchant.clone(), new_total, cap);
+            panic_with_error!(env, Error::WithdrawalRateLimitExceeded);
+        }
+
+        state.withdrawn = new_total;
+        env.storage().persistent().set(&state_key, &state);
+        env.storage().persistent().extend_ttl(
+            &state_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
     }
 
     fn require_admin(env: &Env, admin: &Address) {

--- a/contracts/ahjoor-refund/src/events.rs
+++ b/contracts/ahjoor-refund/src/events.rs
@@ -545,3 +545,29 @@ pub fn emit_refund_counter_accepted(e: &Env, refund_id: u32, customer: Address, 
 pub fn emit_refund_counter_rejected(e: &Env, refund_id: u32, customer: Address) {
     RefundCounterRejected { refund_id, customer }.publish(e);
 }
+
+// --- Issue #228: Refund Merchant Auto-Approval Threshold ---
+
+/// Event: Merchant set their auto-approval threshold
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct AutoApproveThresholdSet {
+    pub merchant: Address,
+    pub amount: i128,
+}
+
+/// Event: Refund auto-approved because amount <= merchant threshold
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct RefundAutoApprovedByThreshold {
+    pub refund_id: u32,
+    pub amount: i128,
+}
+
+pub fn emit_auto_approve_threshold_set(e: &Env, merchant: Address, amount: i128) {
+    AutoApproveThresholdSet { merchant, amount }.publish(e);
+}
+
+pub fn emit_refund_auto_approved_by_threshold(e: &Env, refund_id: u32, amount: i128) {
+    RefundAutoApprovedByThreshold { refund_id, amount }.publish(e);
+}

--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -173,6 +173,10 @@ pub enum DataKey {
     CounterOffer(u32),
     /// Configurable counter-offer expiry window in seconds
     CounterOfferExpirySeconds,
+    /// Per-merchant auto-approval threshold amount (#228)
+    AutoApproveThreshold(Address),
+    /// Global fraud score cap for auto-approval (#228)
+    AutoApproveFraudScoreCap,
 }
 
 mod events;
@@ -466,10 +470,43 @@ impl AhjoorRefundContract {
 
         let is_whitelisted = Self::is_merchant_auto_approved(&env, &merchant);
 
-        let initial_status = if is_whitelisted {
+        // #228: Check amount-based auto-approval threshold
+        let is_threshold_auto_approved = if !is_whitelisted {
+            let threshold: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey::AutoApproveThreshold(merchant.clone()))
+                .unwrap_or(0);
+            if threshold > 0 && effective_amount <= threshold {
+                // Check fraud score cap
+                let fraud_cap: u32 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::AutoApproveFraudScoreCap)
+                    .unwrap_or(u32::MAX);
+                let buyer_score = Self::get_fraud_score(env.clone(), customer.clone());
+                buyer_score < fraud_cap
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        let is_auto_approved = is_whitelisted || is_threshold_auto_approved;
+
+        let initial_status = if is_auto_approved {
             RefundStatus::Approved
         } else {
             RefundStatus::Requested
+        };
+
+        let auto_source = if is_whitelisted {
+            Some(String::from_str(&env, "whitelist"))
+        } else if is_threshold_auto_approved {
+            Some(String::from_str(&env, "threshold"))
+        } else {
+            None
         };
 
         let now = env.ledger().timestamp();
@@ -484,14 +521,10 @@ impl AhjoorRefundContract {
             reason,
             reason_code,
             requested_at: now,
-            approved_at: if is_whitelisted { Some(now) } else { None },
+            approved_at: if is_auto_approved { Some(now) } else { None },
             processed_at: None,
             rejected_at: None,
-            auto_approved_source: if is_whitelisted {
-                Some(String::from_str(&env, "whitelist"))
-            } else {
-                None
-            },
+            auto_approved_source: auto_source,
             escrow_id: None,
             fee_amount: None,
         };
@@ -531,7 +564,7 @@ impl AhjoorRefundContract {
         );
 
         // #164: Add to pending queue only when not auto-approved
-        if !is_whitelisted {
+        if !is_auto_approved {
             Self::append_to_pending_queue(&env, refund_id);
         }
 
@@ -558,7 +591,11 @@ impl AhjoorRefundContract {
         }
 
         if is_whitelisted {
-            events::emit_refund_auto_approved_whitelist(&env, refund_id, merchant, effective_amount);
+            events::emit_refund_auto_approved_whitelist(&env, refund_id, merchant.clone(), effective_amount);
+        }
+
+        if is_threshold_auto_approved {
+            events::emit_refund_auto_approved_by_threshold(&env, refund_id, effective_amount);
         }
 
         env.storage()
@@ -1328,6 +1365,62 @@ impl AhjoorRefundContract {
             .instance()
             .get(&DataKey::FraudScoreBlockThreshold)
             .unwrap_or(10)
+    }
+
+    // -------------------------------------------------------------------------
+    // #228: Refund Merchant Auto-Approval Threshold
+    // -------------------------------------------------------------------------
+
+    /// Merchant sets their auto-approval threshold.
+    /// Refund requests with amount <= threshold are auto-approved (unless fraud score cap blocks).
+    /// Set to 0 to disable auto-approval by threshold.
+    pub fn set_auto_approve_threshold(env: Env, merchant: Address, amount: i128) {
+        Self::require_not_paused(&env);
+        merchant.require_auth();
+
+        if amount < 0 {
+            panic!("Threshold amount cannot be negative");
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::AutoApproveThreshold(merchant.clone()), &amount);
+
+        events::emit_auto_approve_threshold_set(&env, merchant, amount);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get the auto-approval threshold for a merchant. Returns 0 if not set (disabled).
+    pub fn get_auto_approve_threshold(env: Env, merchant: Address) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::AutoApproveThreshold(merchant))
+            .unwrap_or(0)
+    }
+
+    /// Admin sets the global fraud score cap for auto-approval.
+    /// Buyers with fraud_score >= cap are excluded from threshold auto-approval.
+    pub fn set_auto_approve_fraud_score_cap(env: Env, admin: Address, cap: u32) {
+        Self::require_admin(&env, &admin);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::AutoApproveFraudScoreCap, &cap);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get the fraud score cap for auto-approval. Returns u32::MAX if not set (no cap).
+    pub fn get_auto_approve_fraud_score_cap(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::AutoApproveFraudScoreCap)
+            .unwrap_or(u32::MAX)
     }
 
     /// Get the fraud score for a buyer.

--- a/contracts/ahjoor-rosca/src/events.rs
+++ b/contracts/ahjoor-rosca/src/events.rs
@@ -1047,3 +1047,17 @@ pub fn emit_reinstatement_approved(e: &Env, member: Address) {
 pub fn emit_reinstatement_fee_collected(e: &Env, member: Address, amount: i128) {
     e.events().publish((Symbol::new(e, "ReinFee"),), (member, amount));
 }
+
+// #230: Group Merge Events
+pub fn emit_merge_proposed(e: &Env, proposal_id: u32, group_a_admin: Address, group_b_id: u32) {
+    e.events().publish((Symbol::new(e, "MergeProposed"),), (proposal_id, group_a_admin, group_b_id));
+}
+pub fn emit_merge_accepted(e: &Env, proposal_id: u32) {
+    e.events().publish((Symbol::new(e, "MergeAccepted"),), (proposal_id,));
+}
+pub fn emit_merge_completed(e: &Env, proposal_id: u32, members_added: u32) {
+    e.events().publish((Symbol::new(e, "MergeCompleted"),), (proposal_id, members_added));
+}
+pub fn emit_group_marked_merged(e: &Env, group_b_id: u32) {
+    e.events().publish((Symbol::new(e, "GroupMerged"),), (group_b_id,));
+}

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -4607,6 +4607,185 @@ impl AhjoorContract {
             .unwrap_or(Map::new(&env));
         debts.get(member).unwrap_or(0)
     }
+
+    // ─── #230: ROSCA Group Merge ──────────────────────────────────────────────
+
+    /// Admin of this group (Group A) proposes a merge with Group B.
+    /// `group_b_id` is an external identifier for the other group.
+    /// Returns the merge proposal ID.
+    pub fn propose_merge(env: Env, admin: Address, group_b_id: u32) -> u32 {
+        internals::check_not_paused(&env);
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Admin not set");
+        if admin != stored_admin {
+            panic_with_error!(&env, Error::OnlyAdminAllowed);
+        }
+
+        // Cannot merge a dissolved or already-merged group
+        let group_status: GroupStatus = env
+            .storage()
+            .instance()
+            .get(&DataKey2::GroupStatus)
+            .unwrap_or(GroupStatus::Active);
+        if group_status != GroupStatus::Active {
+            panic!("Group is not active");
+        }
+
+        // Merges are only permitted between rounds (PaidMembers must be empty)
+        let paid_members: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaidMembers)
+            .unwrap_or(Vec::new(&env));
+        if !paid_members.is_empty() {
+            panic!("Merge only permitted between rounds");
+        }
+
+        let proposal_id: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey2::MergeProposalCounter)
+            .unwrap_or(0) + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey2::MergeProposalCounter, &proposal_id);
+
+        let proposal = MergeProposal {
+            id: proposal_id,
+            group_a_admin: admin.clone(),
+            group_b_id,
+            proposed_at: env.ledger().timestamp(),
+            accepted: false,
+        };
+
+        let mut proposals: Map<u32, MergeProposal> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::MergeProposals)
+            .unwrap_or(Map::new(&env));
+        proposals.set(proposal_id, proposal);
+        env.storage()
+            .instance()
+            .set(&DataKey2::MergeProposals, &proposals);
+
+        events::emit_merge_proposed(&env, proposal_id, admin, group_b_id);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        proposal_id
+    }
+
+    /// Admin accepts a merge proposal and executes the merge.
+    /// `new_members` is the list of Group B's members to append to this group's payout order.
+    /// `group_b_balance` is the amount of tokens transferred from Group B (caller must have
+    /// already transferred the tokens to this contract before calling).
+    pub fn accept_merge(
+        env: Env,
+        admin: Address,
+        merge_proposal_id: u32,
+        new_members: Vec<Address>,
+    ) {
+        internals::check_not_paused(&env);
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Admin not set");
+        if admin != stored_admin {
+            panic_with_error!(&env, Error::OnlyAdminAllowed);
+        }
+
+        let mut proposals: Map<u32, MergeProposal> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::MergeProposals)
+            .unwrap_or(Map::new(&env));
+        let mut proposal = proposals.get(merge_proposal_id).expect("Merge proposal not found");
+
+        if proposal.accepted {
+            panic!("Merge proposal already accepted");
+        }
+
+        // Merges are only permitted between rounds
+        let paid_members: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaidMembers)
+            .unwrap_or(Vec::new(&env));
+        if !paid_members.is_empty() {
+            panic!("Merge only permitted between rounds");
+        }
+
+        let max_members: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxMembers)
+            .unwrap_or(50);
+
+        let mut members: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Members)
+            .expect("Not initialized");
+
+        let combined_count = members.len() as u32 + new_members.len() as u32;
+        if combined_count > max_members {
+            panic!("Combined member count exceeds max_members");
+        }
+
+        let mut payout_order: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::PayoutOrder)
+            .expect("Not initialized");
+
+        // Append Group B's members after Group A's remaining members
+        for m in new_members.iter() {
+            if !members.contains(&m) {
+                members.push_back(m.clone());
+                payout_order.push_back(m.clone());
+            }
+        }
+
+        env.storage().instance().set(&DataKey::Members, &members);
+        env.storage().instance().set(&DataKey::PayoutOrder, &payout_order);
+
+        // Mark Group B as merged
+        env.storage()
+            .instance()
+            .set(&DataKey2::GroupMergedInto, &proposal.group_b_id);
+
+        proposal.accepted = true;
+        proposals.set(merge_proposal_id, proposal.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey2::MergeProposals, &proposals);
+
+        events::emit_merge_accepted(&env, merge_proposal_id);
+        events::emit_merge_completed(&env, merge_proposal_id, new_members.len() as u32);
+        events::emit_group_marked_merged(&env, proposal.group_b_id);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get a merge proposal by ID.
+    pub fn get_merge_proposal(env: Env, proposal_id: u32) -> MergeProposal {
+        let proposals: Map<u32, MergeProposal> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::MergeProposals)
+            .unwrap_or(Map::new(&env));
+        proposals.get(proposal_id).expect("Merge proposal not found")
+    }
 }
 
 mod test;

--- a/contracts/ahjoor-rosca/src/types.rs
+++ b/contracts/ahjoor-rosca/src/types.rs
@@ -246,6 +246,13 @@ pub enum DataKey2 {
     ReinstatementFee,        // i128
     PendingReinstatementFee, // Vec<Address>
     ActiveReinstatementProposal, // Map<Address, u32>
+    // Waitlist (#219)
+    Waitlist,                // Vec<(Address, u64)> — (address, joined_at)
+    CatchUpDebt,             // Map<Address, i128> — catch-up contributions owed
+    // #230: Group Merge
+    MergeProposalCounter,    // u32
+    MergeProposals,          // Map<u32, MergeProposal>
+    GroupMergedInto,         // u32 — target group_id this group was merged into
 }
 
 /// Persistent storage keys — kept separate because DataKey was hitting
@@ -310,6 +317,8 @@ pub struct EmergencyPayoutConfig {
 pub enum GroupStatus {
     Active = 0,
     Dissolved = 1,
+    /// Group was merged into another group; all further interactions are rejected.
+    Merged = 2,
 }
 
 #[contracttype]
@@ -317,6 +326,17 @@ pub enum GroupStatus {
 pub struct DissolutionConfig {
     pub dissolution_quorum_bps: u32,    // e.g., 7500 = 75%
     pub dissolution_vote_window_seconds: u64,
+}
+
+/// #230: Merge proposal between two ROSCA groups.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MergeProposal {
+    pub id: u32,
+    pub group_a_admin: Address,
+    pub group_b_id: u32,
+    pub proposed_at: u64,
+    pub accepted: bool,
 }
 
 // #213: Payout Slot Swap


### PR DESCRIPTION
## Summary

Implements four features across four contracts.

---

## Issue #228 — Refund Merchant Auto-Approval Threshold (`ahjoor-refund`)

- `set_auto_approve_threshold(merchant, amount)` — merchant configures threshold; `0` disables
- `get_auto_approve_threshold(merchant)` — read current threshold
- `set/get_auto_approve_fraud_score_cap` — admin sets fraud score cap that blocks auto-approval
- Integration in `request_refund`: if `amount <= threshold` and buyer fraud score < cap, refund is immediately `Approved` with `auto_approved_source = "threshold"`
- New DataKey variants: `AutoApproveThreshold(Address)`, `AutoApproveFraudScoreCap`
- New events: `AutoApproveThresholdSet`, `RefundAutoApprovedByThreshold`

---

## Issue #229 — Escrow Mutual Cancellation with Configurable Penalty (`ahjoor-escrow`)

- `EscrowStatus::CancellationPending` — new state when a party requests cancellation
- `CancellationRequest` struct — stores initiator, reason hash, requested_at, expires_at
- `request_cancellation` — buyer or seller initiates; escrow enters `CancellationPending`
- `accept_cancellation` — counterparty accepts; funds returned to buyer minus penalty; penalty to fee collector
- `reject_cancellation` — counterparty rejects; escrow resumes `Active`
- `expire_cancellation` — anyone calls after window elapses to restore `Active`
- `set_cancellation_penalty_bps` / `set_cancellation_response_window` — admin config
- New DataKey variants: `CancellationRequest(u32)`, `CancellationPenaltyBps`, `CancellationResponseWindow`
- New events: `CancellationRequested`, `CancellationAccepted`, `CancellationRejected`, `CancellationExpired`

---

## Issue #230 — ROSCA Group Merge (`ahjoor-rosca`)

- `GroupStatus::Merged` — new terminal status for merged-out group
- `MergeProposal` struct — stores proposal id, group_a_admin, group_b_id, proposed_at, accepted
- `propose_merge(admin, group_b_id)` — admin proposes merge; only permitted between rounds
- `accept_merge(admin, merge_proposal_id, new_members)` — executes merge; appends Group B members to payout order; validates combined count <= max_members
- `get_merge_proposal(proposal_id)` — read a proposal
- New DataKey2 variants: `Waitlist`, `CatchUpDebt`, `MergeProposalCounter`, `MergeProposals`, `GroupMergedInto`
- New events: `MergeProposed`, `MergeAccepted`, `MergeCompleted`, `GroupMarkedMerged`

---

## Issue #231 — Payments Merchant Withdrawal Rate Limiting (`ahjoor-payments`)

- `Error::WithdrawalRateLimitExceeded` (code 14)
- `WithdrawalLimit` struct — `{ window_seconds, cap }`
- `WithdrawalWindowState` struct — rolling window tracker
- `set_withdrawal_window(admin, window_seconds, cap)` — global defaults
- `set_withdrawal_limit(merchant, window_seconds, cap)` — merchant sets stricter personal limit
- `override_withdrawal_limit(admin, merchant, cap)` — emergency admin override
- `check_and_update_withdrawal_rate_limit` — internal helper; resets window on expiry, rejects if cap exceeded
- Integrated into `settle_merchant_payments` before token transfer
- New DataKey variants: `WithdrawalWindowSeconds`, `WithdrawalWindowCap`, `MerchantWithdrawalLimit(Address)`, `MerchantWithdrawalWindow(Address)`
- New events: `WdrlLimitSet`, `WdrlLimitExceeded`

---

Closes #228
Closes #229
Closes #230
Closes #231