### PR TITLE
feat: implement #146 rating system, #216 recurring invoice, #217 batch refund, #219 multi-party split

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -789,3 +789,56 @@ pub struct EscrowToppedUp {
 pub fn emit_escrow_topped_up(e: &Env, escrow_id: u32, added_amount: i128, new_total: i128, buyer: Address) {
     EscrowToppedUp { escrow_id, added_amount, new_total, buyer }.publish(e);
 }
+
+// --- Issue #146: Post-Resolution Rating System ---
+
+/// Event: Rating submitted after escrow completion
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct RatingSubmitted {
+    pub escrow_id: u32,
+    pub rater: Address,
+    pub ratee: Address,
+    pub rating: u32,
+    pub comment_hash: Option<BytesN<32>>,
+}
+
+pub fn emit_rating_submitted(
+    e: &Env,
+    escrow_id: u32,
+    rater: Address,
+    ratee: Address,
+    rating: u32,
+    comment_hash: Option<BytesN<32>>,
+) {
+    RatingSubmitted {
+        escrow_id,
+        rater,
+        ratee,
+        rating,
+        comment_hash,
+    }
+    .publish(e);
+}
+
+// --- Issue #219: Multi-Party Split Release ---
+
+/// Event: Multi-seller escrow created with explicit payee list and shares
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MultiSellerEscrowCreated {
+    pub escrow_id: u32,
+    pub sellers_count: u32,
+}
+
+pub fn emit_multi_seller_escrow_created(
+    e: &Env,
+    escrow_id: u32,
+    sellers: soroban_sdk::Vec<(Address, u32)>,
+) {
+    MultiSellerEscrowCreated {
+        escrow_id,
+        sellers_count: sellers.len(),
+    }
+    .publish(e);
+}

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -253,6 +253,10 @@ pub enum DataKey {
     MaxTopUpBps,
     /// #225: cumulative top-up amount per escrow
     EscrowToppedUpAmount(u32),
+    /// #146: (ratee) → (total_score: u64, count: u32) for reputation
+    RatingScore(Address),
+    /// #146: (escrow_id, rater) → bool — prevents double-rating
+    RatingSubmitted(u32, Address),
 }
 
 const MAX_PROTOCOL_FEE_BPS: u32 = 200; // 2%
@@ -3590,6 +3594,168 @@ impl AhjoorEscrowContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    // ─── #219: Multi-Party Split Release ─────────────────────────────────────
+
+    /// Create an escrow with explicit multi-party seller splits.
+    /// `sellers` is a list of (address, bps) where bps must sum to 10,000.
+    /// On release, each seller receives their proportional share of the net amount.
+    /// Emits `MultiSellerEscrowCreated` in addition to the standard escrow events.
+    pub fn create_multi_seller_escrow(
+        env: Env,
+        buyer: Address,
+        sellers: Vec<(Address, u32)>,
+        arbiter: Address,
+        amount: i128,
+        token: Address,
+        deadline: u64,
+        metadata_hash: Option<BytesN<32>>,
+    ) -> u32 {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        if sellers.is_empty() {
+            panic!("At least one seller required");
+        }
+
+        // Validate shares sum to 10,000 bps
+        let mut total_bps: u32 = 0;
+        for i in 0..sellers.len() {
+            let (_, bps) = sellers.get(i).unwrap();
+            total_bps += bps;
+        }
+        if total_bps != 10_000 {
+            panic!("Seller shares must sum to 10000 bps");
+        }
+
+        let primary_seller = sellers.get(0).unwrap().0;
+
+        let request = EscrowCreateRequest {
+            seller: primary_seller,
+            arbiter,
+            amount,
+            token,
+            deadline,
+            metadata_hash,
+            sellers,
+            auto_renew: false,
+            renewal_count: 0,
+            buyer_inactivity_secs: 0,
+            min_lock_until: None,
+            release_base: None,
+            release_quote: None,
+            release_comparison: None,
+            release_threshold_price: None,
+            arbiter_fee_bps: None,
+            dispute_default_winner: None,
+        };
+
+        let escrow_id = Self::create_escrow_core(&env, &buyer, request);
+
+        let escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        events::emit_multi_seller_escrow_created(&env, escrow_id, escrow.sellers.clone());
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        escrow_id
+    }
+
+    // ─── #146: Post-Resolution Rating System ─────────────────────────────────
+
+    /// Submit a 1-5 star rating for the counterparty after escrow completion.
+    /// Callable by buyer (rating seller) or seller (rating buyer).
+    /// Only allowed once per escrow per rater; escrow must be Released or Resolved.
+    pub fn submit_rating(
+        env: Env,
+        rater: Address,
+        escrow_id: u32,
+        rating: u32,
+        comment_hash: Option<BytesN<32>>,
+    ) {
+        rater.require_auth();
+
+        if rating < 1 || rating > 5 {
+            panic!("Rating must be between 1 and 5");
+        }
+
+        let escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::Released && escrow.status != EscrowStatus::Resolved {
+            panic!("Rating only allowed after escrow is Released or Resolved");
+        }
+
+        // Determine ratee: buyer rates seller, seller rates buyer
+        let ratee = if rater == escrow.buyer {
+            escrow.seller.clone()
+        } else if rater == escrow.seller {
+            escrow.buyer.clone()
+        } else {
+            panic!("Only buyer or seller can submit a rating");
+        };
+
+        // Prevent double-rating
+        let rating_key = DataKey::RatingSubmitted(escrow_id, rater.clone());
+        if env.storage().persistent().has(&rating_key) {
+            panic!("Rating already submitted for this escrow");
+        }
+        env.storage().persistent().set(&rating_key, &true);
+        env.storage().persistent().extend_ttl(
+            &rating_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        // Accumulate score
+        let score_key = DataKey::RatingScore(ratee.clone());
+        let (total_score, count): (u64, u32) = env
+            .storage()
+            .persistent()
+            .get(&score_key)
+            .unwrap_or((0u64, 0u32));
+        let new_total = total_score + rating as u64;
+        let new_count = count + 1;
+        env.storage()
+            .persistent()
+            .set(&score_key, &(new_total, new_count));
+        env.storage().persistent().extend_ttl(
+            &score_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_rating_submitted(&env, escrow_id, rater, ratee, rating, comment_hash);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Returns (avg_score_x100, total_ratings) for an address.
+    /// avg_score_x100 = (total_score * 100) / count, or 0 if no ratings.
+    pub fn get_reputation(env: Env, address: Address) -> (u32, u32) {
+        let score_key = DataKey::RatingScore(address);
+        let (total_score, count): (u64, u32) = env
+            .storage()
+            .persistent()
+            .get(&score_key)
+            .unwrap_or((0u64, 0u32));
+        if count == 0 {
+            return (0, 0);
+        }
+        let avg_x100 = ((total_score * 100) / count as u64) as u32;
+        (avg_x100, count)
     }
 }
 

--- a/contracts/ahjoor-payments/src/events.rs
+++ b/contracts/ahjoor-payments/src/events.rs
@@ -1034,3 +1034,55 @@ pub fn emit_appeal_approved(e: &Env, merchant: Address) {
 pub fn emit_appeal_rejected(e: &Env, merchant: Address) {
     AppealRejected { merchant }.publish(e);
 }
+
+// --- #216: Recurring Invoice Events ---
+
+/// Event: Recurring invoice schedule created
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct RecurringInvoiceCreated {
+    pub invoice_id: u32,
+    pub merchant: Address,
+    pub customer: Address,
+    pub amount: i128,
+}
+
+/// Event: Invoice cycle triggered, creating a new payment
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct InvoiceCycleTriggered {
+    pub invoice_id: u32,
+    pub payment_id: u32,
+    pub cycle_number: u32,
+}
+
+/// Event: Recurring invoice cancelled
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct RecurringInvoiceCancelled {
+    pub invoice_id: u32,
+    pub cancelled_by: Address,
+}
+
+/// Event: Recurring invoice completed (max cycles reached)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct RecurringInvoiceCompleted {
+    pub invoice_id: u32,
+}
+
+pub fn emit_recurring_invoice_created(e: &Env, invoice_id: u32, merchant: Address, customer: Address, amount: i128) {
+    RecurringInvoiceCreated { invoice_id, merchant, customer, amount }.publish(e);
+}
+
+pub fn emit_invoice_cycle_triggered(e: &Env, invoice_id: u32, payment_id: u32, cycle_number: u32) {
+    InvoiceCycleTriggered { invoice_id, payment_id, cycle_number }.publish(e);
+}
+
+pub fn emit_recurring_invoice_cancelled(e: &Env, invoice_id: u32, cancelled_by: Address) {
+    RecurringInvoiceCancelled { invoice_id, cancelled_by }.publish(e);
+}
+
+pub fn emit_recurring_invoice_completed(e: &Env, invoice_id: u32) {
+    RecurringInvoiceCompleted { invoice_id }.publish(e);
+}

--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -485,9 +485,30 @@ pub enum DataKey {
     AppealRejectionCooldownSeconds,
     /// Persistent: per-merchant revenue dashboard summary (#226)
     MerchantSummary(Address),
+    /// #216: recurring invoice counter
+    RecurringInvoiceCounter,
+    /// #216: recurring invoice record
+    RecurringInvoice(u32),
 }
 
 mod events;
+
+/// #216: Recurring invoice schedule.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecurringInvoice {
+    pub id: u32,
+    pub merchant: Address,
+    pub customer: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub interval_seconds: u64,
+    pub max_cycles: u32,
+    pub cycles_triggered: u32,
+    pub next_due_at: u64,
+    pub reference_hash: Option<BytesN<32>>,
+    pub active: bool,
+}
 
 #[contract]
 pub struct AhjoorPaymentsContract;
@@ -5525,6 +5546,187 @@ impl AhjoorPaymentsContract {
             PERSISTENT_BUMP_AMOUNT,
         );
         env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    // ─── #216: Recurring Invoice Scheduling ──────────────────────────────────
+
+    /// Merchant creates a recurring invoice schedule.
+    /// `max_cycles` = 0 means unlimited.
+    pub fn create_recurring_invoice(
+        env: Env,
+        merchant: Address,
+        customer: Address,
+        amount: i128,
+        token: Address,
+        interval_seconds: u64,
+        max_cycles: u32,
+        reference_hash: Option<BytesN<32>>,
+    ) -> u32 {
+        Self::require_not_paused(&env);
+        merchant.require_auth();
+
+        if amount <= 0 {
+            panic!("Amount must be positive");
+        }
+        if interval_seconds == 0 {
+            panic!("Interval must be positive");
+        }
+
+        Self::require_token_allowed(&env, &token);
+        Self::require_merchant_approved(&env, &merchant);
+
+        let mut counter: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RecurringInvoiceCounter)
+            .unwrap_or(0);
+        let invoice_id = counter;
+        counter += 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::RecurringInvoiceCounter, &counter);
+
+        let now = env.ledger().timestamp();
+        let invoice = RecurringInvoice {
+            id: invoice_id,
+            merchant: merchant.clone(),
+            customer: customer.clone(),
+            amount,
+            token,
+            interval_seconds,
+            max_cycles,
+            cycles_triggered: 0,
+            next_due_at: now,
+            reference_hash,
+            active: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecurringInvoice(invoice_id), &invoice);
+        env.storage().persistent().extend_ttl(
+            &DataKey::RecurringInvoice(invoice_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_recurring_invoice_created(&env, invoice_id, merchant, customer, amount);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        invoice_id
+    }
+
+    /// Trigger the next invoice cycle, creating a standard Payment entry.
+    /// Callable by anyone (merchant, keeper, etc.) when the interval has elapsed.
+    /// Returns the new payment_id.
+    pub fn trigger_invoice_cycle(env: Env, invoice_id: u32) -> u32 {
+        Self::require_not_paused(&env);
+
+        let mut invoice: RecurringInvoice = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecurringInvoice(invoice_id))
+            .expect("Recurring invoice not found");
+
+        if !invoice.active {
+            panic!("Recurring invoice is cancelled");
+        }
+
+        let now = env.ledger().timestamp();
+        if now < invoice.next_due_at {
+            panic!("Invoice interval has not elapsed");
+        }
+
+        if invoice.max_cycles > 0 && invoice.cycles_triggered >= invoice.max_cycles {
+            panic!("Max cycles reached");
+        }
+
+        // Create a standard Payment entry (funds transferred from customer)
+        let payment_id = Self::create_payment_with_options(
+            env.clone(),
+            invoice.customer.clone(),
+            invoice.merchant.clone(),
+            invoice.amount,
+            invoice.token.clone(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        invoice.cycles_triggered += 1;
+        invoice.next_due_at = now + invoice.interval_seconds;
+
+        // Auto-complete if max_cycles reached
+        if invoice.max_cycles > 0 && invoice.cycles_triggered >= invoice.max_cycles {
+            invoice.active = false;
+            events::emit_recurring_invoice_completed(&env, invoice_id);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecurringInvoice(invoice_id), &invoice);
+        env.storage().persistent().extend_ttl(
+            &DataKey::RecurringInvoice(invoice_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_invoice_cycle_triggered(&env, invoice_id, payment_id, invoice.cycles_triggered);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        payment_id
+    }
+
+    /// Cancel a recurring invoice. Callable by merchant or customer.
+    pub fn cancel_recurring_invoice(env: Env, caller: Address, invoice_id: u32) {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        let mut invoice: RecurringInvoice = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecurringInvoice(invoice_id))
+            .expect("Recurring invoice not found");
+
+        if caller != invoice.merchant && caller != invoice.customer {
+            panic!("Only merchant or customer can cancel");
+        }
+
+        if !invoice.active {
+            panic!("Recurring invoice is already cancelled");
+        }
+
+        invoice.active = false;
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecurringInvoice(invoice_id), &invoice);
+        env.storage().persistent().extend_ttl(
+            &DataKey::RecurringInvoice(invoice_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_recurring_invoice_cancelled(&env, invoice_id, caller);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get a recurring invoice by ID.
+    pub fn get_recurring_invoice(env: Env, invoice_id: u32) -> RecurringInvoice {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RecurringInvoice(invoice_id))
+            .expect("Recurring invoice not found")
     }
 
 }

--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -173,6 +173,8 @@ pub enum DataKey {
     CounterOffer(u32),
     /// Configurable counter-offer expiry window in seconds
     CounterOfferExpirySeconds,
+    /// #217: admin-configurable max batch size for batch refund operations
+    MaxBatchSize,
 }
 
 mod events;
@@ -187,6 +189,16 @@ pub struct CounterOffer {
 }
 
 const DEFAULT_COUNTER_OFFER_EXPIRY_SECONDS: u64 = 48 * 60 * 60; // 48 hours
+
+const DEFAULT_MAX_BATCH_SIZE: u32 = 20;
+
+/// Result of a batch refund operation (#217).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatchRefundResult {
+    pub processed: Vec<u32>,
+    pub skipped: Vec<u32>,
+}
 
 /// Optional extended configuration for `initialize`.
 /// Groups the extra parameters that would otherwise exceed Soroban's 10-parameter limit.
@@ -2795,6 +2807,184 @@ impl AhjoorRefundContract {
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
         );
+    }
+
+    // ─── #217: Batch Refund Processing ───────────────────────────────────────
+
+    /// Admin sets the maximum batch size for batch refund operations.
+    pub fn set_max_batch_size(env: Env, admin: Address, max_batch_size: u32) {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        if admin != stored_admin {
+            panic!("Only admin can set max batch size");
+        }
+        if max_batch_size == 0 {
+            panic!("Max batch size must be positive");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxBatchSize, &max_batch_size);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Approve multiple pending refund requests in a single transaction.
+    /// Skips IDs that are not in Requested status rather than reverting.
+    /// Returns a BatchRefundResult with processed and skipped IDs.
+    pub fn batch_approve_refunds(env: Env, admin: Address, refund_ids: Vec<u32>) -> BatchRefundResult {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        if admin != stored_admin {
+            panic!("Only admin can batch approve refunds");
+        }
+
+        let max_batch: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxBatchSize)
+            .unwrap_or(DEFAULT_MAX_BATCH_SIZE);
+
+        if refund_ids.len() > max_batch {
+            panic!("Batch size exceeds maximum allowed");
+        }
+
+        let mut processed = Vec::new(&env);
+        let mut skipped = Vec::new(&env);
+        let now = env.ledger().timestamp();
+
+        for i in 0..refund_ids.len() {
+            let refund_id = refund_ids.get(i).unwrap();
+            let maybe_refund: Option<Refund> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Refund(refund_id));
+
+            match maybe_refund {
+                Some(mut refund) if refund.status == RefundStatus::Requested => {
+                    refund.status = RefundStatus::Approved;
+                    refund.approved_at = Some(now);
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::Refund(refund_id), &refund);
+                    env.storage().persistent().extend_ttl(
+                        &DataKey::Refund(refund_id),
+                        PERSISTENT_LIFETIME_THRESHOLD,
+                        PERSISTENT_BUMP_AMOUNT,
+                    );
+                    Self::remove_from_pending_queue(&env, refund_id);
+                    Self::decrement_fraud_score(&env, &refund.customer);
+                    Self::update_stats_on_approve(&env, &refund.merchant);
+                    events::emit_refund_approved(&env, refund_id, admin.clone(), now);
+                    processed.push_back(refund_id);
+                }
+                _ => {
+                    skipped.push_back(refund_id);
+                }
+            }
+        }
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        BatchRefundResult { processed, skipped }
+    }
+
+    /// Reject multiple pending refund requests in a single transaction.
+    /// Skips IDs that are not in Requested status rather than reverting.
+    /// Returns a BatchRefundResult with processed and skipped IDs.
+    pub fn batch_reject_refunds(
+        env: Env,
+        admin: Address,
+        refund_ids: Vec<u32>,
+        reason_hash: BytesN<32>,
+    ) -> BatchRefundResult {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        if admin != stored_admin {
+            panic!("Only admin can batch reject refunds");
+        }
+
+        let max_batch: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxBatchSize)
+            .unwrap_or(DEFAULT_MAX_BATCH_SIZE);
+
+        if refund_ids.len() > max_batch {
+            panic!("Batch size exceeds maximum allowed");
+        }
+
+        let mut processed = Vec::new(&env);
+        let mut skipped = Vec::new(&env);
+        let now = env.ledger().timestamp();
+
+        for i in 0..refund_ids.len() {
+            let refund_id = refund_ids.get(i).unwrap();
+            let maybe_refund: Option<Refund> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Refund(refund_id));
+
+            match maybe_refund {
+                Some(mut refund) if refund.status == RefundStatus::Requested => {
+                    refund.status = RefundStatus::Rejected;
+                    refund.rejected_at = Some(now);
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::Refund(refund_id), &refund);
+                    env.storage().persistent().extend_ttl(
+                        &DataKey::Refund(refund_id),
+                        PERSISTENT_LIFETIME_THRESHOLD,
+                        PERSISTENT_BUMP_AMOUNT,
+                    );
+                    Self::remove_from_pending_queue(&env, refund_id);
+                    Self::increment_fraud_score(&env, &refund.customer, Symbol::new(&env, "admin_rejected"));
+                    Self::update_stats_on_reject(&env, &refund.merchant);
+                    events::emit_refund_rejected(
+                        &env,
+                        refund_id,
+                        admin.clone(),
+                        String::from_str(&env, "batch_reject"),
+                        now,
+                    );
+                    processed.push_back(refund_id);
+                }
+                _ => {
+                    skipped.push_back(refund_id);
+                }
+            }
+        }
+
+        // Store reason_hash for audit (emit as event)
+        env.events().publish(
+            (Symbol::new(&env, "BatchRejectReason"),),
+            (admin.clone(), reason_hash),
+        );
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        BatchRefundResult { processed, skipped }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR implements four feature issues across the `ahjoor-escrow`, `ahjoor-payments`, and `ahjoor-refund` contracts.

---

## Issue #146 — Post-Resolution Rating System (`ahjoor-escrow`)

**Problem:** No on-chain reputation for escrow participants.

**Changes:**
- Added `RatingScore(Address)` and `RatingSubmitted(u32, Address)` DataKeys to persistent storage
- Added `submit_rating(env, rater, escrow_id, rating: u32, comment_hash: Option<BytesN<32>>)`:
  - Only callable after escrow status is `Released` or `Resolved`
  - Rating must be 1–5; out-of-range is rejected
  - Each party (buyer/seller) can rate the other once per escrow; double-rating panics
  - Accumulates `(total_score, count)` in persistent storage per ratee
- Added `get_reputation(env, address) -> (avg_score_x100, total_ratings)`
- Added `RatingSubmitted { escrow_id, rater, ratee, rating, comment_hash }` event

---

## Issue #216 — Recurring Invoice Scheduling (`ahjoor-payments`)

**Problem:** Merchants must manually create a new payment for each billing cycle.

**Changes:**
- Added `RecurringInvoice` struct with `interval_seconds`, `max_cycles`, `cycles_triggered`, `next_due_at`, `active`
- Added `RecurringInvoiceCounter` and `RecurringInvoice(u32)` DataKeys
- Added `create_recurring_invoice(merchant, customer, amount, token, interval_seconds, max_cycles, reference_hash) -> u32`
- Added `trigger_invoice_cycle(invoice_id) -> payment_id`:
  - Rejected if called before `next_due_at` or if `max_cycles` is reached
  - Creates a standard `Payment` entry via `create_payment_with_options`
  - Auto-cancels schedule when max cycles reached
- Added `cancel_recurring_invoice(caller, invoice_id)`: callable by merchant or customer
- Added `get_recurring_invoice(invoice_id)` query
- Added events: `RecurringInvoiceCreated`, `InvoiceCycleTriggered`, `RecurringInvoiceCancelled`, `RecurringInvoiceCompleted`

---

## Issue #217 — Batch Refund Processing (`ahjoor-refund`)

**Problem:** Processing refunds one-by-one is inefficient during high-volume periods.

**Changes:**
- Added `MaxBatchSize` DataKey and `DEFAULT_MAX_BATCH_SIZE = 20` constant
- Added `BatchRefundResult { processed: Vec<u32>, skipped: Vec<u32> }` return type
- Added `set_max_batch_size(admin, max_batch_size)` admin configuration function
- Added `batch_approve_refunds(admin, refund_ids) -> BatchRefundResult`:
  - Processes each ID atomically in sequence
  - Skips IDs not in `Requested` status (records in `skipped`) instead of reverting
  - Enforces `max_batch_size` cap (default 20)
- Added `batch_reject_refunds(admin, refund_ids, reason_hash) -> BatchRefundResult`:
  - Same skip-on-error semantics
  - Emits `BatchRejectReason` event with `reason_hash` for audit trail

---

## Issue #219 — Multi-Party Split Release (`ahjoor-escrow`)

**Problem:** Current escrow only supports a single seller address.

**Changes:**
- Added `create_multi_seller_escrow(buyer, sellers: Vec<(Address, u32)>, arbiter, amount, token, deadline, metadata_hash) -> u32`:
  - Explicit entry point for multi-party escrows
  - Validates `sellers` shares sum to 10,000 bps
  - Delegates to `create_escrow_core` (reuses all existing validation)
  - On `release_escrow`, `transfer_to_sellers` distributes proportionally to each seller
  - Dispute resolution via `resolve_dispute` applies buyer/seller split to aggregate seller pool, then distributes proportionally
- Added `MultiSellerEscrowCreated { escrow_id, sellers_count }` event
- Single-seller escrows remain fully backward-compatible (treated as one-element sellers list)

---

## Files Changed

| File | Change |
|------|--------|
| `contracts/ahjoor-escrow/src/lib.rs` | #146 rating functions + #219 multi-seller entry point |
| `contracts/ahjoor-escrow/src/events.rs` | `RatingSubmitted` + `MultiSellerEscrowCreated` events |
| `contracts/ahjoor-payments/src/lib.rs` | #216 recurring invoice struct + functions |
| `contracts/ahjoor-payments/src/events.rs` | 4 recurring invoice events |
| `contracts/ahjoor-refund/src/lib.rs` | #217 batch refund functions + `BatchRefundResult` |

Closes #146
Closes #216
Closes #217
Closes #219