### PR TITLE
[FEATURE] #319 Escrow Bounty Board for Open Competitive Work Assignment

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -1397,3 +1397,129 @@ pub fn emit_partial_release_rejected(
     }
     .publish(e);
 }
+
+// ── #319: Bounty Board Events ─────────────────────────────────────────────────
+
+/// Event: Bounty created with open competitive work assignment
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BountyCreated {
+    pub escrow_id: u32,
+    pub buyer: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub description_hash: BytesN<32>,
+    pub claim_deadline_ledger: u64,
+    pub submission_deadline_ledger: u64,
+}
+
+/// Event: Bounty claimed by a solver
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BountyClaimed {
+    pub escrow_id: u32,
+    pub solver: Address,
+}
+
+/// Event: Bounty work submitted by solver
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BountyWorkSubmitted {
+    pub escrow_id: u32,
+    pub solver: Address,
+    pub submission_hash: BytesN<32>,
+}
+
+/// Event: Bounty submission approved and funds awarded to solver
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BountyAwarded {
+    pub escrow_id: u32,
+    pub solver: Address,
+    pub amount: i128,
+}
+
+/// Event: Bounty submission rejected and bounty re-opened
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BountyRejected {
+    pub escrow_id: u32,
+    pub solver: Address,
+    pub rejection_count: u32,
+}
+
+/// Event: Bounty cancelled by buyer (no claims or after max rejections)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BountyCancelled {
+    pub escrow_id: u32,
+    pub buyer: Address,
+    pub refund_amount: i128,
+}
+
+pub fn emit_bounty_created(
+    e: &Env,
+    escrow_id: u32,
+    buyer: Address,
+    amount: i128,
+    token: Address,
+    description_hash: BytesN<32>,
+    claim_deadline_ledger: u64,
+    submission_deadline_ledger: u64,
+) {
+    BountyCreated {
+        escrow_id,
+        buyer,
+        amount,
+        token,
+        description_hash,
+        claim_deadline_ledger,
+        submission_deadline_ledger,
+    }
+    .publish(e);
+}
+
+pub fn emit_bounty_claimed(e: &Env, escrow_id: u32, solver: Address) {
+    BountyClaimed { escrow_id, solver }.publish(e);
+}
+
+pub fn emit_bounty_work_submitted(
+    e: &Env,
+    escrow_id: u32,
+    solver: Address,
+    submission_hash: BytesN<32>,
+) {
+    BountyWorkSubmitted {
+        escrow_id,
+        solver,
+        submission_hash,
+    }
+    .publish(e);
+}
+
+pub fn emit_bounty_awarded(e: &Env, escrow_id: u32, solver: Address, amount: i128) {
+    BountyAwarded {
+        escrow_id,
+        solver,
+        amount,
+    }
+    .publish(e);
+}
+
+pub fn emit_bounty_rejected(e: &Env, escrow_id: u32, solver: Address, rejection_count: u32) {
+    BountyRejected {
+        escrow_id,
+        solver,
+        rejection_count,
+    }
+    .publish(e);
+}
+
+pub fn emit_bounty_cancelled(e: &Env, escrow_id: u32, buyer: Address, refund_amount: i128) {
+    BountyCancelled {
+        escrow_id,
+        buyer,
+        refund_amount,
+    }
+    .publish(e);
+}

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -41,6 +41,10 @@ pub enum EscrowStatus {
     InspectionPassed = 12,
     /// #272: Inspector rejected; buyer/seller may negotiate or dispute.
     InspectionFailed = 13,
+    /// #319: Bounty created but not yet claimed by any solver.
+    BountyUnclaimed = 14,
+    /// #319: Bounty claimed by a solver; awaiting submission.
+    BountyClaimed = 15,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -393,6 +397,10 @@ pub enum DataKey2 {
 pub enum DataKey2 {
     /// #332: BPS-based milestone states for proportional progressive release
     EscrowMilestonesV2(u32),
+    /// #319: Bounty metadata per escrow
+    BountyData(u32),
+    /// #319: Admin-configurable max rejection rounds for bounties
+    MaxBountyRejectionRounds,
 }
 
 // ── #332: Milestone BPS Progressive Release ───────────────────────────────────
@@ -432,6 +440,27 @@ const MAX_ARBITER_FEE_BPS: u32 = 1_000; // 10%
 const DEFAULT_RESOLUTION_COOLING_OFF_SECONDS: u64 = 24 * 60 * 60; // 24 hours
 const DEFAULT_SELLER_TRANSFER_VETO_WINDOW: u32 = 100; // ledgers
 const DEFAULT_AMENDMENT_EXPIRY_SECONDS: u64 = 7 * 24 * 60 * 60; // 7 days
+const DEFAULT_MAX_BOUNTY_REJECTION_ROUNDS: u32 = 3; // #319: max times a bounty can be rejected and re-opened
+
+// ── #319: Bounty Board for Open Competitive Work Assignment ──────────────────
+
+/// Bounty metadata for open competitive work assignment.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BountyData {
+    /// Hash of the bounty description/requirements.
+    pub description_hash: BytesN<32>,
+    /// Ledger timestamp deadline for claiming the bounty.
+    pub claim_deadline_ledger: u64,
+    /// Ledger timestamp deadline for submitting work after claiming.
+    pub submission_deadline_ledger: u64,
+    /// Address of the solver who claimed the bounty (None if unclaimed).
+    pub solver: Option<Address>,
+    /// Hash of the submitted work (None if not yet submitted).
+    pub submission_hash: Option<BytesN<32>>,
+    /// Number of times this bounty has been rejected and re-opened.
+    pub rejection_count: u32,
+}
 
 /// Auto-renewal configuration for recurring service agreements.
 /// When provided at escrow creation, the escrow will automatically re-fund
@@ -551,6 +580,7 @@ impl AhjoorEscrowContract {
             .set(&DataKey::DefaultDisputeWinner, &DisputeDefaultWinner::Buyer);
         env.storage().instance().set(&DataKey::MaxTopupMultiplier, &DEFAULT_MAX_TOPUP_MULTIPLIER);
         env.storage().instance().set(&DataKey::PartialReleaseResponseDeadline, &DEFAULT_PARTIAL_RELEASE_RESPONSE_DEADLINE);
+        env.storage().instance().set(&DataKey2::MaxBountyRejectionRounds, &DEFAULT_MAX_BOUNTY_REJECTION_ROUNDS);
 
         env.storage()
             .instance()
@@ -4684,6 +4714,464 @@ impl AhjoorEscrowContract {
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 
+    // ── #319: Bounty Board for Open Competitive Work Assignment ──────────────
+
+    /// Create a bounty escrow with no pre-assigned seller.
+    /// Any whitelisted solver can claim it first-come-first-served.
+    pub fn create_bounty(
+        env: Env,
+        buyer: Address,
+        token: Address,
+        amount: i128,
+        description_hash: BytesN<32>,
+        claim_deadline_ledger: u64,
+        submission_deadline_ledger: u64,
+    ) -> u32 {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        if amount <= 0 {
+            panic!("Bounty amount must be positive");
+        }
+
+        let current_time = env.ledger().timestamp();
+        if claim_deadline_ledger <= current_time {
+            panic!("Claim deadline must be in the future");
+        }
+        if submission_deadline_ledger <= claim_deadline_ledger {
+            panic!("Submission deadline must be after claim deadline");
+        }
+
+        // Check token whitelist if configured
+        if let Some(whitelist_addr) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::TokenWhitelistContract)
+        {
+            let whitelist_client = TokenWhitelistClient::new(&env, &whitelist_addr);
+            if !whitelist_client.is_whitelisted(&token) {
+                panic!("Token not whitelisted");
+            }
+        }
+
+        // Transfer funds from buyer to contract
+        let token_client = token::Client::new(&env, &token);
+        token_client.transfer(&buyer, &env.current_contract_address(), &amount);
+
+        // Create escrow with BountyUnclaimed status
+        let escrow_id = env
+            .storage()
+            .instance()
+            .get(&DataKey::EscrowCounter)
+            .unwrap_or(0u32)
+            + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::EscrowCounter, &escrow_id);
+
+        let escrow = Escrow {
+            id: escrow_id,
+            buyer: buyer.clone(),
+            seller: env.current_contract_address(), // Placeholder until claimed
+            arbiter: env.current_contract_address(), // No arbiter for bounties
+            amount,
+            original_amount: amount,
+            token: token.clone(),
+            status: EscrowStatus::BountyUnclaimed,
+            created_at: current_time,
+            deadline: submission_deadline_ledger,
+            metadata_hash: Some(description_hash.clone()),
+            sellers: Vec::new(&env),
+            extensions: EscrowExtensions {
+                auto_renew: false,
+                renewal_count: 0,
+                renewals_remaining: 0,
+                dispute_timeout_seconds: None,
+                buyer_inactivity_secs: 0,
+                min_lock_until: None,
+                release_base: None,
+                release_quote: None,
+                release_comparison: None,
+                release_threshold_price: None,
+                arbiter_fee_bps: None,
+                dispute_default_winner: None,
+                required_collateral_bps: 0,
+                collateral_forfeit_bps: 0,
+                collateral_deposit_deadline: 0,
+                collateral_amount: 0,
+                delivery_proof_hash: None,
+                inspector: None,
+                auto_renew_config: None,
+                renewals_completed: 0,
+            },
+            top_up_history: Vec::new(&env),
+            top_up_acknowledged: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        // Store bounty metadata
+        let bounty_data = BountyData {
+            description_hash: description_hash.clone(),
+            claim_deadline_ledger,
+            submission_deadline_ledger,
+            solver: None,
+            submission_hash: None,
+            rejection_count: 0,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey2::BountyData(escrow_id), &bounty_data);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::BountyData(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_bounty_created(
+            &env,
+            escrow_id,
+            buyer,
+            amount,
+            token,
+            description_hash,
+            claim_deadline_ledger,
+            submission_deadline_ledger,
+        );
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        escrow_id
+    }
+
+    /// Claim an unclaimed bounty. First-come-first-served.
+    pub fn claim_bounty(env: Env, solver: Address, escrow_id: u32) {
+        Self::require_not_paused(&env);
+        solver.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::BountyUnclaimed {
+            panic!("Bounty is not available for claiming");
+        }
+
+        let mut bounty_data: BountyData = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::BountyData(escrow_id))
+            .expect("Bounty data not found");
+
+        let current_time = env.ledger().timestamp();
+        if current_time > bounty_data.claim_deadline_ledger {
+            panic!("Claim deadline has passed");
+        }
+
+        // Update escrow with solver as seller
+        escrow.seller = solver.clone();
+        escrow.status = EscrowStatus::BountyClaimed;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        // Update bounty data
+        bounty_data.solver = Some(solver.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey2::BountyData(escrow_id), &bounty_data);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::BountyData(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_bounty_claimed(&env, escrow_id, solver);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Submit bounty work by the solver.
+    pub fn submit_bounty_work(
+        env: Env,
+        solver: Address,
+        escrow_id: u32,
+        submission_hash: BytesN<32>,
+    ) {
+        Self::require_not_paused(&env);
+        solver.require_auth();
+
+        let escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::BountyClaimed {
+            panic!("Bounty is not in claimed status");
+        }
+
+        if escrow.seller != solver {
+            panic!("Only the assigned solver can submit work");
+        }
+
+        let mut bounty_data: BountyData = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::BountyData(escrow_id))
+            .expect("Bounty data not found");
+
+        let current_time = env.ledger().timestamp();
+        if current_time > bounty_data.submission_deadline_ledger {
+            panic!("Submission deadline has passed");
+        }
+
+        // Store submission hash
+        bounty_data.submission_hash = Some(submission_hash.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey2::BountyData(escrow_id), &bounty_data);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::BountyData(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_bounty_work_submitted(&env, escrow_id, solver, submission_hash);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Approve bounty submission and release funds to solver.
+    pub fn approve_bounty_submission(env: Env, buyer: Address, escrow_id: u32) {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.buyer != buyer {
+            panic!("Only buyer can approve submission");
+        }
+
+        if escrow.status != EscrowStatus::BountyClaimed {
+            panic!("Bounty is not in claimed status");
+        }
+
+        let bounty_data: BountyData = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::BountyData(escrow_id))
+            .expect("Bounty data not found");
+
+        if bounty_data.submission_hash.is_none() {
+            panic!("No submission has been made");
+        }
+
+        let solver = escrow.seller.clone();
+        let amount = escrow.amount;
+        let token_client = token::Client::new(&env, &escrow.token);
+
+        // Release funds to solver
+        token_client.transfer(&env.current_contract_address(), &solver, &amount);
+
+        // Update escrow status
+        escrow.status = EscrowStatus::Released;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_bounty_awarded(&env, escrow_id, solver, amount);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Reject bounty submission and re-open for new claims (up to MAX_REJECTION_ROUNDS).
+    pub fn reject_bounty_submission(env: Env, buyer: Address, escrow_id: u32) {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.buyer != buyer {
+            panic!("Only buyer can reject submission");
+        }
+
+        if escrow.status != EscrowStatus::BountyClaimed {
+            panic!("Bounty is not in claimed status");
+        }
+
+        let mut bounty_data: BountyData = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::BountyData(escrow_id))
+            .expect("Bounty data not found");
+
+        let max_rejections: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey2::MaxBountyRejectionRounds)
+            .unwrap_or(DEFAULT_MAX_BOUNTY_REJECTION_ROUNDS);
+
+        if bounty_data.rejection_count >= max_rejections {
+            panic!("Maximum rejection rounds reached");
+        }
+
+        let rejected_solver = escrow.seller.clone();
+
+        // Reset bounty to unclaimed state
+        escrow.seller = env.current_contract_address();
+        escrow.status = EscrowStatus::BountyUnclaimed;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        // Update bounty data
+        bounty_data.solver = None;
+        bounty_data.submission_hash = None;
+        bounty_data.rejection_count += 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey2::BountyData(escrow_id), &bounty_data);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::BountyData(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_bounty_rejected(&env, escrow_id, rejected_solver, bounty_data.rejection_count);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Cancel bounty and refund buyer (only if unclaimed or after claim deadline).
+    pub fn cancel_bounty(env: Env, buyer: Address, escrow_id: u32) {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.buyer != buyer {
+            panic!("Only buyer can cancel bounty");
+        }
+
+        let bounty_data: BountyData = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::BountyData(escrow_id))
+            .expect("Bounty data not found");
+
+        let current_time = env.ledger().timestamp();
+
+        // Can cancel if unclaimed, or if claim deadline passed and still unclaimed
+        if escrow.status == EscrowStatus::BountyUnclaimed {
+            // Allow cancellation anytime if unclaimed
+        } else if escrow.status == EscrowStatus::BountyClaimed
+            && current_time > bounty_data.claim_deadline_ledger
+        {
+            // Allow cancellation if claim deadline passed (edge case)
+        } else {
+            panic!("Cannot cancel bounty in current state");
+        }
+
+        let amount = escrow.amount;
+        let token_client = token::Client::new(&env, &escrow.token);
+
+        // Refund buyer
+        token_client.transfer(&env.current_contract_address(), &buyer, &amount);
+
+        // Update escrow status
+        escrow.status = EscrowStatus::Refunded;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Escrow(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_bounty_cancelled(&env, escrow_id, buyer, amount);
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Admin function to set max bounty rejection rounds.
+    pub fn set_max_bounty_rejection_rounds(env: Env, admin: Address, max_rounds: u32) {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        if admin != stored_admin {
+            panic!("Only admin can set max bounty rejection rounds");
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey2::MaxBountyRejectionRounds, &max_rounds);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get bounty data for an escrow.
+    pub fn get_bounty_data(env: Env, escrow_id: u32) -> Option<BountyData> {
+        env.storage()
+            .persistent()
+            .get(&DataKey2::BountyData(escrow_id))
+    }
+
     // --- Internal Helpers ---
 
     fn require_not_paused(env: &Env) {
@@ -5877,3 +6365,5 @@ mod test_seller_veto;
 mod test_inspector;
 #[cfg(test)]
 mod test_milestone_bps;
+#[cfg(test)]
+mod test_bounty_board;

--- a/contracts/ahjoor-escrow/src/test_bounty_board.rs
+++ b/contracts/ahjoor-escrow/src/test_bounty_board.rs
@@ -1,0 +1,749 @@
+#![cfg(test)]
+
+use crate::{AhjoorEscrowContract, AhjoorEscrowContractClient, BountyData, EscrowStatus};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    token, Address, BytesN, Env, String,
+};
+
+fn create_token_contract<'a>(e: &Env, admin: &Address) -> token::StellarAssetClient<'a> {
+    token::StellarAssetClient::new(e, &e.register_stellar_asset_contract_v2(admin.clone()).address())
+}
+
+fn advance_ledger(e: &Env, delta_secs: u64) {
+    e.ledger().set(LedgerInfo {
+        timestamp: e.ledger().timestamp().saturating_add(delta_secs),
+        protocol_version: 20,
+        sequence_number: e.ledger().sequence(),
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 3110400,
+    });
+}
+
+#[test]
+fn test_create_bounty_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+    let claim_deadline = current_time + 86400; // 1 day
+    let submission_deadline = current_time + 172800; // 2 days
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &claim_deadline,
+        &submission_deadline,
+    );
+
+    assert_eq!(escrow_id, 1);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.buyer, buyer);
+    assert_eq!(escrow.amount, 500);
+    assert_eq!(escrow.status, EscrowStatus::BountyUnclaimed);
+
+    let bounty_data = client.get_bounty_data(&escrow_id).unwrap();
+    assert_eq!(bounty_data.description_hash, description_hash);
+    assert_eq!(bounty_data.claim_deadline_ledger, claim_deadline);
+    assert_eq!(bounty_data.submission_deadline_ledger, submission_deadline);
+    assert_eq!(bounty_data.solver, None);
+    assert_eq!(bounty_data.rejection_count, 0);
+}
+
+#[test]
+#[should_panic(expected = "Bounty amount must be positive")]
+fn test_create_bounty_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    client.create_bounty(
+        &buyer,
+        &token.address,
+        &0,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Claim deadline must be in the future")]
+fn test_create_bounty_past_claim_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time - 100),
+        &(current_time + 172800),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Submission deadline must be after claim deadline")]
+fn test_create_bounty_invalid_deadlines() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 172800),
+        &(current_time + 86400),
+    );
+}
+
+#[test]
+fn test_claim_bounty_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    client.claim_bounty(&solver, &escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.seller, solver);
+    assert_eq!(escrow.status, EscrowStatus::BountyClaimed);
+
+    let bounty_data = client.get_bounty_data(&escrow_id).unwrap();
+    assert_eq!(bounty_data.solver, Some(solver));
+}
+
+#[test]
+#[should_panic(expected = "Bounty is not available for claiming")]
+fn test_claim_bounty_duplicate() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver1 = Address::generate(&env);
+    let solver2 = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    client.claim_bounty(&solver1, &escrow_id);
+    client.claim_bounty(&solver2, &escrow_id); // Should panic
+}
+
+#[test]
+#[should_panic(expected = "Claim deadline has passed")]
+fn test_claim_bounty_after_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    advance_ledger(&env, 86401); // Past claim deadline
+
+    client.claim_bounty(&solver, &escrow_id);
+}
+
+#[test]
+fn test_submit_bounty_work_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    client.claim_bounty(&solver, &escrow_id);
+
+    let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
+    client.submit_bounty_work(&solver, &escrow_id, &submission_hash);
+
+    let bounty_data = client.get_bounty_data(&escrow_id).unwrap();
+    assert_eq!(bounty_data.submission_hash, Some(submission_hash));
+}
+
+#[test]
+#[should_panic(expected = "Only the assigned solver can submit work")]
+fn test_submit_bounty_work_wrong_solver() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let wrong_solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    client.claim_bounty(&solver, &escrow_id);
+
+    let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
+    client.submit_bounty_work(&wrong_solver, &escrow_id, &submission_hash);
+}
+
+#[test]
+#[should_panic(expected = "Submission deadline has passed")]
+fn test_submit_bounty_work_after_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    client.claim_bounty(&solver, &escrow_id);
+
+    advance_ledger(&env, 172801); // Past submission deadline
+
+    let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
+    client.submit_bounty_work(&solver, &escrow_id, &submission_hash);
+}
+
+#[test]
+fn test_approve_bounty_submission_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    client.claim_bounty(&solver, &escrow_id);
+
+    let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
+    client.submit_bounty_work(&solver, &escrow_id, &submission_hash);
+
+    let solver_balance_before = token.balance(&solver);
+    client.approve_bounty_submission(&buyer, &escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+
+    let solver_balance_after = token.balance(&solver);
+    assert_eq!(solver_balance_after - solver_balance_before, 500);
+}
+
+#[test]
+#[should_panic(expected = "No submission has been made")]
+fn test_approve_bounty_without_submission() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    client.claim_bounty(&solver, &escrow_id);
+    client.approve_bounty_submission(&buyer, &escrow_id);
+}
+
+#[test]
+fn test_reject_bounty_submission_and_reclaim() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver1 = Address::generate(&env);
+    let solver2 = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    // First solver claims and submits
+    client.claim_bounty(&solver1, &escrow_id);
+    let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
+    client.submit_bounty_work(&solver1, &escrow_id, &submission_hash);
+
+    // Buyer rejects
+    client.reject_bounty_submission(&buyer, &escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::BountyUnclaimed);
+
+    let bounty_data = client.get_bounty_data(&escrow_id).unwrap();
+    assert_eq!(bounty_data.solver, None);
+    assert_eq!(bounty_data.submission_hash, None);
+    assert_eq!(bounty_data.rejection_count, 1);
+
+    // Second solver can now claim
+    client.claim_bounty(&solver2, &escrow_id);
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.seller, solver2);
+    assert_eq!(escrow.status, EscrowStatus::BountyClaimed);
+}
+
+#[test]
+#[should_panic(expected = "Maximum rejection rounds reached")]
+fn test_reject_bounty_max_rejections() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    // Reject 3 times (default max)
+    for _ in 0..3 {
+        client.claim_bounty(&solver, &escrow_id);
+        let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
+        client.submit_bounty_work(&solver, &escrow_id, &submission_hash);
+        client.reject_bounty_submission(&buyer, &escrow_id);
+    }
+
+    // Fourth rejection should panic
+    client.claim_bounty(&solver, &escrow_id);
+    let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
+    client.submit_bounty_work(&solver, &escrow_id, &submission_hash);
+    client.reject_bounty_submission(&buyer, &escrow_id);
+}
+
+#[test]
+fn test_cancel_bounty_unclaimed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    let buyer_balance_before = token.balance(&buyer);
+    client.cancel_bounty(&buyer, &escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Refunded);
+
+    let buyer_balance_after = token.balance(&buyer);
+    assert_eq!(buyer_balance_after - buyer_balance_before, 500);
+}
+
+#[test]
+#[should_panic(expected = "Cannot cancel bounty in current state")]
+fn test_cancel_bounty_claimed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    client.claim_bounty(&solver, &escrow_id);
+    client.cancel_bounty(&buyer, &escrow_id); // Should panic
+}
+
+#[test]
+fn test_full_bounty_award_flow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    // 1. Create bounty
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::BountyUnclaimed);
+
+    // 2. Solver claims bounty
+    client.claim_bounty(&solver, &escrow_id);
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::BountyClaimed);
+    assert_eq!(escrow.seller, solver);
+
+    // 3. Solver submits work
+    let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
+    client.submit_bounty_work(&solver, &escrow_id, &submission_hash);
+
+    let bounty_data = client.get_bounty_data(&escrow_id).unwrap();
+    assert_eq!(bounty_data.submission_hash, Some(submission_hash));
+
+    // 4. Buyer approves and funds are released
+    let solver_balance_before = token.balance(&solver);
+    client.approve_bounty_submission(&buyer, &escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+
+    let solver_balance_after = token.balance(&solver);
+    assert_eq!(solver_balance_after - solver_balance_before, 500);
+}
+
+#[test]
+fn test_set_max_bounty_rejection_rounds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    // Set max rejection rounds to 5
+    client.set_max_bounty_rejection_rounds(&admin, &5);
+
+    // Verify by creating a bounty and rejecting it 5 times
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = create_token_contract(&env, &token_admin);
+    token.mint(&buyer, &1000);
+
+    let description_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let current_time = env.ledger().timestamp();
+
+    let escrow_id = client.create_bounty(
+        &buyer,
+        &token.address,
+        &500,
+        &description_hash,
+        &(current_time + 86400),
+        &(current_time + 172800),
+    );
+
+    // Should be able to reject 5 times
+    for i in 0..5 {
+        client.claim_bounty(&solver, &escrow_id);
+        let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
+        client.submit_bounty_work(&solver, &escrow_id, &submission_hash);
+        client.reject_bounty_submission(&buyer, &escrow_id);
+
+        let bounty_data = client.get_bounty_data(&escrow_id).unwrap();
+        assert_eq!(bounty_data.rejection_count, i + 1);
+    }
+}


### PR DESCRIPTION
closes #319 

Open bounties (bug fixes, design challenges, data tasks) require a mechanism to publicly advertise funded work without pre-selecting a seller. The current escrow model requires a known seller at creation. A bounty mode allows buyers to attract the best performer from an open field while keeping funds trustlessly locked.

## Implementation

### New Status Types
- **BountyUnclaimed**: Bounty created but not yet claimed by any solver
- **BountyClaimed**: Bounty claimed by a solver; awaiting submission

### New Data Structures
- **BountyData**: Tracks bounty metadata including description hash, deadlines, solver, submission hash, and rejection count
- **DataKey2::BountyData(u32)**: Storage key for bounty metadata
- **DataKey2::MaxBountyRejectionRounds**: Admin-configurable max rejection rounds

### Core Functions

#### create_bounty
Creates an open bounty escrow with no pre-assigned seller.
- Parameters: buyer, token, amount, description_hash, claim_deadline_ledger, submission_deadline_ledger
- Validates deadlines and token whitelist
- Transfers funds from buyer to contract
- Creates escrow in BountyUnclaimed status
- Emits BountyCreated event

#### claim_bounty
Allows any address to claim an unclaimed bounty (first-come-first-served).
- Validates bounty is in BountyUnclaimed status
- Checks claim deadline hasn't passed
- Assigns caller as solver and transitions to BountyClaimed
- Emits BountyClaimed event

#### submit_bounty_work
Solver submits their work before the submission deadline.
- Validates solver is the assigned one
- Checks submission deadline hasn't passed
- Stores submission hash
- Emits BountyWorkSubmitted event

#### approve_bounty_submission
Buyer approves submission and releases funds to solver.
- Validates submission exists
- Transfers full amount to solver
- Updates status to Released
- Emits BountyAwarded event

#### reject_bounty_submission
Buyer rejects submission and re-opens bounty for new claims.
- Validates rejection count is within MAX_REJECTION_ROUNDS
- Resets bounty to BountyUnclaimed status
- Clears solver and submission data
- Increments rejection count
- Emits BountyRejected event

#### cancel_bounty
Buyer cancels bounty and reclaims funds.
- Only allowed if unclaimed or after claim deadline
- Refunds full amount to buyer
- Updates status to Refunded
- Emits BountyCancelled event

#### set_max_bounty_rejection_rounds
Admin function to configure maximum rejection rounds (default: 3).

#### get_bounty_data
Query function to retrieve bounty metadata.

### Events
- **BountyCreated**: Emitted when a bounty is created
- **BountyClaimed**: Emitted when a solver claims a bounty
- **BountyWorkSubmitted**: Emitted when solver submits work
- **BountyAwarded**: Emitted when buyer approves and funds are released
- **BountyRejected**: Emitted when buyer rejects and bounty is re-opened
- **BountyCancelled**: Emitted when buyer cancels and reclaims funds

## Testing
Comprehensive test suite added in `test_bounty_board.rs` covering:

### Success Scenarios
- ✅ Create bounty with valid parameters
- ✅ Claim bounty by solver
- ✅ Submit bounty work
- ✅ Approve submission and award funds
- ✅ Full bounty award flow (create → claim → submit → approve)
- ✅ Reject submission and allow re-claim by new solver
- ✅ Cancel unclaimed bounty
- ✅ Configure max rejection rounds

### Error Scenarios
- ✅ Create bounty with zero amount (panics)
- ✅ Create bounty with past claim deadline (panics)
- ✅ Create bounty with invalid deadline order (panics)
- ✅ Duplicate claim attempt (panics)
- ✅ Claim after deadline (panics)
- ✅ Submit work by wrong solver (panics)
- ✅ Submit work after deadline (panics)
- ✅ Approve without submission (panics)
- ✅ Exceed max rejection rounds (panics)
- ✅ Cancel claimed bounty (panics)

## Acceptance Criteria
All acceptance criteria from issue #319 have been met:

- ✅ `create_bounty` creates escrow in Unclaimed status with no seller
- ✅ `claim_bounty` assigns first caller as solver; BountyClaimed on duplicate
- ✅ `submit_bounty_work` stores submission hash with deadline enforcement
- ✅ `approve_bounty_submission` releases funds to solver
- ✅ `reject_bounty_submission` resets to Unclaimed within MAX_REJECTION_ROUNDS
- ✅ `cancel_bounty` returns funds to buyer after claim_deadline_ledger
- ✅ Tests: full award flow, duplicate claim, post-deadline submission, rejection and re-claim, max rejection rounds, cancelled bounty
