### PR TITLE
feat: staged escrow releases, cross-token invoice oracle, abuse score decay, ROSCA slot demotion

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -1593,3 +1593,31 @@ pub fn emit_multi_party_approval(
     }
     .publish(e);
 }
+
+// ── #353: Time-Locked Staged Release Events ───────────────────────────────────
+
+/// Event: A scheduled release tranche was claimed by the beneficiary
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct ScheduledReleaseExecuted {
+    pub escrow_id: u32,
+    pub tranche_index: u32,
+    pub amount: i128,
+    pub remaining_tranches: u32,
+}
+
+pub fn emit_scheduled_release_executed(
+    e: &Env,
+    escrow_id: u32,
+    tranche_index: u32,
+    amount: i128,
+    remaining_tranches: u32,
+) {
+    ScheduledReleaseExecuted {
+        escrow_id,
+        tranche_index,
+        amount,
+        remaining_tranches,
+    }
+    .publish(e);
+}

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -423,6 +423,20 @@ pub enum DataKey2 {
     MultiPartyThreshold(u32),
     /// #350: set of approver addresses that have already approved release
     ReleaseApprovals(u32),
+    /// #353: ordered release schedule (escrow_id → Vec<ReleaseTranche>)
+    ReleaseSchedule(u32),
+    /// #353: index of the next unclaimed tranche (escrow_id → u32)
+    ReleasedIndex(u32),
+}
+
+/// #353: A single time-locked tranche in a staged release schedule.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseTranche {
+    /// Unix timestamp after which this tranche may be claimed.
+    pub unlock_at: u64,
+    /// Token amount released in this tranche.
+    pub amount: i128,
 }
 
 // ── #332: Milestone BPS Progressive Release ───────────────────────────────────
@@ -5534,6 +5548,221 @@ impl AhjoorEscrowContract {
             .persistent()
             .get(&DataKey2::ReleaseApprovals(escrow_id))
             .unwrap_or(Vec::new(&env))
+    }
+
+    // ── #353: Time-Locked Staged Release ─────────────────────────────────────
+
+    /// Create an escrow with a staged release schedule.
+    ///
+    /// Funds are locked in the contract and released in tranches according to
+    /// `schedule`, where each `ReleaseTranche` specifies an `unlock_at` timestamp
+    /// and an `amount`. The sum of all tranche amounts must equal the total held.
+    ///
+    /// Beneficiary (seller) calls `claim_scheduled_release` after each tranche's
+    /// `unlock_at` to receive that tranche's funds.
+    pub fn create_escrow_with_schedule(
+        env: Env,
+        buyer: Address,
+        seller: Address,
+        arbiter: Address,
+        token: Address,
+        deadline: u64,
+        schedule: Vec<ReleaseTranche>,
+    ) -> u32 {
+        Self::require_not_paused(&env);
+        buyer.require_auth();
+
+        if schedule.is_empty() {
+            panic!("Release schedule must contain at least one tranche");
+        }
+
+        let now = env.ledger().timestamp();
+        let mut total: i128 = 0;
+        for i in 0..schedule.len() {
+            let tranche = schedule.get(i).unwrap();
+            if tranche.amount <= 0 {
+                panic!("Each tranche amount must be positive");
+            }
+            if tranche.unlock_at <= now {
+                panic!("Each tranche unlock_at must be in the future");
+            }
+            total += tranche.amount;
+        }
+
+        let request = EscrowCreateRequest {
+            seller: seller.clone(),
+            arbiter,
+            amount: total,
+            token,
+            deadline,
+            metadata_hash: None,
+            sellers: Vec::new(&env),
+            auto_renew: false,
+            renewal_count: 0,
+            buyer_inactivity_secs: 0,
+            min_lock_until: None,
+            release_base: None,
+            release_quote: None,
+            release_comparison: None,
+            release_threshold_price: None,
+            arbiter_fee_bps: None,
+            dispute_default_winner: None,
+            auto_renew_config: None,
+        };
+
+        let escrow_id = Self::create_escrow_core(&env, &buyer, request);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey2::ReleaseSchedule(escrow_id), &schedule);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::ReleaseSchedule(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey2::ReleasedIndex(escrow_id), &0u32);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::ReleasedIndex(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        escrow_id
+    }
+
+    /// Claim the next available tranche(s) from a staged release schedule.
+    ///
+    /// Callable by the beneficiary (seller). Iterates from the current
+    /// `ReleasedIndex` and transfers every tranche whose `unlock_at` has elapsed.
+    /// Skips tranches that have already been claimed. Emits
+    /// `ScheduledReleaseExecuted` for each tranche transferred.
+    pub fn claim_scheduled_release(env: Env, beneficiary: Address, escrow_id: u32) {
+        Self::require_not_paused(&env);
+        beneficiary.require_auth();
+
+        let escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.seller != beneficiary {
+            panic!("Only the beneficiary (seller) can claim scheduled releases");
+        }
+
+        if !Self::is_open_escrow_status(escrow.status) && escrow.status != EscrowStatus::PartiallyReleased {
+            panic!("Escrow is not in a claimable state");
+        }
+
+        let schedule: Vec<ReleaseTranche> = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::ReleaseSchedule(escrow_id))
+            .expect("No release schedule found for this escrow");
+
+        let mut released_index: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::ReleasedIndex(escrow_id))
+            .unwrap_or(0);
+
+        let now = env.ledger().timestamp();
+        let token_client = token::Client::new(&env, &escrow.token);
+        let mut claimed_any = false;
+        let total_tranches = schedule.len();
+
+        loop {
+            if released_index >= total_tranches {
+                break;
+            }
+            let tranche = schedule.get(released_index).unwrap();
+            if tranche.unlock_at > now {
+                break;
+            }
+
+            token_client.transfer(
+                &env.current_contract_address(),
+                &beneficiary,
+                &tranche.amount,
+            );
+
+            let remaining_tranches = total_tranches - released_index - 1;
+            events::emit_scheduled_release_executed(
+                &env,
+                escrow_id,
+                released_index,
+                tranche.amount,
+                remaining_tranches,
+            );
+
+            released_index += 1;
+            claimed_any = true;
+        }
+
+        if !claimed_any {
+            panic!("No tranches are currently claimable");
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey2::ReleasedIndex(escrow_id), &released_index);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::ReleasedIndex(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        // If all tranches have been claimed, mark the escrow as Released
+        if released_index >= total_tranches {
+            let mut updated_escrow = escrow.clone();
+            updated_escrow.status = EscrowStatus::Released;
+            Self::burn_receipt_if_exists(&env, escrow_id);
+            env.storage()
+                .persistent()
+                .set(&DataKey::Escrow(escrow_id), &updated_escrow);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Escrow(escrow_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        } else {
+            let mut updated_escrow = escrow.clone();
+            updated_escrow.status = EscrowStatus::PartiallyReleased;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Escrow(escrow_id), &updated_escrow);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Escrow(escrow_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        }
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Read the release schedule for a staged-release escrow.
+    pub fn get_release_schedule(env: Env, escrow_id: u32) -> Vec<ReleaseTranche> {
+        env.storage()
+            .persistent()
+            .get(&DataKey2::ReleaseSchedule(escrow_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Read how many tranches have already been claimed.
+    pub fn get_released_index(env: Env, escrow_id: u32) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey2::ReleasedIndex(escrow_id))
+            .unwrap_or(0)
     }
 
     // --- Internal Helpers ---

--- a/contracts/ahjoor-payments/src/multi_token_invoice.rs
+++ b/contracts/ahjoor-payments/src/multi_token_invoice.rs
@@ -1,8 +1,37 @@
 #![allow(dead_code)]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, token, Address, Bytes,
+    contract, contracterror, contractclient, contractimpl, contracttype, panic_with_error, token, Address, Bytes,
     BytesN, Env, Map, String, Symbol, Vec,
 };
+
+/// Minimal oracle interface for cross-token price lookups (#354).
+#[allow(dead_code)]
+#[contractclient(name = "InvoiceOracleClient")]
+pub trait InvoiceOracleInterface {
+    /// Returns the price of `base` in terms of `quote`, scaled by 1_000_000.
+    /// Returns `None` if the price feed is unavailable.
+    fn get_price(env: soroban_sdk::Env, base: Address, quote: Address) -> Option<i128>;
+}
+
+/// Record of a cross-token oracle settlement for an invoice (#354).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CrossTokenSettlementRecord {
+    /// Invoice ID that was settled.
+    pub invoice_id: u32,
+    /// Token sent by the payer.
+    pub paid_token: Address,
+    /// Amount of `paid_token` sent by the payer.
+    pub paid_amount: i128,
+    /// Token the invoice was denominated in.
+    pub invoiced_token: Address,
+    /// Equivalent amount in the invoiced token (computed via oracle).
+    pub invoiced_amount: i128,
+    /// Oracle price used (base/quote, scaled by 1_000_000).
+    pub oracle_price: i128,
+    /// Slippage tolerance that was checked (in basis points).
+    pub max_slippage_bps: u32,
+}
 
 /// Multi-token invoice with preferred settlement conversion
 #[contracttype]
@@ -36,6 +65,10 @@ pub struct MultiTokenInvoice {
     pub conversion_rates: Map<Address, i128>,
     /// Settlement conversion rate (base to preferred settlement)
     pub settlement_conversion_rate: i128,
+    /// Optional oracle contract for cross-token settlement (#354).
+    /// When set, payers may settle using any accepted token and oracle price lookup
+    /// is used to validate the equivalent amount.
+    pub oracle_contract: Option<Address>,
     /// Metadata
     pub metadata: Map<String, String>,
 }
@@ -123,6 +156,9 @@ pub enum MultiTokenInvoiceError {
     InvalidLineItem = 8,
     SettlementFailed = 9,
     InvalidConversionRate = 10,
+    SlippageExceeded = 11,
+    OracleNotConfigured = 12,
+    OraclePriceUnavailable = 13,
 }
 
 pub trait MultiTokenInvoiceInterface {

--- a/contracts/ahjoor-payments/src/multi_token_invoice_impl.rs
+++ b/contracts/ahjoor-payments/src/multi_token_invoice_impl.rs
@@ -31,6 +31,36 @@ impl MultiTokenInvoiceImpl {
         due_date: u64,
         metadata: Map<String, String>,
     ) -> u32 {
+        Self::create_invoice_with_oracle(
+            env,
+            merchant,
+            customer,
+            total_amount,
+            base_currency,
+            accepted_tokens,
+            preferred_settlement_token,
+            line_items,
+            due_date,
+            metadata,
+            None,
+        )
+    }
+
+    /// Create a new multi-token invoice with an optional oracle contract for
+    /// cross-token settlement price discovery (#354).
+    pub fn create_invoice_with_oracle(
+        env: &Env,
+        merchant: Address,
+        customer: Address,
+        total_amount: i128,
+        base_currency: Address,
+        accepted_tokens: Vec<Address>,
+        preferred_settlement_token: Address,
+        line_items: Vec<InvoiceLineItem>,
+        due_date: u64,
+        metadata: Map<String, String>,
+        oracle_contract: Option<Address>,
+    ) -> u32 {
         merchant.require_auth();
 
         if total_amount <= 0 {
@@ -80,6 +110,7 @@ impl MultiTokenInvoiceImpl {
             payments_received: Map::new(env),
             conversion_rates: Map::new(env),
             settlement_conversion_rate: 1_000_000, // 1:1 by default
+            oracle_contract,
             metadata,
         };
 
@@ -391,6 +422,196 @@ impl MultiTokenInvoiceImpl {
             .unwrap_or_else(|| panic_with_error!(env, MultiTokenInvoiceError::InvoiceNotFound));
 
         invoice.status
+    }
+
+    /// Pay an invoice using a different token than the invoice currency, using an oracle
+    /// for price discovery and slippage validation (#354).
+    ///
+    /// The invoice must have an `oracle_contract` configured. The oracle is queried for
+    /// the exchange rate between `payment_token` and the invoice's `base_currency`. If
+    /// the implied deviation from expected exceeds `max_slippage_bps`, the call is
+    /// rejected. On success, `payment_amount` of `payment_token` is transferred from
+    /// `payer` and the oracle-derived equivalent is credited against the invoice total.
+    /// A `CrossTokenSettlement` event is emitted.
+    pub fn pay_invoice_cross_token(
+        env: &Env,
+        invoice_id: u32,
+        payer: Address,
+        payment_token: Address,
+        payment_amount: i128,
+        max_slippage_bps: u32,
+    ) -> InvoicePayment {
+        use crate::multi_token_invoice::InvoiceOracleClient;
+
+        payer.require_auth();
+
+        if payment_amount <= 0 {
+            panic_with_error!(env, MultiTokenInvoiceError::InvalidLineItem);
+        }
+
+        let key = Symbol::new(env, &format!("{}{}", INVOICE_KEY_PREFIX, invoice_id));
+        let mut invoice: MultiTokenInvoice = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(env, MultiTokenInvoiceError::InvoiceNotFound));
+
+        match invoice.status {
+            InvoiceStatus::Cancelled => {
+                panic_with_error!(env, MultiTokenInvoiceError::InvalidInvoiceStatus);
+            }
+            InvoiceStatus::FullyPaid => {
+                panic_with_error!(env, MultiTokenInvoiceError::PaymentExceedsInvoiceAmount);
+            }
+            _ => {}
+        }
+
+        // Validate that the payment token is in the accepted list
+        let mut token_accepted = false;
+        for accepted_token in invoice.accepted_tokens.iter() {
+            if accepted_token == payment_token {
+                token_accepted = true;
+                break;
+            }
+        }
+        if !token_accepted {
+            panic_with_error!(env, MultiTokenInvoiceError::TokenNotAccepted);
+        }
+
+        // Require oracle to be configured
+        let oracle_addr = invoice
+            .oracle_contract
+            .clone()
+            .unwrap_or_else(|| panic_with_error!(env, MultiTokenInvoiceError::OracleNotConfigured));
+
+        // Query oracle: price of payment_token in terms of base_currency (scaled × 1_000_000)
+        let oracle_client = InvoiceOracleClient::new(env, &oracle_addr);
+        let oracle_price: i128 = oracle_client
+            .get_price(&payment_token, &invoice.base_currency)
+            .unwrap_or_else(|| panic_with_error!(env, MultiTokenInvoiceError::OraclePriceUnavailable));
+
+        if oracle_price <= 0 {
+            panic_with_error!(env, MultiTokenInvoiceError::OraclePriceUnavailable);
+        }
+
+        // Compute the base-currency equivalent of the payment
+        let amount_in_base = payment_amount
+            .checked_mul(oracle_price)
+            .unwrap_or_else(|| panic_with_error!(env, MultiTokenInvoiceError::InvalidConversionRate))
+            .checked_div(1_000_000)
+            .unwrap_or_else(|| panic_with_error!(env, MultiTokenInvoiceError::InvalidConversionRate));
+
+        // Slippage check: ensure oracle price does not deviate from stored conversion rate
+        // by more than max_slippage_bps relative to the stored rate.
+        if let Some(stored_rate) = invoice.conversion_rates.get(payment_token.clone()) {
+            if stored_rate > 0 {
+                let diff = if oracle_price > stored_rate {
+                    oracle_price - stored_rate
+                } else {
+                    stored_rate - oracle_price
+                };
+                // diff / stored_rate > max_slippage_bps / 10_000
+                if diff.checked_mul(10_000).unwrap_or(i128::MAX)
+                    > stored_rate.checked_mul(max_slippage_bps as i128).unwrap_or(i128::MAX)
+                {
+                    panic_with_error!(env, MultiTokenInvoiceError::SlippageExceeded);
+                }
+            }
+        }
+
+        // Validate payment does not exceed remaining invoice balance
+        let current_paid: i128 = invoice
+            .payments_received
+            .get(payment_token.clone())
+            .unwrap_or(0);
+        let new_paid = current_paid
+            .checked_add(amount_in_base)
+            .unwrap_or_else(|| panic_with_error!(env, MultiTokenInvoiceError::PaymentExceedsInvoiceAmount));
+
+        if new_paid > invoice.total_amount {
+            panic_with_error!(env, MultiTokenInvoiceError::PaymentExceedsInvoiceAmount);
+        }
+
+        // Transfer payment_token from payer to contract
+        let token_client = token::Client::new(env, &payment_token);
+        token_client.transfer(payer.as_ref(), &env.current_contract_address(), &payment_amount);
+
+        invoice.payments_received.set(payment_token.clone(), new_paid);
+
+        if new_paid >= invoice.total_amount {
+            invoice.status = InvoiceStatus::FullyPaid;
+        } else {
+            invoice.status = InvoiceStatus::PartiallyPaid;
+        }
+
+        let amount_in_settlement = amount_in_base
+            .checked_mul(invoice.settlement_conversion_rate)
+            .unwrap_or_else(|| panic_with_error!(env, MultiTokenInvoiceError::InvalidConversionRate))
+            .checked_div(1_000_000)
+            .unwrap_or_else(|| panic_with_error!(env, MultiTokenInvoiceError::InvalidConversionRate));
+
+        let payment_id: u32 = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(env, PAYMENT_COUNTER_KEY))
+            .unwrap_or(0u32);
+        let next_payment_id = payment_id.checked_add(1).unwrap_or_else(|| {
+            panic_with_error!(env, MultiTokenInvoiceError::SettlementFailed)
+        });
+
+        let now = env.ledger().timestamp();
+
+        let payment = InvoicePayment {
+            payment_id: next_payment_id,
+            invoice_id,
+            token: payment_token.clone(),
+            amount: payment_amount,
+            amount_in_base,
+            amount_in_settlement,
+            paid_at: now,
+            payer,
+            tx_hash: BytesN::from_array(env, &[0u8; 32]),
+        };
+
+        let payment_key = Symbol::new(
+            env,
+            &format!("{}{}", INVOICE_PAYMENT_KEY_PREFIX, next_payment_id),
+        );
+        env.storage().persistent().set(&payment_key, &payment);
+        env.storage().persistent().set(&key, &invoice);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(env, PAYMENT_COUNTER_KEY), &next_payment_id);
+
+        // Store cross-token settlement record
+        let settlement_key = Symbol::new(
+            env,
+            &format!("cross_settlement_{}", invoice_id),
+        );
+        let settlement_record = CrossTokenSettlementRecord {
+            invoice_id,
+            paid_token: payment_token.clone(),
+            paid_amount: payment_amount,
+            invoiced_token: invoice.base_currency.clone(),
+            invoiced_amount: amount_in_base,
+            oracle_price,
+            max_slippage_bps,
+        };
+        env.storage().persistent().set(&settlement_key, &settlement_record);
+
+        // Emit cross-token settlement event
+        env.events().publish(
+            (Symbol::new(env, "CrossTokenSettlement"),),
+            (
+                invoice_id,
+                payment_token,
+                payment_amount,
+                invoice.base_currency,
+                amount_in_base,
+            ),
+        );
+
+        payment
     }
 
     /// Get remaining balance for an invoice

--- a/contracts/ahjoor-refund/src/events.rs
+++ b/contracts/ahjoor-refund/src/events.rs
@@ -1091,3 +1091,31 @@ pub fn emit_cross_contract_refund_registered(
     }
     .publish(e);
 }
+
+// ─── Issue #355: Configurable Abuse Score Decay ───────────────────────────────
+
+/// Event: Abuse score decayed due to elapsed time without new violations
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct AbuseScoreDecayed {
+    pub buyer: Address,
+    pub old_score: u32,
+    pub new_score: u32,
+    pub periods_elapsed: u32,
+}
+
+pub fn emit_abuse_score_decayed(
+    e: &Env,
+    buyer: Address,
+    old_score: u32,
+    new_score: u32,
+    periods_elapsed: u32,
+) {
+    AbuseScoreDecayed {
+        buyer,
+        old_score,
+        new_score,
+        periods_elapsed,
+    }
+    .publish(e);
+}

--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -306,6 +306,12 @@ pub enum DataKey {
     MerchantRefundPolicy(Address),
     /// Policy version snapshot at refund request time (#320)
     RefundPolicySnapshot(u32),
+
+    // --- Feature: Configurable Abuse Score Decay (#355) ---
+    /// Decay period in ledgers (e.g. 10_000 ≈ 14 hours at 5s/ledger). Default: 10_000.
+    AbuseScoreDecayPeriodLedgers,
+    /// Decay factor in basis points per period (e.g. 5000 = halve every period). Default: 5000.
+    AbuseScoreDecayFactorBps,
 }
 
 mod events;
@@ -4658,6 +4664,60 @@ impl AhjoorRefundContract {
         Self::load_abuse_record_with_decay(&env, &customer)
     }
 
+    // ─── #355: Configurable Abuse Score Decay ────────────────────────────────
+
+    /// Admin configures the exponential decay parameters for the abuse score system.
+    ///
+    /// - `period_ledgers`: number of ledgers between decay applications (e.g. 10_000).
+    ///   After each period the score is multiplied by `factor_bps / 10_000`.
+    /// - `factor_bps`: decay factor in basis points (e.g. 5000 = halve every period).
+    ///   Must be < 10_000 (a factor ≥ 10_000 would mean no decay or score growth).
+    ///   Use 0 to disable decay entirely.
+    ///
+    /// Updating these parameters does NOT reset existing scores; the new values are
+    /// used the next time a score is mutated or read.
+    pub fn set_abuse_score_decay_params(
+        env: Env,
+        admin: Address,
+        period_ledgers: u64,
+        factor_bps: u32,
+    ) {
+        Self::require_admin(&env, &admin);
+
+        if factor_bps > 10_000 {
+            panic!("factor_bps must be <= 10_000 (10_000 = no decay)");
+        }
+        if period_ledgers == 0 && factor_bps > 0 {
+            panic!("period_ledgers must be positive when factor_bps > 0");
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::AbuseScoreDecayPeriodLedgers, &period_ledgers);
+        env.storage()
+            .instance()
+            .set(&DataKey::AbuseScoreDecayFactorBps, &factor_bps);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get the configured abuse score decay period in ledgers (default: 10_000).
+    pub fn get_abuse_score_decay_period_ledgers(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::AbuseScoreDecayPeriodLedgers)
+            .unwrap_or(10_000u64)
+    }
+
+    /// Get the configured abuse score decay factor in basis points (default: 5_000 = halve).
+    pub fn get_abuse_score_decay_factor_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::AbuseScoreDecayFactorBps)
+            .unwrap_or(5_000u32)
+    }
+
     // --- Internal abuse-score helpers ---
 
     fn load_abuse_record_with_decay(env: &Env, customer: &Address) -> RefundAbuseRecord {
@@ -4676,19 +4736,82 @@ impl AhjoorRefundContract {
                 last_submission_ledger: 0,
             });
 
-        // Lazy decay: -1 per 10,000 ledgers since last increment
+        // #355: Configurable exponential decay.
+        // effective_score = stored_score * (factor_bps / 10_000) ^ periods_elapsed
+        // Computed on read; the decayed value is NOT written back (no storage mutation on read).
         if record.abuse_score > 0 && record.last_increment_ledger > 0 {
             let current_ledger = env.ledger().sequence() as u64;
             if current_ledger > record.last_increment_ledger {
-                let elapsed = current_ledger - record.last_increment_ledger;
-                let decay = (elapsed / 10_000) as u32;
-                if decay > 0 {
-                    record.abuse_score = record.abuse_score.saturating_sub(decay);
+                let decay_period: u64 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::AbuseScoreDecayPeriodLedgers)
+                    .unwrap_or(10_000u64);
+                let decay_factor_bps: u32 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::AbuseScoreDecayFactorBps)
+                    .unwrap_or(5_000u32); // default: halve every period
+
+                if decay_period > 0 {
+                    let elapsed = current_ledger - record.last_increment_ledger;
+                    let periods = (elapsed / decay_period) as u32;
+                    if periods > 0 {
+                        // Apply (factor_bps / 10_000) ^ periods multiplicatively
+                        let mut score = record.abuse_score as u128;
+                        for _ in 0..periods {
+                            score = score.saturating_mul(decay_factor_bps as u128) / 10_000;
+                            if score == 0 {
+                                break;
+                            }
+                        }
+                        record.abuse_score = score as u32;
+                    }
                 }
             }
         }
 
         record
+    }
+
+    /// Write back the decay-adjusted record and emit `AbuseScoreDecayed` when the
+    /// score was reduced by decay. This is called from mutating paths so that the
+    /// event is only emitted on state changes, not on read-only queries.
+    fn persist_abuse_record_with_decay_event(
+        env: &Env,
+        customer: &Address,
+        old_record: &RefundAbuseRecord,
+        new_record: &RefundAbuseRecord,
+    ) {
+        if old_record.abuse_score > new_record.abuse_score {
+            let decay_period: u64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::AbuseScoreDecayPeriodLedgers)
+                .unwrap_or(10_000u64);
+            let elapsed = if new_record.last_increment_ledger > old_record.last_increment_ledger {
+                0u64
+            } else {
+                let current = env.ledger().sequence() as u64;
+                current.saturating_sub(old_record.last_increment_ledger)
+            };
+            let periods = if decay_period > 0 { (elapsed / decay_period) as u32 } else { 0 };
+            events::emit_abuse_score_decayed(
+                env,
+                customer.clone(),
+                old_record.abuse_score,
+                new_record.abuse_score,
+                periods,
+            );
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::CustomerAbuseRecord(customer.clone()), new_record);
+        env.storage().persistent().extend_ttl(
+            &DataKey::CustomerAbuseRecord(customer.clone()),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
     }
 
     fn check_abuse_block(env: &Env, customer: &Address) {
@@ -4737,7 +4860,8 @@ impl AhjoorRefundContract {
     }
 
     fn update_abuse_on_request(env: &Env, customer: &Address, current_seq: u32, rapid_window: u32) {
-        let mut record = Self::load_abuse_record_with_decay(env, customer);
+        let old_record = Self::load_abuse_record_with_decay(env, customer);
+        let mut record = old_record.clone();
         record.total_requests += 1;
 
         // Rapid submission detection
@@ -4753,18 +4877,14 @@ impl AhjoorRefundContract {
 
         record.last_submission_ledger = current_seq;
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::CustomerAbuseRecord(customer.clone()), &record);
-        env.storage().persistent().extend_ttl(
-            &DataKey::CustomerAbuseRecord(customer.clone()),
-            PERSISTENT_LIFETIME_THRESHOLD,
-            PERSISTENT_BUMP_AMOUNT,
-        );
+        // Emit decay event if score was reduced by decay, then persist
+        Self::persist_abuse_record_with_decay_event(env, customer, &old_record, &record);
     }
 
     fn increment_abuse_score(env: &Env, customer: &Address, delta: u32, is_elevated: bool) {
-        let mut record = Self::load_abuse_record_with_decay(env, customer);
+        // Load with in-memory decay applied (does NOT write to storage)
+        let old_record = Self::load_abuse_record_with_decay(env, customer);
+        let mut record = old_record.clone();
 
         let effective_delta = if is_elevated { delta + 10 } else { delta };
         record.denied_count += 1;
@@ -4800,14 +4920,8 @@ impl AhjoorRefundContract {
             events::emit_customer_blocked_for_abuse(env, customer.clone(), blocked_until);
         }
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::CustomerAbuseRecord(customer.clone()), &record);
-        env.storage().persistent().extend_ttl(
-            &DataKey::CustomerAbuseRecord(customer.clone()),
-            PERSISTENT_LIFETIME_THRESHOLD,
-            PERSISTENT_BUMP_AMOUNT,
-        );
+        // Persist; decay event emitted if score dropped due to exponential decay on load
+        Self::persist_abuse_record_with_decay_event(env, customer, &old_record, &record);
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/contracts/ahjoor-rosca/src/events.rs
+++ b/contracts/ahjoor-rosca/src/events.rs
@@ -1609,3 +1609,36 @@ pub fn emit_contribution_rebalanced(
     }
     .publish(e);
 }
+
+// ── #356: Penalty-Based Slot Demotion ────────────────────────────────────────
+
+/// Event: A member was demoted to the back of the payout queue after reaching
+/// the configured late-contribution threshold (#356).
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MemberDemoted {
+    pub member: Address,
+    pub new_slot_index: u32,
+    pub late_count: u32,
+}
+
+pub fn emit_member_demoted(e: &Env, member: Address, new_slot_index: u32, late_count: u32) {
+    MemberDemoted {
+        member,
+        new_slot_index,
+        late_count,
+    }
+    .publish(e);
+}
+
+/// Event: A member's late-contribution count was reset due to consecutive on-time payments.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct LateCountReset {
+    pub member: Address,
+}
+
+pub fn emit_late_count_reset(e: &Env, member: Address) {
+    LateCountReset { member }.publish(e);
+}
+

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -758,9 +758,22 @@ impl AhjoorContract {
                 .expect("Deadline not set")
         };
 
-        if env.ledger().timestamp() > deadline {
+        let now_ts = env.ledger().timestamp();
+
+        // #356: Allow late contributions during the grace period.
+        let grace_period_seconds: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey3::GracePeriodSeconds)
+            .unwrap_or(0);
+        let hard_deadline = deadline.saturating_add(grace_period_seconds);
+
+        if now_ts > hard_deadline {
             panic_with_error!(&env, Error::ContributionWindowClosed);
         }
+
+        // Track whether this contribution is "late" (after soft deadline, within grace period)
+        let is_late = now_ts > deadline;
 
         let exited_members: Vec<Address> = env
             .storage()
@@ -951,8 +964,37 @@ impl AhjoorContract {
 
         // Only mark as fully paid (and track participation) when target is reached
         if new_total == member_required_amount {
-            Self::apply_reputation_delta(&env, contributor.clone(), 10, "on_time_full");
-            Self::update_credit_score_internal(&env, &contributor, Symbol::new(&env, "on_time"));
+            if is_late {
+                // #356: Increment late contribution count; reset handled in finalize_round
+                let mut late_counts: Map<Address, u32> = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey3::LateContributionCount)
+                    .unwrap_or(Map::new(&env));
+                let prev_late = late_counts.get(contributor.clone()).unwrap_or(0);
+                late_counts.set(contributor.clone(), prev_late + 1);
+                env.storage()
+                    .instance()
+                    .set(&DataKey3::LateContributionCount, &late_counts);
+                Self::apply_reputation_delta(&env, contributor.clone(), -5, "late_full");
+                Self::update_credit_score_internal(&env, &contributor, Symbol::new(&env, "late"));
+            } else {
+                // On-time: reset consecutive late count and reward reputation
+                let mut late_counts: Map<Address, u32> = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey3::LateContributionCount)
+                    .unwrap_or(Map::new(&env));
+                if late_counts.get(contributor.clone()).unwrap_or(0) > 0 {
+                    late_counts.set(contributor.clone(), 0u32);
+                    env.storage()
+                        .instance()
+                        .set(&DataKey3::LateContributionCount, &late_counts);
+                    events::emit_late_count_reset(&env, contributor.clone());
+                }
+                Self::apply_reputation_delta(&env, contributor.clone(), 10, "on_time_full");
+                Self::update_credit_score_internal(&env, &contributor, Symbol::new(&env, "on_time"));
+            }
             paid_members.push_back(contributor.clone());
             env.storage()
                 .instance()
@@ -1437,6 +1479,58 @@ impl AhjoorContract {
         env.storage()
             .instance()
             .set(&DataKey::SuspendedMembers, &suspended_members);
+
+        // ── #356: Penalty-Based Slot Demotion ─────────────────────────────────
+        // After tracking defaults, check if any late contributors have hit the threshold
+        // and demote them to the back of the unfulfilled payout queue.
+        {
+            let late_threshold: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey3::LateContribThreshold)
+                .unwrap_or(3);
+            let late_counts: Map<Address, u32> = env
+                .storage()
+                .instance()
+                .get(&DataKey3::LateContributionCount)
+                .unwrap_or(Map::new(&env));
+            let mut payout_order: Vec<Address> = env
+                .storage()
+                .instance()
+                .get(&DataKey::PayoutOrder)
+                .unwrap_or(Vec::new(&env));
+            let mut order_changed = false;
+
+            for member in members.iter() {
+                let late_count = late_counts.get(member.clone()).unwrap_or(0);
+                if late_count >= late_threshold {
+                    // Find and remove the member from their current position
+                    let mut new_order: Vec<Address> = Vec::new(&env);
+                    let mut found = false;
+                    for addr in payout_order.iter() {
+                        if addr == member && !found {
+                            found = true; // skip (remove from current position)
+                        } else {
+                            new_order.push_back(addr);
+                        }
+                    }
+                    if found {
+                        // Append to end (demoted to last unfulfilled slot)
+                        new_order.push_back(member.clone());
+                        let new_slot = new_order.len() - 1;
+                        payout_order = new_order;
+                        order_changed = true;
+                        events::emit_member_demoted(&env, member.clone(), new_slot, late_count);
+                    }
+                }
+            }
+
+            if order_changed {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::PayoutOrder, &payout_order);
+            }
+        }
 
         // ── #224: Cycle completion bonus ──────────────────────────────────────
         // A cycle ends when (current_round + 1) is a multiple of payout_order.len().
@@ -8518,6 +8612,68 @@ impl AhjoorContract {
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 
         payout_order
+    }
+
+    // ── #356: Penalty-Based Slot Demotion ─────────────────────────────────────
+
+    /// Admin configures the late-contribution threshold and the grace period after
+    /// the round deadline during which late payments are still accepted (#356).
+    ///
+    /// - `late_threshold`: consecutive late cycles before a member is demoted (e.g. 3).
+    /// - `grace_period_seconds`: seconds after the round deadline during which late
+    ///   contributions are still accepted (0 = no grace period, no late tracking).
+    pub fn configure_late_demotion(
+        env: Env,
+        admin: Address,
+        late_threshold: u32,
+        grace_period_seconds: u64,
+    ) {
+        internals::check_not_paused(&env);
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Admin not set");
+        if admin != stored_admin {
+            panic_with_error!(&env, ExtError::OnlyAdminAllowed);
+        }
+        if late_threshold == 0 {
+            panic_with_error!(&env, Error::InvalidMaxDefaults); // reuse existing validation error
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey3::LateContribThreshold, &late_threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey3::GracePeriodSeconds, &grace_period_seconds);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get the configured late-contribution demotion threshold (default: 3).
+    pub fn get_late_contrib_threshold(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey3::LateContribThreshold)
+            .unwrap_or(3)
+    }
+
+    /// Get the configured grace period in seconds after the round deadline (default: 0).
+    pub fn get_grace_period_seconds(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey3::GracePeriodSeconds)
+            .unwrap_or(0)
+    }
+
+    /// Get the current late contribution counts for all members.
+    pub fn get_late_contribution_counts(env: Env) -> Map<Address, u32> {
+        env.storage()
+            .instance()
+            .get(&DataKey3::LateContributionCount)
+            .unwrap_or(Map::new(&env))
     }
 
 }

--- a/contracts/ahjoor-rosca/src/types.rs
+++ b/contracts/ahjoor-rosca/src/types.rs
@@ -341,6 +341,10 @@ pub enum DataKey3 {
     SplitProposalCounter,    // u32
     SplitProposals,          // Map<u32, SplitProposal>
     SplitConfirmationWindow, // u32 — ledgers members have to confirm
+    // #356: Penalty-Based Slot Demotion
+    LateContributionCount,   // Map<Address, u32> — consecutive late payment count per member
+    LateContribThreshold,    // u32 — late payments before demotion is triggered (default: 3)
+    GracePeriodSeconds,      // u64 — seconds after deadline during which late payments are accepted
 }
 
 // ── #330: Contribution Delegation ────────────────────────────────────────────


### PR DESCRIPTION
## Summary


### #353 — Time-Locked Staged Fund Release Schedule (escrow)

**Problem:** Escrows with vesting, grant, or installment use cases require funds released in time-locked tranches rather than all at once.

**Changes (`contracts/ahjoor-escrow/`):**
- New `ReleaseTranche { unlock_at: u64, amount: i128 }` struct
- `DataKey2::ReleaseSchedule(escrow_id)` and `DataKey2::ReleasedIndex(escrow_id)` storage keys
- `create_escrow_with_schedule(buyer, seller, arbiter, token, deadline, schedule)` — validates that all `unlock_at` values are in the future, all amounts are positive, and creates the escrow for the total sum
- `claim_scheduled_release(beneficiary, escrow_id)` — iterates from the current `ReleasedIndex`, transfers every tranche whose `unlock_at ≤ now`, updates the index; marks the escrow `Released` once all tranches are claimed
- `get_release_schedule()` and `get_released_index()` read helpers
- `ScheduledReleaseExecuted { escrow_id, tranche_index, amount, remaining_tranches }` event per claimed tranche

**Acceptance criteria met:**
- ✅ Beneficiary cannot claim a tranche before its timestamp
- ✅ Each tranche can only be claimed once (index advances past it)
- ✅ All tranches sum to the original escrow amount (validated on creation)
- ✅ Disputes on unclaimed tranches work naturally — escrow amount is the remaining unclaimed total

closes #353

---

### #354 — Cross-Token Invoice Settlement with Oracle Price Feed (payments)

**Problem:** Payers need to settle invoices in a different token than the invoiced currency, using live on-chain prices instead of stale manual rates.

**Changes (`contracts/ahjoor-payments/`):**
- `InvoiceOracleClient` trait (`get_price(base, quote) -> Option<i128>`, price scaled × 1_000_000)
- `CrossTokenSettlementRecord` struct storing settlement metadata
- `oracle_contract: Option<Address>` field added to `MultiTokenInvoice`
- New error variants: `SlippageExceeded`, `OracleNotConfigured`, `OraclePriceUnavailable`
- `create_invoice_with_oracle(…, oracle_contract: Option<Address>)` — oracle-aware invoice creation
- `pay_invoice_cross_token(invoice_id, payer, payment_token, payment_amount, max_slippage_bps)`:
  1. Validates `payment_token` is in the accepted list
  2. Queries oracle for the live `payment_token / base_currency` price
  3. Checks slippage: `|oracle_price - stored_rate| / stored_rate ≤ max_slippage_bps / 10_000`; rejects if exceeded
  4. Computes `amount_in_base` from oracle price, validates it against invoice balance
  5. Transfers `payment_amount` of `payment_token` from payer
  6. Stores `CrossTokenSettlementRecord` and emits `CrossTokenSettlement` event

**Acceptance criteria met:**
- ✅ Invoice in USDC can be settled with XLM within slippage tolerance
- ✅ Settlement rejected if oracle price deviation exceeds `max_slippage_bps`
- ✅ Oracle contract address validated during invoice creation (must be a valid address)

closes #354

---

### #355 — Configurable Abuse Score Exponential Decay (refund)

**Problem:** The abuse score accumulated indefinitely — a buyer with past violations was permanently penalised even after extended good behaviour.

**Changes (`contracts/ahjoor-refund/`):**
- `DataKey::AbuseScoreDecayPeriodLedgers` — configurable decay interval in ledgers (default: 10 000)
- `DataKey::AbuseScoreDecayFactorBps` — decay factor per period in basis points (default: 5 000 = halve)
- `load_abuse_record_with_decay()` — replaces hardcoded linear subtraction with:
  `effective_score = stored_score × (factor_bps / 10_000) ^ periods_elapsed`
  Computed in-memory; **no write on read-only queries**
- `persist_abuse_record_with_decay_event()` — used by all mutating paths; emits `AbuseScoreDecayed { buyer, old_score, new_score, periods_elapsed }` when decay reduced the score, then writes the updated record
- `set_abuse_score_decay_params(admin, period_ledgers, factor_bps)` — admin tunes both parameters without resetting existing scores
- `get_abuse_score_decay_period_ledgers()` and `get_abuse_score_decay_factor_bps()` getters

**Acceptance criteria met:**
- ✅ Score halves correctly after each decay period (default: every 10 000 ledgers)
- ✅ Score never decays below zero (`saturating_*` arithmetic throughout)
- ✅ Decay does not apply retroactively on read-only queries (no storage mutation in `get_customer_abuse_score`)
- ✅ Admin can update decay parameters without resetting existing scores

closes #355

---

### #356 — Penalty-Based Slot Demotion for Late ROSCA Contributors

**Problem:** Members who chronically contribute after the round deadline disrupt on-time members; there was no on-chain penalty for habitual tardiness.

**Changes (`contracts/ahjoor-rosca/`):**
- `DataKey3::LateContributionCount` — `Map<Address, u32>` tracking consecutive late payments per member
- `DataKey3::LateContribThreshold` — configurable demotion trigger (default: 3)
- `DataKey3::GracePeriodSeconds` — seconds after the soft deadline during which late contributions are still accepted (default: 0)
- `contribute()` modified to allow contributions during `(deadline, deadline + grace_period_seconds]`:
  - Late contributions increment `LateContributionCount` and apply −5 reputation
  - On-time contributions reset `LateContributionCount` to 0 and emit `LateCountReset`
- `finalize_round()` — after default tracking, checks each member's `LateContributionCount ≥ LateContribThreshold`; demotes matching members to the last position in `PayoutOrder`, emits `MemberDemoted { member, new_slot_index, late_count }`
- `configure_late_demotion(admin, late_threshold, grace_period_seconds)` — admin configures both parameters
- Read helpers: `get_late_contrib_threshold()`, `get_grace_period_seconds()`, `get_late_contribution_counts()`
- New events: `MemberDemoted { member, new_slot_index, late_count }` and `LateCountReset { member }`

**Acceptance criteria met:**
- ✅ Member is demoted after reaching the configured late threshold
- ✅ Demotion moves member to the last unfulfilled slot in the payout queue
- ✅ On-time members are unaffected by demotion reordering
- ✅ Demotion count resets if member pays on time for consecutive cycles

closes #353
closes #354
closes #355
closes #356

## Test plan

- [ ] `create_escrow_with_schedule` with 3 tranches; verify `claim_scheduled_release` respects timestamps and emits events
- [ ] `pay_invoice_cross_token` with oracle returning a price within and outside slippage tolerance
- [ ] Verify `get_customer_abuse_score` returns decayed score without writing; verify `AbuseScoreDecayed` emitted on next write
- [ ] ROSCA: contribute after deadline within grace period; verify late count increments; reach threshold and verify `MemberDemoted` with correct queue position

