### PR TITLE
feat: inspector reputation scoring, buyer trust tiers, and savings goal milestone rewards

### DIFF
--- a/contracts/ahjoor-escrow/src/events.rs
+++ b/contracts/ahjoor-escrow/src/events.rs
@@ -1318,6 +1318,73 @@ pub fn emit_release_condition_waived(env: &Env, escrow_id: u32) {
     );
 }
 
+// --- #272/#357: Inspector Events ---
+
+/// Event: Seller marked work complete; awaiting inspector (#272)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct SellerMarkedComplete {
+    pub escrow_id: u32,
+    pub seller: Address,
+}
+
+/// Event: Inspector replaced by mutual agreement (#272)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct InspectorReplaced {
+    pub escrow_id: u32,
+    pub old_inspector: Address,
+    pub new_inspector: Address,
+}
+
+/// Event: Inspection report submitted by inspector (#272)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct InspectionReportSubmitted {
+    pub escrow_id: u32,
+    pub inspector: Address,
+    pub approved: bool,
+    pub report_hash: BytesN<32>,
+}
+
+/// Event: Inspector reputation score updated (#357)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct InspectorScoreUpdated {
+    pub inspector: Address,
+    pub total_rulings: u32,
+    pub correct_rulings: u32,
+    pub accuracy_bps: u32,
+}
+
+pub fn emit_seller_marked_complete(e: &Env, escrow_id: u32, seller: Address) {
+    SellerMarkedComplete { escrow_id, seller }.publish(e);
+}
+
+pub fn emit_inspector_replaced(e: &Env, escrow_id: u32, old_inspector: Address, new_inspector: Address) {
+    InspectorReplaced { escrow_id, old_inspector, new_inspector }.publish(e);
+}
+
+pub fn emit_inspection_report_submitted(
+    e: &Env,
+    escrow_id: u32,
+    inspector: Address,
+    approved: bool,
+    report_hash: BytesN<32>,
+) {
+    InspectionReportSubmitted { escrow_id, inspector, approved, report_hash }.publish(e);
+}
+
+pub fn emit_inspector_score_updated(
+    e: &Env,
+    inspector: Address,
+    total_rulings: u32,
+    correct_rulings: u32,
+    accuracy_bps: u32,
+) {
+    InspectorScoreUpdated { inspector, total_rulings, correct_rulings, accuracy_bps }.publish(e);
+}
+
 // ── #332: Milestone BPS Events ────────────────────────────────────────────────
 
 pub fn emit_milestone_submitted(e: &Env, escrow_id: u32, milestone_index: u32, delivery_hash: BytesN<32>) {

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -433,6 +433,22 @@ pub enum DataKey2 {
     VetoOverrideWindow,
     /// #366: immutable reason hash stored by admin when overriding a veto
     VetoReasonHash(u32),
+    /// #357: inspector reputation score (inspector → InspectorScore)
+    InspectorScore(Address),
+    /// #357: minimum inspector accuracy in bps required for high-value escrows (default 0 = disabled)
+    MinInspectorScoreBps,
+    /// #357: escrow amount above which inspector score threshold is enforced (default 0 = disabled)
+    InspectorScoreValueThreshold,
+    /// #357: tracks whether the inspector ruling for an escrow has been appealed (escrow_id → bool)
+    InspectorRulingAppealed(u32),
+}
+
+/// #357: On-chain reputation record for an inspector.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InspectorScore {
+    pub total_rulings: u32,
+    pub correct_rulings: u32,
 }
 
 /// #353: A single time-locked tranche in a staged release schedule.
@@ -841,6 +857,10 @@ impl AhjoorEscrowContract {
     ) -> u32 {
         Self::require_not_paused(&env);
         buyer.require_auth();
+        // #357: Enforce inspector score threshold for high-value escrows
+        if let Some(ref insp) = inspector {
+            Self::require_inspector_score_ok(&env, insp, request.amount);
+        }
         let escrow_id = Self::create_escrow_core(&env, &buyer, request);
         if let Some(ref insp) = inspector {
             let mut escrow: Escrow = env
@@ -956,6 +976,149 @@ impl AhjoorEscrowContract {
     /// Get the inspector report for an escrow.
     pub fn get_inspector_report(env: Env, escrow_id: u32) -> Option<InspectorReport> {
         env.storage().persistent().get(&DataKey::InspectorReport(escrow_id))
+    }
+
+    // ─── #357: Inspector Reputation Scoring ─────────────────────────────────
+
+    /// Admin-configurable minimum inspector accuracy (bps) and value threshold.
+    /// Inspectors below min_score_bps are blocked from escrows above value_threshold.
+    /// Set value_threshold to 0 to disable gating entirely.
+    pub fn set_inspector_score_threshold(
+        env: Env,
+        admin: Address,
+        min_score_bps: u32,
+        value_threshold: i128,
+    ) {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage().instance().get(&DataKey::Admin).expect("Not initialized");
+        if admin != stored_admin { panic!("Only admin can set inspector score threshold"); }
+        if min_score_bps > 10_000 { panic!("min_score_bps must be <= 10000"); }
+        env.storage().instance().set(&DataKey2::MinInspectorScoreBps, &min_score_bps);
+        env.storage().instance().set(&DataKey2::InspectorScoreValueThreshold, &value_threshold);
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Returns the inspector's on-chain reputation score.
+    /// Returns (total_rulings, correct_rulings, accuracy_bps).
+    /// New inspectors with no rulings return (0, 0, 10_000) — neutral/full trust.
+    pub fn get_inspector_score(env: Env, inspector: Address) -> (u32, u32, u32) {
+        let score: InspectorScore = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::InspectorScore(inspector))
+            .unwrap_or(InspectorScore { total_rulings: 0, correct_rulings: 0 });
+        let accuracy_bps = if score.total_rulings == 0 {
+            10_000
+        } else {
+            (score.correct_rulings as u32 * 10_000) / score.total_rulings
+        };
+        (score.total_rulings, score.correct_rulings, accuracy_bps)
+    }
+
+    /// Admin-only: reverse a previous inspector ruling (e.g. overturned on appeal).
+    /// Decrements the inspector's correct_rulings and emits InspectorScoreUpdated.
+    /// Panics if the ruling was already appealed or no inspector was on the escrow.
+    pub fn appeal_inspector_ruling(env: Env, admin: Address, escrow_id: u32) {
+        Self::require_not_paused(&env);
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage().instance().get(&DataKey::Admin).expect("Not initialized");
+        if admin != stored_admin { panic!("Only admin can appeal inspector ruling"); }
+
+        // Ensure an inspector was involved
+        let escrow: Escrow = env
+            .storage().persistent().get(&DataKey::Escrow(escrow_id)).expect("Escrow not found");
+        let inspector = escrow.extensions.inspector.clone().expect("No inspector on this escrow");
+
+        // Prevent double-appeal
+        let already_appealed: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::InspectorRulingAppealed(escrow_id))
+            .unwrap_or(false);
+        if already_appealed { panic!("Inspector ruling already appealed for this escrow"); }
+
+        // Decrement correct_rulings (floor at 0)
+        let key = DataKey2::InspectorScore(inspector.clone());
+        let mut score: InspectorScore = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(InspectorScore { total_rulings: 1, correct_rulings: 1 });
+        if score.correct_rulings > 0 {
+            score.correct_rulings -= 1;
+        }
+        env.storage().persistent().set(&key, &score);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+
+        // Mark as appealed
+        env.storage().persistent().set(&DataKey2::InspectorRulingAppealed(escrow_id), &true);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::InspectorRulingAppealed(escrow_id),
+            PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT,
+        );
+
+        let accuracy_bps = if score.total_rulings == 0 {
+            10_000
+        } else {
+            (score.correct_rulings * 10_000) / score.total_rulings
+        };
+        events::emit_inspector_score_updated(&env, inspector, score.total_rulings, score.correct_rulings, accuracy_bps);
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Internal: record a ruling for an inspector (increment total + correct).
+    /// Initializes to (1, 1) on first ruling for a neutral starting score.
+    fn record_inspector_ruling(env: &Env, inspector: &Address, correct: bool) {
+        let key = DataKey2::InspectorScore(inspector.clone());
+        let mut score: InspectorScore = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(InspectorScore { total_rulings: 0, correct_rulings: 0 });
+
+        if score.total_rulings == 0 {
+            // First ruling: initialize to neutral (1 total, 1 correct)
+            score.total_rulings = 1;
+            score.correct_rulings = 1;
+        } else {
+            score.total_rulings = score.total_rulings.saturating_add(1);
+            if correct {
+                score.correct_rulings = score.correct_rulings.saturating_add(1);
+            }
+        }
+
+        env.storage().persistent().set(&key, &score);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+
+        let accuracy_bps = (score.correct_rulings * 10_000) / score.total_rulings;
+        events::emit_inspector_score_updated(env, inspector.clone(), score.total_rulings, score.correct_rulings, accuracy_bps);
+    }
+
+    /// Internal: check that the inspector meets the score threshold for a high-value escrow.
+    fn require_inspector_score_ok(env: &Env, inspector: &Address, amount: i128) {
+        let value_threshold: i128 = env
+            .storage().instance().get(&DataKey2::InspectorScoreValueThreshold).unwrap_or(0);
+        if value_threshold == 0 || amount <= value_threshold { return; }
+
+        let min_score_bps: u32 = env
+            .storage().instance().get(&DataKey2::MinInspectorScoreBps).unwrap_or(0);
+        if min_score_bps == 0 { return; }
+
+        let score: InspectorScore = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::InspectorScore(inspector.clone()))
+            .unwrap_or(InspectorScore { total_rulings: 0, correct_rulings: 0 });
+
+        // New inspectors (0 rulings) pass — they have not been disqualified yet
+        if score.total_rulings == 0 { return; }
+
+        let accuracy_bps = (score.correct_rulings * 10_000) / score.total_rulings;
+        if accuracy_bps < min_score_bps {
+            panic!("Inspector score below minimum threshold for high-value escrow");
+        }
     }
 
     fn create_escrow_core(env: &Env, buyer: &Address, request: EscrowCreateRequest) -> u32 {
@@ -2393,6 +2556,11 @@ impl AhjoorEscrowContract {
         let release_to_seller = buyer_percent == 0;
         events::emit_dispute_resolved(env, escrow_id, release_to_seller, arbiter.clone());
         events::emit_resolution_finalized(env, escrow_id, buyer_percent, arbiter);
+
+        // #357: Update inspector reputation score on each ruling
+        if let Some(inspector) = escrow.extensions.inspector.clone() {
+            Self::record_inspector_ruling(env, &inspector, true);
+        }
     }
 
     /// Returns true when an unresolved dispute has exceeded its timeout window.

--- a/contracts/ahjoor-escrow/src/test_inspector.rs
+++ b/contracts/ahjoor-escrow/src/test_inspector.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::Client as TokenClient,
     token::StellarAssetClient as TokenAdminClient,
-    Address, BytesN, Env, String,
+    Address, BytesN, Env, String, Vec,
 };
 
 fn setup_test_env() -> (
@@ -111,5 +111,113 @@ fn test_inspector_rejection_blocks_release() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.release_escrow(&buyer, &escrow_id);
     }));
+    assert!(result.is_err());
+}
+
+// ── #357: Inspector Reputation Scoring Tests ─────────────────────────────────
+
+fn make_request(env: &soroban_sdk::Env, seller: &Address, arbiter: &Address, token: &Address, amount: i128) -> crate::EscrowCreateRequest {
+    crate::EscrowCreateRequest {
+        seller: seller.clone(), arbiter: arbiter.clone(), amount,
+        token: token.clone(), deadline: env.ledger().timestamp() + 86400,
+        metadata_hash: None, sellers: soroban_sdk::Vec::new(env), auto_renew: false,
+        renewal_count: 0, buyer_inactivity_secs: 0, min_lock_until: None,
+        release_base: None, release_quote: None, release_comparison: None,
+        release_threshold_price: None, arbiter_fee_bps: None, dispute_default_winner: None,
+        auto_renew_config: None,
+    }
+}
+
+#[test]
+fn test_inspector_score_initialized_on_first_ruling() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    // No score yet → neutral (0, 0, 10_000)
+    let (total, correct, accuracy) = client.get_inspector_score(&inspector);
+    assert_eq!(total, 0);
+    assert_eq!(correct, 0);
+    assert_eq!(accuracy, 10_000);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let eid = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+    client.dispute_escrow(&buyer, &eid, &String::from_str(&env, "test"), &1000);
+    client.resolve_dispute(&arbiter, &eid, &50);
+
+    // First ruling: initialized to neutral (1, 1, 10_000)
+    let (total, correct, accuracy) = client.get_inspector_score(&inspector);
+    assert_eq!(total, 1);
+    assert_eq!(correct, 1);
+    assert_eq!(accuracy, 10_000);
+}
+
+#[test]
+fn test_inspector_score_increases_on_ruling() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    // Mint extra tokens for buyer
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&buyer, &5_000);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let e1 = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+    let e2 = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+
+    client.dispute_escrow(&buyer, &e1, &String::from_str(&env, "d"), &1000);
+    client.resolve_dispute(&arbiter, &e1, &0);
+
+    client.dispute_escrow(&buyer, &e2, &String::from_str(&env, "d"), &1000);
+    client.resolve_dispute(&arbiter, &e2, &0);
+
+    // Two rulings: first initializes to (1,1), second increments to (2,2)
+    let (total, correct, _accuracy) = client.get_inspector_score(&inspector);
+    assert_eq!(total, 2);
+    assert_eq!(correct, 2);
+}
+
+#[test]
+fn test_inspector_score_decreases_on_appeal() {
+    let (env, admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let eid = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+    client.dispute_escrow(&buyer, &eid, &String::from_str(&env, "d"), &1000);
+    client.resolve_dispute(&arbiter, &eid, &0);
+
+    // Score after ruling: (1, 1)
+    let (total_before, correct_before, _) = client.get_inspector_score(&inspector);
+    assert_eq!(total_before, 1);
+    assert_eq!(correct_before, 1);
+
+    // Admin appeals → correct_rulings decremented
+    client.appeal_inspector_ruling(&admin, &eid);
+
+    let (total_after, correct_after, accuracy_after) = client.get_inspector_score(&inspector);
+    assert_eq!(total_after, 1);
+    assert_eq!(correct_after, 0);
+    assert_eq!(accuracy_after, 0);
+}
+
+#[test]
+fn test_low_score_inspector_blocked_from_high_value_escrow() {
+    let (env, admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&buyer, &100_000);
+
+    // Create ruling + appeal → inspector score = 0/1 = 0 bps
+    let req = make_request(&env, &seller, &arbiter, &token, 500);
+    let e1 = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+    client.dispute_escrow(&buyer, &e1, &String::from_str(&env, "d"), &500);
+    client.resolve_dispute(&arbiter, &e1, &0);
+    client.appeal_inspector_ruling(&admin, &e1);
+
+    // Set threshold: min 5000 bps for escrows above 1000
+    client.set_inspector_score_threshold(&admin, &5_000u32, &1_000i128);
+
+    // High-value escrow with low-score inspector must be rejected
+    let hv_req = make_request(&env, &seller, &arbiter, &token, 5_000);
+    let result = client.try_create_escrow_with_inspector(&buyer, &hv_req, &Some(inspector.clone()));
     assert!(result.is_err());
 }

--- a/contracts/ahjoor-payments/src/events.rs
+++ b/contracts/ahjoor-payments/src/events.rs
@@ -1885,6 +1885,28 @@ pub fn emit_recurring_payment_cancelled(e: &soroban_sdk::Env, schedule_id: u32, 
     );
 }
 
+// ── #358: Buyer Trust Tier Events ────────────────────────────────────────────
+
+/// Event: Merchant updated a buyer's trust tier (#358)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BuyerTierUpdated {
+    pub merchant: Address,
+    pub buyer: Address,
+    pub old_tier: u32,
+    pub new_tier: u32,
+}
+
+pub fn emit_buyer_tier_updated(
+    e: &Env,
+    merchant: Address,
+    buyer: Address,
+    old_tier: u32,
+    new_tier: u32,
+) {
+    BuyerTierUpdated { merchant, buyer, old_tier, new_tier }.publish(e);
+}
+
 // ── #367: Dynamic Settlement Fee Tiers ───────────────────────────────────────
 
 /// Event: Fee tier applied during merchant settlement (#367)

--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -219,6 +219,16 @@ pub struct SpendLimit {
     pub window_seconds: u64,
 }
 
+/// #358: Trust tier for a buyer as assigned by the merchant.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BuyerTrustTierLevel {
+    New = 0,
+    Standard = 1,
+    Trusted = 2,
+    VIP = 3,
+}
+
 /// Tracks cumulative spend within the current rolling window (#235).
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -917,6 +927,10 @@ pub enum DataKey2 {
     RecurringSchedule(u32),
     /// #367: 30-day rolling settled volume record per merchant
     MerchantSettlementVolume(Address),
+    /// #358: buyer trust tier assigned by merchant (merchant, buyer) → BuyerTrustTierLevel
+    BuyerTrustTier(Address, Address),
+    /// #358: per-tier spending limit (merchant, tier_value as u32) → SpendLimit
+    TierSpendingLimit(Address, u32),
 }
 
 mod events;
@@ -7463,6 +7477,68 @@ impl AhjoorPaymentsContract {
             .get(&DataKey2::DefaultSpendLimit(merchant))
     }
 
+    // ─── #358: Buyer Trust Tier System ───────────────────────────────────────
+
+    /// Merchant assigns a trust tier to a buyer (New/Standard/Trusted/VIP).
+    /// Only the merchant may call this.
+    pub fn set_buyer_tier(
+        env: Env,
+        merchant: Address,
+        buyer: Address,
+        tier: BuyerTrustTierLevel,
+    ) {
+        Self::require_not_paused(&env);
+        merchant.require_auth();
+        let key = DataKey2::BuyerTrustTier(merchant.clone(), buyer.clone());
+        let old_tier: u32 = env
+            .storage()
+            .persistent()
+            .get::<_, BuyerTrustTierLevel>(&key)
+            .map(|t| t as u32)
+            .unwrap_or(BuyerTrustTierLevel::New as u32);
+        env.storage().persistent().set(&key, &tier);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        events::emit_buyer_tier_updated(&env, merchant, buyer, old_tier, tier as u32);
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Returns the trust tier assigned to a buyer by a specific merchant.
+    pub fn get_buyer_tier(env: Env, merchant: Address, buyer: Address) -> BuyerTrustTierLevel {
+        env.storage()
+            .persistent()
+            .get(&DataKey2::BuyerTrustTier(merchant, buyer))
+            .unwrap_or(BuyerTrustTierLevel::New)
+    }
+
+    /// Merchant sets the spending limit for a specific trust tier.
+    /// tier_value: 0=New, 1=Standard, 2=Trusted, 3=VIP.
+    pub fn set_tier_spending_limit(
+        env: Env,
+        merchant: Address,
+        tier: BuyerTrustTierLevel,
+        amount: i128,
+        window_seconds: u64,
+    ) {
+        Self::require_not_paused(&env);
+        merchant.require_auth();
+        if amount <= 0 { panic!("Tier spend limit amount must be positive"); }
+        if window_seconds == 0 { panic!("Window seconds must be positive"); }
+        let key = DataKey2::TierSpendingLimit(merchant.clone(), tier as u32);
+        let limit = SpendLimit { amount, window_seconds };
+        env.storage().persistent().set(&key, &limit);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Returns the spending limit configured for a trust tier by a merchant, if any.
+    pub fn get_tier_spending_limit(
+        env: Env,
+        merchant: Address,
+        tier: BuyerTrustTierLevel,
+    ) -> Option<SpendLimit> {
+        env.storage().persistent().get(&DataKey2::TierSpendingLimit(merchant, tier as u32))
+    }
+
     /// Check and update the customer spend window. Panics with CustomerSpendLimitExceeded if cap would be breached.
     fn check_and_update_customer_spend_limit(
         env: &Env,
@@ -7470,14 +7546,22 @@ impl AhjoorPaymentsContract {
         customer: &Address,
         amount: i128,
     ) {
-        // Individual override takes priority over default
+        // Priority: per-customer override → tier-based limit → global default (#358)
         let limit_opt: Option<SpendLimit> = env
             .storage()
             .persistent()
-            .get(&DataKey2::CustomerSpendLimit(
-                merchant.clone(),
-                customer.clone(),
-            ))
+            .get(&DataKey2::CustomerSpendLimit(merchant.clone(), customer.clone()))
+            .or_else(|| {
+                // #358: check tier-based limit
+                let tier: BuyerTrustTierLevel = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey2::BuyerTrustTier(merchant.clone(), customer.clone()))
+                    .unwrap_or(BuyerTrustTierLevel::New);
+                env.storage()
+                    .persistent()
+                    .get(&DataKey2::TierSpendingLimit(merchant.clone(), tier as u32))
+            })
             .or_else(|| {
                 env.storage()
                     .persistent()
@@ -9159,5 +9243,7 @@ mod test_referral;
 mod test_retry_queue;
 #[cfg(test)]
 mod test_spending_limit;
+#[cfg(test)]
+mod test_buyer_trust_tier;
 
 pub use events::*;

--- a/contracts/ahjoor-payments/src/test_buyer_trust_tier.rs
+++ b/contracts/ahjoor-payments/src/test_buyer_trust_tier.rs
@@ -1,0 +1,129 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup<'a>() -> (
+    Env,
+    AhjoorPaymentsContractClient<'a>,
+    Address,
+    Address,
+    Address,
+    Address,
+    TokenAdminClient<'a>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AhjoorPaymentsContract, ());
+    let client = AhjoorPaymentsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let tac = TokenAdminClient::new(&env, &token_addr);
+
+    client.initialize(&admin, &admin, &0u32);
+    client.set_min_collateral(&0i128);
+    client.approve_merchant(&merchant);
+    tac.mint(&buyer, &100_000);
+
+    (env, client, admin, merchant, buyer, token_addr, tac)
+}
+
+#[test]
+fn test_set_and_get_buyer_tier() {
+    let (env, client, _admin, merchant, buyer, _token, _tac) = setup();
+
+    // Default tier is New
+    assert_eq!(client.get_buyer_tier(&merchant, &buyer), BuyerTrustTierLevel::New);
+
+    // Set to Trusted
+    client.set_buyer_tier(&merchant, &buyer, &BuyerTrustTierLevel::Trusted);
+    assert_eq!(client.get_buyer_tier(&merchant, &buyer), BuyerTrustTierLevel::Trusted);
+
+    // Upgrade to VIP
+    client.set_buyer_tier(&merchant, &buyer, &BuyerTrustTierLevel::VIP);
+    assert_eq!(client.get_buyer_tier(&merchant, &buyer), BuyerTrustTierLevel::VIP);
+}
+
+#[test]
+fn test_tier_downgrade_takes_effect_immediately() {
+    let (env, client, _admin, merchant, buyer, token, _tac) = setup();
+
+    // Set VIP tier with high limit
+    client.set_buyer_tier(&merchant, &buyer, &BuyerTrustTierLevel::VIP);
+    client.set_tier_spending_limit(&merchant, &BuyerTrustTierLevel::VIP, &50_000i128, &3600u64);
+
+    // Payment succeeds under VIP limit
+    let pid = client.create_payment(&buyer, &merchant, &10_000, &token, &None, &None, &None);
+    client.complete_payment(&pid);
+
+    // Downgrade to New (strict limit)
+    client.set_buyer_tier(&merchant, &buyer, &BuyerTrustTierLevel::New);
+    client.set_tier_spending_limit(&merchant, &BuyerTrustTierLevel::New, &100i128, &3600u64);
+
+    // New payment with downgraded tier is rejected
+    let pid2 = client.create_payment(&buyer, &merchant, &500, &token, &None, &None, &None);
+    let result = client.try_complete_payment(&pid2);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_tier_limit_falls_back_to_global_when_unset() {
+    let (env, client, _admin, merchant, buyer, token, _tac) = setup();
+
+    // Set buyer tier but no tier-specific limit
+    client.set_buyer_tier(&merchant, &buyer, &BuyerTrustTierLevel::Trusted);
+
+    // Set global default limit
+    client.set_default_spend_limit(&merchant, &200i128, &3600u64);
+
+    // Payment exceeding global default should fail
+    let pid = client.create_payment(&buyer, &merchant, &300, &token, &None, &None, &None);
+    let result = client.try_complete_payment(&pid);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_per_customer_override_takes_priority_over_tier() {
+    let (env, client, _admin, merchant, buyer, token, _tac) = setup();
+
+    // Set Trusted tier with low limit
+    client.set_buyer_tier(&merchant, &buyer, &BuyerTrustTierLevel::Trusted);
+    client.set_tier_spending_limit(&merchant, &BuyerTrustTierLevel::Trusted, &100i128, &3600u64);
+
+    // Set per-customer override with high limit
+    client.set_customer_spend_limit(&merchant, &buyer, &50_000i128, &3600u64);
+
+    // Payment within per-customer override should succeed
+    let pid = client.create_payment(&buyer, &merchant, &10_000, &token, &None, &None, &None);
+    client.complete_payment(&pid);
+    assert_eq!(client.get_payment(&pid).status, PaymentStatus::Completed);
+}
+
+#[test]
+fn test_each_tier_has_independent_limit() {
+    let (env, client, _admin, merchant, buyer, token, _tac) = setup();
+    let buyer2 = Address::generate(&env);
+    let tac = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    tac.mint(&buyer2, &100_000);
+
+    // Set different limits per tier
+    client.set_tier_spending_limit(&merchant, &BuyerTrustTierLevel::New, &100i128, &3600u64);
+    client.set_tier_spending_limit(&merchant, &BuyerTrustTierLevel::Trusted, &10_000i128, &3600u64);
+
+    // buyer → New tier, buyer2 → Trusted tier
+    client.set_buyer_tier(&merchant, &buyer, &BuyerTrustTierLevel::New);
+    client.set_buyer_tier(&merchant, &buyer2, &BuyerTrustTierLevel::Trusted);
+
+    // New-tier buyer fails on large payment
+    let p1 = client.create_payment(&buyer, &merchant, &500, &token, &None, &None, &None);
+    assert!(client.try_complete_payment(&p1).is_err());
+
+    // Trusted-tier buyer succeeds on same payment
+    let p2 = client.create_payment(&buyer2, &merchant, &500, &token, &None, &None, &None);
+    client.complete_payment(&p2);
+    assert_eq!(client.get_payment(&p2).status, PaymentStatus::Completed);
+}

--- a/contracts/ahjoor-rosca/src/events.rs
+++ b/contracts/ahjoor-rosca/src/events.rs
@@ -1657,3 +1657,25 @@ pub fn emit_snapshot_created(e: &Env, group_id: u32, cycle_number: u32, snapshot
     SnapshotCreated { group_id, cycle_number, snapshot_hash }.publish(e);
 }
 
+// ── #359: Savings Goal Milestone Rewards ─────────────────────────────────────
+
+/// Event: Member reached a savings goal milestone and received a reward (#359)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MilestoneReached {
+    pub group_id: u32,
+    pub member: Address,
+    pub milestone_pct: u32,
+    pub reward_amount: i128,
+}
+
+pub fn emit_milestone_reached(
+    e: &Env,
+    group_id: u32,
+    member: Address,
+    milestone_pct: u32,
+    reward_amount: i128,
+) {
+    MilestoneReached { group_id, member, milestone_pct, reward_amount }.publish(e);
+}
+

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -5,13 +5,13 @@ use soroban_sdk::{
 use ahjoor_token_whitelist::TokenWhitelistClient;
 
 // Instance storage: config, counters, and active round state (bounded, shared TTL)
-const INSTANCE_LIFETIME_THRESHOLD: u32 = 100_000;
-const INSTANCE_BUMP_AMOUNT: u32 = 120_000;
+pub(crate) const INSTANCE_LIFETIME_THRESHOLD: u32 = 100_000;
+pub(crate) const INSTANCE_BUMP_AMOUNT: u32 = 120_000;
 
 // Persistent storage: RoundHistory (grows by one record per round — unbounded)
 // Each write extends its own TTL independently of the instance.
-const PERSISTENT_LIFETIME_THRESHOLD: u32 = 100_000;
-const PERSISTENT_BUMP_AMOUNT: u32 = 120_000;
+pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 100_000;
+pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 120_000;
 
 // Temporary storage: ExitRequests (in-progress, pending admin approval — short-lived)
 // Auto-expires if not acted upon; no long-term retention needed.
@@ -8692,6 +8692,83 @@ impl AhjoorContract {
             .unwrap_or(Map::new(&env))
     }
 
+    // ── #359: Savings Goal Milestone Reward Distribution ─────────────────────
+
+    /// Admin funds the savings goal reward pool. Tokens are transferred from admin
+    /// to the contract and credited to the shared reward pool.
+    pub fn fund_savings_reward_pool(env: Env, admin: Address, amount: i128) {
+        internals::check_not_paused(&env);
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage().instance().get(&DataKey::Admin).expect("Not initialized");
+        if admin != stored_admin { panic!("Only admin can fund the savings reward pool"); }
+        if amount <= 0 { panic!("Amount must be positive"); }
+
+        let token_addr: Address = env.storage().instance().get(&DataKey::Token).expect("Token not set");
+        let client = token::Client::new(&env, &token_addr);
+        client.transfer(&admin, &env.current_contract_address(), &amount);
+
+        let pool: i128 = env.storage().instance().get(&DataKey::RewardPool).unwrap_or(0);
+        env.storage().instance().set(&DataKey::RewardPool, &(pool + amount));
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Create a new savings goal for a group member.
+    pub fn create_savings_goal(
+        env: Env,
+        member: Address,
+        group_id: u32,
+        name: String,
+        description: String,
+        target_amount: i128,
+        token: Address,
+        target_date: u64,
+        priority: u32,
+        category: String,
+        metadata: Map<String, String>,
+    ) -> u32 {
+        savings_goal_tracking_impl::SavingsGoalTrackingImpl::create_goal(
+            &env, member, group_id, name, description, target_amount, token,
+            target_date, priority, category, metadata,
+        )
+    }
+
+    /// Add milestones (with optional reward_bps) to a savings goal.
+    pub fn add_savings_goal_milestones(
+        env: Env,
+        goal_id: u32,
+        milestones: Vec<savings_goal_tracking::Milestone>,
+    ) {
+        savings_goal_tracking_impl::SavingsGoalTrackingImpl::add_milestones(&env, goal_id, milestones);
+    }
+
+    /// Contribute to a savings goal. Milestone thresholds are checked and token rewards
+    /// distributed from the reward pool if any reward_bps milestones are newly crossed.
+    pub fn contribute_to_savings_goal(
+        env: Env,
+        goal_id: u32,
+        member: Address,
+        amount: i128,
+        source: String,
+    ) -> savings_goal_tracking::GoalContribution {
+        savings_goal_tracking_impl::SavingsGoalTrackingImpl::contribute_to_goal(
+            &env, goal_id, member, amount, source,
+        )
+    }
+
+    /// Returns the savings goal reward pool balance.
+    pub fn get_savings_reward_pool(env: Env) -> i128 {
+        env.storage().instance().get(&DataKey::RewardPool).unwrap_or(0)
+    }
+
+    /// Returns the bitmask of claimed milestones for a (goal_id, member) pair.
+    pub fn get_savings_milestones_claimed(env: Env, goal_id: u32, member: Address) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey3::SavingsMilestonesClaimed(goal_id, member))
+            .unwrap_or(0u64)
+    }
+
 }
 
 mod test;
@@ -8705,4 +8782,6 @@ mod test_cosigner_guarantee;
 mod test_proxy;
 mod test_group_freeze;
 mod test_snapshot;
+#[cfg(test)]
+mod test_savings_milestone_rewards;
 pub use events::*;

--- a/contracts/ahjoor-rosca/src/savings_goal_tracking.rs
+++ b/contracts/ahjoor-rosca/src/savings_goal_tracking.rs
@@ -61,6 +61,8 @@ pub struct Milestone {
     pub reward_value: i128,
     /// Celebration event
     pub celebration_event: String,
+    /// #359: On-chain token reward as basis points of contribution amount (0 = no token reward)
+    pub reward_bps: u32,
 }
 
 #[contracttype]

--- a/contracts/ahjoor-rosca/src/savings_goal_tracking_impl.rs
+++ b/contracts/ahjoor-rosca/src/savings_goal_tracking_impl.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{
     BytesN, Env, Map, String, Symbol, Vec,
 };
 use crate::savings_goal_tracking::*;
+use crate::types::{DataKey, DataKey3};
 
 // Storage keys
 const GOAL_COUNTER_KEY: &str = "goal_counter";
@@ -229,7 +230,90 @@ impl SavingsGoalTrackingImpl {
             .instance()
             .set(&Symbol::new(env, CONTRIBUTION_COUNTER_KEY), &next_contribution_id);
 
+        // #359: Check milestones with reward_bps > 0 and distribute rewards
+        Self::check_and_distribute_milestone_rewards(env, goal_id, &goal, amount);
+
         contribution
+    }
+
+    /// #359: Check whether any milestones have been newly crossed and transfer rewards.
+    /// Rewards are transferred from the SavingsRewardPool. Pool depletion skips reward transfer
+    /// without reverting.
+    pub fn check_and_distribute_milestone_rewards(
+        env: &Env,
+        goal_id: u32,
+        goal: &SavingsGoal,
+        contribution_amount: i128,
+    ) {
+        if goal.target_amount == 0 { return; }
+        let pct_now = ((goal.current_amount * 100) / goal.target_amount) as u32;
+
+        for milestone in goal.milestones.iter() {
+            if milestone.reward_bps == 0 { continue; }
+
+            // Skip milestones already claimed (bitmask check)
+            let bitmask_key = DataKey3::SavingsMilestonesClaimed(goal_id, goal.member.clone());
+            let bitmask: u64 = env
+                .storage()
+                .persistent()
+                .get(&bitmask_key)
+                .unwrap_or(0u64);
+
+            let bit = 1u64 << (milestone.milestone_id as u64 % 64);
+            if bitmask & bit != 0 { continue; }
+
+            // Check if threshold newly crossed
+            let pct_before = if contribution_amount >= goal.current_amount {
+                0u32
+            } else {
+                (((goal.current_amount - contribution_amount) * 100) / goal.target_amount) as u32
+            };
+
+            if pct_before < milestone.percentage && pct_now >= milestone.percentage {
+                let reward_amount = (contribution_amount * milestone.reward_bps as i128) / 10_000;
+                if reward_amount > 0 {
+                    // Transfer from reward pool if available
+                    let pool: i128 = env
+                        .storage()
+                        .instance()
+                        .get(&DataKey::RewardPool)
+                        .unwrap_or(0i128);
+
+                    if pool >= reward_amount {
+                        let token_addr: Address = env
+                            .storage()
+                            .instance()
+                            .get(&DataKey::Token)
+                            .expect("Token not set");
+                        let client = token::Client::new(env, &token_addr);
+                        client.transfer(
+                            &env.current_contract_address(),
+                            &goal.member,
+                            &reward_amount,
+                        );
+                        env.storage().instance().set(&DataKey::RewardPool, &(pool - reward_amount));
+
+                        crate::events::emit_milestone_reached(
+                            env,
+                            goal.group_id,
+                            goal.member.clone(),
+                            milestone.percentage,
+                            reward_amount,
+                        );
+                    }
+                    // If pool depleted: skip reward but mark milestone as claimed to avoid loops
+                }
+
+                // Mark milestone as claimed in bitmask
+                let new_bitmask = bitmask | bit;
+                env.storage().persistent().set(&bitmask_key, &new_bitmask);
+                env.storage().persistent().extend_ttl(
+                    &bitmask_key,
+                    crate::PERSISTENT_LIFETIME_THRESHOLD,
+                    crate::PERSISTENT_BUMP_AMOUNT,
+                );
+            }
+        }
     }
 
     /// Get goal details

--- a/contracts/ahjoor-rosca/src/test_savings_milestone_rewards.rs
+++ b/contracts/ahjoor-rosca/src/test_savings_milestone_rewards.rs
@@ -1,0 +1,240 @@
+#![cfg(test)]
+use super::*;
+use crate::savings_goal_tracking::{GoalStatus, Milestone, RewardType};
+use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
+use soroban_sdk::{testutils::Address as _, Address, Env, Map, String, Vec};
+
+fn setup_rosca<'a>() -> (
+    Env,
+    AhjoorContractClient<'a>,
+    Address,
+    Address,
+    Address,
+    TokenAdminClient<'a>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AhjoorContract, ());
+    let client = AhjoorContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let member = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let tac = TokenAdminClient::new(&env, &token_addr);
+
+    tac.mint(&admin, &1_000_000);
+    tac.mint(&member, &1_000_000);
+
+    let mut members = Vec::new(&env);
+    members.push_back(member.clone());
+
+    client.init(
+        &admin,
+        &members,
+        &100i128,
+        &token_addr,
+        &3600u64,
+        &RoscaConfig {
+            strategy: PayoutStrategy::RoundRobin,
+            custom_order: None,
+            penalty_amount: 0,
+            exit_penalty_bps: 0,
+            collective_goal: None,
+            member_goals: None,
+            fee_bps: 0,
+            fee_recipient: None,
+            max_defaults: 3,
+            grace_period_ledgers: 0,
+            use_timestamp_schedule: false,
+            round_duration_seconds: 0,
+            max_members: None,
+            skip_fee: 0,
+            max_skips_per_cycle: 0,
+            voting_mode: VotingMode::Equal,
+            late_fee_bps: 0,
+            grace_period_seconds: 0,
+            auction_enabled: false,
+            auction_window_ledgers: 0,
+            randomize_payout_order: false,
+            reserve_enabled: false,
+            reserve_contribution_bps: 0,
+        },
+        &None,
+    );
+
+    (env, client, admin, member, token_addr, tac)
+}
+
+fn make_milestone(env: &Env, id: u32, pct: u32, reward_bps: u32) -> Milestone {
+    Milestone {
+        milestone_id: id,
+        percentage: pct,
+        amount: 0,
+        name: String::from_str(env, "test"),
+        description: String::from_str(env, ""),
+        reward_type: RewardType::Bonus,
+        reward_value: 0,
+        celebration_event: String::from_str(env, ""),
+        reward_bps,
+    }
+}
+
+#[test]
+fn test_milestone_reward_distributed_once() {
+    let (env, client, admin, member, token_addr, tac) = setup_rosca();
+
+    // Fund the reward pool
+    client.fund_savings_reward_pool(&admin, &10_000i128);
+    assert_eq!(client.get_savings_reward_pool(), 10_000i128);
+
+    // Create a savings goal
+    let goal_id = client.create_savings_goal(
+        &member,
+        &1u32,
+        &String::from_str(&env, "vacation"),
+        &String::from_str(&env, ""),
+        &1_000i128,
+        &token_addr,
+        &(env.ledger().timestamp() + 86400),
+        &1u32,
+        &String::from_str(&env, "travel"),
+        &Map::new(&env),
+    );
+
+    // Add a 25% milestone with 1000 bps reward (10% of contribution)
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(make_milestone(&env, 1, 25, 1_000));
+    client.add_savings_goal_milestones(&goal_id, &milestones);
+
+    let member_balance_before = soroban_sdk::token::Client::new(&env, &token_addr).balance(&member);
+
+    // Contribute 250 (25% of 1000) — should cross the milestone
+    client.contribute_to_savings_goal(
+        &goal_id,
+        &member,
+        &250i128,
+        &String::from_str(&env, "manual"),
+    );
+
+    let member_balance_after = soroban_sdk::token::Client::new(&env, &token_addr).balance(&member);
+
+    // contribute_to_savings_goal tracks the amount but doesn't debit the wallet;
+    // only the reward transfer (pool → member) changes the balance.
+    // Reward = 250 * 1000 / 10000 = 25
+    assert_eq!(member_balance_after - member_balance_before, 25);
+
+    // Pool reduced by 25
+    assert_eq!(client.get_savings_reward_pool(), 10_000 - 25);
+
+    // Bitmask bit 1 should be set
+    let bitmask = client.get_savings_milestones_claimed(&goal_id, &member);
+    assert_eq!(bitmask & 2, 2); // bit for milestone_id=1
+}
+
+#[test]
+fn test_milestone_reward_distributed_exactly_once() {
+    let (env, client, admin, member, token_addr, _tac) = setup_rosca();
+
+    client.fund_savings_reward_pool(&admin, &10_000i128);
+
+    let goal_id = client.create_savings_goal(
+        &member, &1u32,
+        &String::from_str(&env, "goal"),
+        &String::from_str(&env, ""),
+        &1_000i128, &token_addr,
+        &(env.ledger().timestamp() + 86400),
+        &1u32, &String::from_str(&env, "test"),
+        &Map::new(&env),
+    );
+
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(make_milestone(&env, 1, 25, 1_000));
+    client.add_savings_goal_milestones(&goal_id, &milestones);
+
+    // First contribution crosses the milestone
+    client.contribute_to_savings_goal(&goal_id, &member, &250i128, &String::from_str(&env, "m"));
+    let pool_after_first = client.get_savings_reward_pool();
+
+    // Second contribution — milestone already claimed, no reward
+    client.contribute_to_savings_goal(&goal_id, &member, &100i128, &String::from_str(&env, "m"));
+    let pool_after_second = client.get_savings_reward_pool();
+
+    assert_eq!(pool_after_first, pool_after_second); // No additional reward
+}
+
+#[test]
+fn test_reward_pool_depletion_does_not_revert() {
+    let (env, client, admin, member, token_addr, _tac) = setup_rosca();
+
+    // Fund pool with only 1 token (less than reward would be)
+    client.fund_savings_reward_pool(&admin, &1i128);
+
+    let goal_id = client.create_savings_goal(
+        &member, &1u32,
+        &String::from_str(&env, "goal"),
+        &String::from_str(&env, ""),
+        &1_000i128, &token_addr,
+        &(env.ledger().timestamp() + 86400),
+        &1u32, &String::from_str(&env, "test"),
+        &Map::new(&env),
+    );
+
+    // 1000 bps of 250 = 25, but pool only has 1 — gracefully skips
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(make_milestone(&env, 1, 25, 1_000));
+    client.add_savings_goal_milestones(&goal_id, &milestones);
+
+    // Should not revert even though pool < reward
+    client.contribute_to_savings_goal(&goal_id, &member, &250i128, &String::from_str(&env, "m"));
+    // milestone is still claimed in bitmask
+    let bitmask = client.get_savings_milestones_claimed(&goal_id, &member);
+    assert_eq!(bitmask & 2, 2);
+}
+
+#[test]
+fn test_multiple_milestones_crossed_in_one_contribution() {
+    let (env, client, admin, member, token_addr, _tac) = setup_rosca();
+
+    client.fund_savings_reward_pool(&admin, &100_000i128);
+
+    let goal_id = client.create_savings_goal(
+        &member, &1u32,
+        &String::from_str(&env, "goal"),
+        &String::from_str(&env, ""),
+        &1_000i128, &token_addr,
+        &(env.ledger().timestamp() + 86400),
+        &1u32, &String::from_str(&env, "test"),
+        &Map::new(&env),
+    );
+
+    let mut milestones = Vec::new(&env);
+    milestones.push_back(make_milestone(&env, 1, 25, 500));  // 5% reward
+    milestones.push_back(make_milestone(&env, 2, 50, 500));  // 5% reward
+    client.add_savings_goal_milestones(&goal_id, &milestones);
+
+    // Single contribution of 600 crosses both 25% and 50% thresholds
+    let pool_before = client.get_savings_reward_pool();
+    client.contribute_to_savings_goal(&goal_id, &member, &600i128, &String::from_str(&env, "m"));
+    let pool_after = client.get_savings_reward_pool();
+
+    // Both milestones trigger: each gives 600 * 500 / 10000 = 30
+    assert_eq!(pool_before - pool_after, 60);
+
+    let bitmask = client.get_savings_milestones_claimed(&goal_id, &member);
+    assert_eq!(bitmask & 2, 2); // milestone_id=1
+    assert_eq!(bitmask & 4, 4); // milestone_id=2
+}
+
+#[test]
+fn test_admin_can_fund_reward_pool_post_init() {
+    let (env, client, admin, _member, _token_addr, _tac) = setup_rosca();
+
+    assert_eq!(client.get_savings_reward_pool(), 0);
+
+    client.fund_savings_reward_pool(&admin, &5_000i128);
+    assert_eq!(client.get_savings_reward_pool(), 5_000i128);
+
+    client.fund_savings_reward_pool(&admin, &3_000i128);
+    assert_eq!(client.get_savings_reward_pool(), 8_000i128);
+}

--- a/contracts/ahjoor-rosca/src/types.rs
+++ b/contracts/ahjoor-rosca/src/types.rs
@@ -345,6 +345,10 @@ pub enum DataKey3 {
     LateContributionCount,   // Map<Address, u32> — consecutive late payment count per member
     LateContribThreshold,    // u32 — late payments before demotion is triggered (default: 3)
     GracePeriodSeconds,      // u64 — seconds after deadline during which late payments are accepted
+    // #359: Savings goal milestone reward pool
+    SavingsRewardPool,       // i128 — token balance held for savings goal milestone rewards
+    // #359: Per-member milestone claim bitmask (goal_id, member) → u64 bitmask
+    SavingsMilestonesClaimed(u32, Address), // (goal_id, member) → u64
 }
 
 // ── #330: Contribution Delegation ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#357 (escrow)**: Inspector reputation scoring — tracks `(total_rulings, correct_rulings)` per inspector on-chain; score updated after every dispute resolution involving an inspector; `appeal_inspector_ruling(admin, escrow_id)` decrements `correct_rulings` on reversal; low-score inspectors blocked from high-value escrow assignments via admin-configurable `MinInspectorScoreBps` + `InspectorScoreValueThreshold`; `get_inspector_score` returns accuracy in bps
- **#358 (payments)**: Buyer trust tier system — `BuyerTrustTierLevel` enum (New/Standard/Trusted/VIP); merchant assigns tiers via `set_buyer_tier`; independent spending limits per tier via `set_tier_spending_limit`; priority chain enforced: per-customer override → tier limit → global default; `BuyerTierUpdated` event; tier downgrade takes effect immediately on the next transaction
- **#359 (rosca)**: Savings goal milestone rewards — `reward_bps` on `Milestone` enables on-chain token transfer from reward pool when percentage threshold is crossed; per-member bitmask prevents double-payment; pool depletion gracefully skips reward without reverting; `fund_savings_reward_pool` for post-init funding by admin; `MilestoneReached` event emitted per crossing

## Test plan

- [ ] `test_inspector_score_initialized_on_first_ruling` — neutral (1,1) on first ruling
- [ ] `test_inspector_score_increases_on_ruling` — increments per resolved dispute
- [ ] `test_inspector_score_decreases_on_appeal` — admin appeal decrements correct_rulings
- [ ] `test_low_score_inspector_blocked_from_high_value_escrow` — assignment gating enforced
- [ ] `test_set_and_get_buyer_tier` — tier CRUD works
- [ ] `test_tier_downgrade_takes_effect_immediately` — downgrade blocks next transaction
- [ ] `test_tier_limit_falls_back_to_global_when_unset` — fallback chain works
- [ ] `test_per_customer_override_takes_priority_over_tier` — override wins
- [ ] `test_each_tier_has_independent_limit` — tier limits are isolated
- [ ] `test_milestone_reward_distributed_once` — reward paid exactly once per milestone
- [ ] `test_reward_pool_depletion_does_not_revert` — graceful handling on empty pool
- [ ] `test_multiple_milestones_crossed_in_one_contribution` — bulk crossing works
- [ ] `test_admin_can_fund_reward_pool_post_init` — admin funding post-initialization

closes #357
closes #358
closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)