### PR TITLE
multi token invoice

### DIFF
--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -981,6 +981,8 @@ pub enum DataKey3 {
     NotificationKeyHistory(Address),
     /// #377: notification key rotation config
     NotificationKeyRotationConfig,
+    /// Slippage tolerance for multi-token dynamic payments (merchant) -> u32
+    SlippageToleranceBps(Address),
 }
 
 mod events;
@@ -2591,6 +2593,26 @@ impl AhjoorPaymentsContract {
 
         Self::add_customer_payment(&env, &customer, payment_id);
 
+        // Store DynamicPayment so settle_dynamic_payment_if_needed can find it
+        let dynamic = DynamicPayment {
+            payment_id,
+            fiat_amount: amount_usdc,
+            fiat_currency: Symbol::new(&env, "USDC"),
+            oracle_address: oracle_addr,
+            token: payment_token.clone(),
+            slippage_bps,
+            creation_rate: price_data.price,
+            expiry: payment.expires_at,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey2::DynamicPayment(payment_id), &dynamic);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::DynamicPayment(payment_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
         // Emit SlippageToleranceApplied event (#135)
         events::emit_slippage_tolerance_applied(
             &env,
@@ -2640,6 +2662,12 @@ impl AhjoorPaymentsContract {
     }
 
     // --- Admin ---
+
+    pub fn set_merchant_slippage_tolerance(env: Env, merchant: Address, bps: u32) {
+        Self::require_not_paused(&env);
+        merchant.require_auth();
+        env.storage().persistent().set(&DataKey3::SlippageToleranceBps(merchant), &bps);
+    }
 
     pub fn set_max_batch_size(env: Env, new_size: u32) {
         Self::require_not_paused(&env);
@@ -6050,6 +6078,40 @@ impl AhjoorPaymentsContract {
             if dp.expiry > 0 && now > dp.expiry {
                 panic_with_error!(env, Error::DynamicPaymentExpired);
             }
+
+            // Fetch the current price from the oracle
+            let oracle_client = oracle::OracleClient::new(env, &dp.oracle_address);
+            let usdc_token: Address = env.storage().instance().get(&DataKey::UsdcToken).expect("Oracle not configured");
+            let current_price_data = oracle_client.lastprice(&dp.token, &usdc_token).expect("Oracle price unavailable");
+            let current_price = current_price_data.price;
+
+            // Get merchant-configured slippage tolerance or default to the payment's initial config
+            let merchant_slippage: Option<u32> = env.storage().persistent()
+                .get(&DataKey3::SlippageToleranceBps(payment.merchant.clone()));
+            let slippage_tolerance_bps = merchant_slippage.unwrap_or(dp.slippage_bps);
+
+            // Compute rate deviation
+            let rate_deviation = if current_price >= dp.creation_rate {
+                current_price - dp.creation_rate
+            } else {
+                dp.creation_rate - current_price
+            };
+            
+            // Check against tolerance
+            let deviation_bps = (rate_deviation * 10_000) / dp.creation_rate;
+            if deviation_bps > slippage_tolerance_bps as i128 {
+                events::emit_payment_swap_failed(
+                    env, 
+                    payment.id, 
+                    payment.customer.clone(), 
+                    dp.token.clone(), 
+                    payment.amount, 
+                    Symbol::new(env, "StalePrice")
+                );
+                panic_with_error!(env, Error::SlippageExceeded);
+            }
+
+            events::emit_dynamic_payment_settled(env, payment.id, dp.fiat_amount, payment.amount, current_price);
         }
     }
 
@@ -9577,5 +9639,7 @@ mod test_retry_queue;
 mod test_spending_limit;
 #[cfg(test)]
 mod test_buyer_trust_tier;
+#[cfg(test)]
+mod test_oracle_staleness;
 
 pub use events::*;

--- a/contracts/ahjoor-payments/src/test_oracle_staleness.rs
+++ b/contracts/ahjoor-payments/src/test_oracle_staleness.rs
@@ -1,0 +1,94 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::token::Client as TokenClient;
+use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, Symbol};
+
+mod mock_oracle_initial {
+    use soroban_sdk::{contract, contractimpl, Address, Env};
+    use crate::PriceData;
+    #[contract] pub struct MockOracleInitial;
+    #[contractimpl] impl MockOracleInitial {
+        pub fn lastprice(_env: Env, _base: Address, _quote: Address) -> Option<PriceData> {
+            Some(PriceData { price: 10_000_000, timestamp: 0 })
+        }
+    }
+}
+
+mod mock_oracle_stale {
+    use soroban_sdk::{contract, contractimpl, Address, Env};
+    use crate::PriceData;
+    #[contract] pub struct MockOracleStale;
+    #[contractimpl] impl MockOracleStale {
+        pub fn lastprice(_env: Env, _base: Address, _quote: Address) -> Option<PriceData> {
+            Some(PriceData { price: 5_000_000, timestamp: 0 })
+        }
+    }
+}
+
+fn setup_dynamic<'a>() -> (Env, AhjoorPaymentsContractClient<'a>, Address, Address, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AhjoorPaymentsContract, ());
+    let client = AhjoorPaymentsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    
+    // usdc_token
+    let usdc_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    // payment token
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+
+    let oracle_initial = env.register(mock_oracle_initial::MockOracleInitial, ());
+    let oracle_stale = env.register(mock_oracle_stale::MockOracleStale, ());
+
+    client.initialize(&admin, &admin, &0u32);
+    client.set_min_collateral(&0i128);
+    client.approve_merchant(&merchant);
+    client.set_oracle(&oracle_initial, &usdc_addr, &3600u64);
+
+    (env, client, admin, merchant, usdc_addr, token_addr, oracle_initial, oracle_stale)
+}
+
+#[test]
+fn test_settlement_rejects_stale_oracle_price() {
+    let (env, client, admin, merchant, usdc_addr, token_addr, oracle_initial, oracle_stale) = setup_dynamic();
+    
+    let customer = Address::generate(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token_admin.mint(&customer, &10_000_000);
+
+    // Set slippage tolerance to 500 bps (5%)
+    client.set_merchant_slippage_tolerance(&merchant, &500u32);
+
+    // Create a multi-token payment
+    // We are requesting 1_000_000 USDC. Oracle says 1 token = 1 USDC.
+    // So 1_000_000 token_addr will be escrowed.
+    let pid = client.create_payment_multi_token(
+        &customer,
+        &merchant,
+        &1_000_000,
+        &token_addr,
+        &Some(500u32),
+    );
+
+    // Now, simulate that the oracle price drops to 0.5 USDC per token (50% drop, > 5% slippage).
+    client.set_oracle(&oracle_stale, &usdc_addr, &3600u64);
+
+    // Provide some USDC to the contract to fulfill the completion if it wasn't aborted
+    let usdc_admin = soroban_sdk::token::StellarAssetClient::new(&env, &usdc_addr);
+    usdc_admin.mint(&client.address, &1_000_000);
+
+    // Attempt to settle payment
+    // complete_payment should fail with SlippageExceeded (error code 21)
+    let res = client.try_complete_payment(&pid);
+    assert!(res.is_err());
+    let err = res.unwrap_err().unwrap();
+    // In soroban-sdk, contract errors are returned as soroban_sdk::Error. 
+    // We can check if it's a contract error.
+    assert!(err.is_type(soroban_sdk::xdr::ScErrorType::Contract));
+    // error code 21
+    assert_eq!(err.get_code(), 21);
+}


### PR DESCRIPTION
closes #413 

 I've fixed the compilation error in the tests! The issue was that 
  res.unwrap_err().unwrap()  returns a  soroban_sdk::Error  which doesn't
  implement a third  .unwrap() . I updated  test_oracle_staleness.rs  to
  properly assert the contract error type and error code (21) using the SDK's
  is_type()  and  get_code()  methods.
  Here is the final breakdown of the completed implementation:
  1. Configurable Slippage Tolerance ( lib.rs ):
      • Added  SlippageToleranceBps(Address)  to  DataKey3  to support
      configurable merchant-specific tolerances.
      • Added the  set_merchant_slippage_tolerance  function so merchants can
      configure their desired  slippage_tolerance_bps .
  2. Persistent  DynamicPayment  Records ( lib.rs ):
      • Modified  create_payment_multi_token  to successfully persist the 
      DynamicPayment  struct to  DataKey2::DynamicPayment(payment_id) . This
      makes sure the  complete_payment  operation can fetch the 
      creation_rate ,  payment_token , and initial  slippage_bps  during
      settlement.
  3. Price Drift Validation ( lib.rs ):
      • Updated  settle_dynamic_payment_if_needed  (which is called
      internally by  complete_payment ).
      • The method now fetches the current price from the oracle and
      retrieves the merchant's configured  SlippageToleranceBps  (falling
      back to the original configuration if the merchant hasn't set one).
      • We check  |current_price - stored_price| / stored_price >
      slippage_tolerance_bps / 10_000 . If this drift threshold is breached,
      it safely aborts and panics with  Error::SlippageExceeded  (Code 21),
      emitting the required  PaymentSwapFailed { reason:
      Symbol::new("StalePrice") }  event.
      • For valid execution,  DynamicPaymentSettled  is emitted on success.
  4. Testing ( test_oracle_staleness.rs ):
      • Created the test file  test_oracle_staleness.rs  and registered the
      module in  lib.rs .
      • Wrote  test_settlement_rejects_stale_oracle_price . The test
      successfully mocks a 50% plunge in oracle price between creation and
      settlement, verifying that  complete_payment  aborts appropriately and
      matches the  21u32  ( SlippageExceeded ) error code.



