### PR TITLE
slashedfunds

### DIFF
--- a/contracts/ahjoor-rosca/src/internals.rs
+++ b/contracts/ahjoor-rosca/src/internals.rs
@@ -301,6 +301,7 @@ pub(crate) fn complete_round_payout(env: &Env, _paid_members: &Vec<Address>) {
         contributions.push_back(ContributionEntry {
             member: member.clone(),
             amount,
+            timestamp: env.ledger().timestamp(),
         });
     }
 
@@ -370,7 +371,7 @@ pub(crate) fn complete_round_payout(env: &Env, _paid_members: &Vec<Address>) {
         env,
         current_round,
         total_payout_history_amt,
-        payout_recipient,
+        payout_recipient.clone(),
         total_payout_history_amt,
         contributions,
         defaulters,

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -337,10 +337,17 @@ impl AhjoorContract {
             .instance()
             .set(&DataKey::QuorumPercentage, &51u32);
 
+        // Guard: reject if contribution_amount × max_members would overflow i128.
+        if contribution_amount.checked_mul(max_members as i128).is_none() {
+            panic_with_error!(&env, ExtError::InvalidAmount);
+        }
+
         events::emit_rosc_init(&env, member_count as u32, contribution_amount);
 
         // #352: Store immutable base pool target (initial_members × contribution_amount)
-        let base_pool_target = contribution_amount * (member_count as i128);
+        let base_pool_target = contribution_amount
+            .checked_mul(member_count as i128)
+            .unwrap_or_else(|| panic_with_error!(&env, ExtError::InvalidAmount));
         env.storage()
             .instance()
             .set(&DataKey3::BasePoolTarget, &base_pool_target);

--- a/contracts/ahjoor-rosca/src/test.rs
+++ b/contracts/ahjoor-rosca/src/test.rs
@@ -4682,3 +4682,52 @@ fn test_exit_zero_refund_when_payout_exceeds_contributions() {
 
 
 
+
+#[test]
+fn test_overflow_guard_on_large_contribution() {
+    // contribution_amount = i128::MAX / 50, max_members = 100 → product overflows i128
+    let setup = setup_env();
+    let mut members = soroban_sdk::Vec::new(&setup.env);
+    for _ in 0..2 {
+        members.push_back(Address::generate(&setup.env));
+    }
+    let overflow_amount: i128 = i128::MAX / 50;
+    let res = setup.client.try_init(
+        &setup.admin,
+        &members,
+        &overflow_amount,
+        &setup.token_admin,
+        &3600,
+        &RoscaConfig {
+            strategy: PayoutStrategy::RoundRobin,
+            custom_order: None,
+            penalty_amount: 0,
+            exit_penalty_bps: 0,
+            collective_goal: None,
+            member_goals: None,
+            fee_bps: 0,
+            fee_recipient: None,
+            max_defaults: 3,
+            grace_period_ledgers: 0,
+            use_timestamp_schedule: false,
+            round_duration_seconds: 0,
+            max_members: Some(100),
+            skip_fee: 0,
+            max_skips_per_cycle: 0,
+            voting_mode: VotingMode::Equal,
+            late_fee_bps: 0,
+            grace_period_seconds: 0,
+            auction_enabled: false,
+            auction_window_ledgers: 0,
+            randomize_payout_order: false,
+            reserve_enabled: false,
+            reserve_contribution_bps: 0,
+        },
+        &None,
+    );
+    assert_eq!(res.unwrap_err().unwrap(), ExtError::InvalidAmount.into());
+
+    // Normal group (small amount) must initialize without error
+    let setup2 = setup_with_members(3, 1_000_000);
+    default_init(&setup2);
+}


### PR DESCRIPTION
- initialize with contribution_amount = i128::MAX / 50 and max_members = 100 returns
  ExtError::InvalidAmount ✓
  - Normal groups initialize without error ✓
  - test_overflow_guard_on_large_contribution added and passes ✓
  - Full suite: 214 passed; 0 failed ✓

closes #394 