### PR TITLE
fix(#392): use typed AuctionWindowClosed error for reveal/settle deadline guards

### DIFF
--- a/PR_DESCRIPTION_392.md
+++ b/PR_DESCRIPTION_392.md
@@ -1,0 +1,38 @@
+# fix: enforce reveal_until deadline and settle guard with typed errors
+
+## Summary
+
+`reveal_slot_bid` contained a `commit_until` guard but its `reveal_until` guard used `panic!("Reveal phase has closed")` — a plain string panic rather than a typed contract error. `settle_sealed_slot_auction` similarly used `panic!("Reveal phase is still open")`. Both paths should surface `ExtError2::AuctionWindowClosed = 103` so callers can distinguish the error programmatically.
+
+A bidder who missed the reveal window could call `reveal_slot_bid` and, if the guard were absent or mis-coded, inject a valid bid into `DataKey3::SealedRevealedBids(round)` retroactively and influence `settle_sealed_slot_auction` outcome.
+
+## Changes
+
+### `contracts/ahjoor-rosca/src/lib.rs`
+
+| Location | Before | After |
+|---|---|---|
+| `reveal_slot_bid` — post-reveal window | `panic!("Reveal phase has closed")` | `panic_with_error!(&env, ExtError2::AuctionWindowClosed)` |
+| `settle_sealed_slot_auction` — pre-settle guard | `panic!("Reveal phase is still open")` | `panic_with_error!(&env, ExtError2::AuctionWindowClosed)` |
+
+Both changes are one-liner replacements with no logic change — the guard conditions (`now > state.reveal_until` and `timestamp <= state.reveal_until`) were already correct.
+
+### `contracts/ahjoor-rosca/src/test_sealed_slot_auction.rs`
+
+Three new tests added under the `// ── #392` section:
+
+| Test | What it verifies |
+|---|---|
+| `test_late_reveal_rejected` | `reveal_slot_bid` after `reveal_until` returns an error (AuctionWindowClosed) |
+| `test_early_settle_rejected` | `settle_sealed_slot_auction` called inside the reveal window returns an error |
+| `test_reveal_within_window_accepted` | A reveal within the window succeeds and appears in `SealedRevealedBids` |
+
+## Acceptance Criteria Coverage
+
+- [x] `reveal_slot_bid` called after `reveal_until` returns `ExtError2::AuctionWindowClosed`
+- [x] `settle_sealed_slot_auction` called before `reveal_until` returns an appropriate error
+- [x] A bid revealed within the window is accepted and appears in `DataKey3::SealedRevealedBids`
+- [x] `test_late_reveal_rejected` added to `test_sealed_slot_auction.rs`
+- [x] `test_early_settle_rejected` added to `test_sealed_slot_auction.rs`
+
+closes #392

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -2287,7 +2287,7 @@ impl AhjoorContract {
             panic!("Reveal phase has not opened yet");
         }
         if now > state.reveal_until {
-            panic!("Reveal phase has closed");
+            panic_with_error!(&env, ExtError2::AuctionWindowClosed);
         }
 
         let round = state.round;
@@ -2381,7 +2381,7 @@ impl AhjoorContract {
             panic!("No open sealed auction to settle");
         }
         if env.ledger().timestamp() <= state.reveal_until {
-            panic!("Reveal phase is still open");
+            panic_with_error!(&env, ExtError2::AuctionWindowClosed);
         }
 
         let round = state.round;

--- a/contracts/ahjoor-rosca/src/test_sealed_slot_auction.rs
+++ b/contracts/ahjoor-rosca/src/test_sealed_slot_auction.rs
@@ -269,3 +269,55 @@ fn test_unrevealed_commit_is_forfeited() {
     // The forfeited 300 deposit remains held by the contract.
     assert_eq!(hx.token.balance(&hx.contract_id), 300);
 }
+
+// ── #392: deadline guards ─────────────────────────────────────────────────────
+
+/// reveal_slot_bid called after reveal_until returns AuctionWindowClosed (103).
+#[test]
+fn test_late_reveal_rejected() {
+    let hx = setup(100);
+    let m1 = hx.members.get(1).unwrap();
+    let salt = BytesN::from_array(&hx.env, &[7u8; 32]);
+
+    hx.client.commit_slot_bid(&m1, &commit_hash(&hx.env, &m1, 300, &salt), &300);
+
+    // Advance past the entire reveal window.
+    hx.env.ledger().set_timestamp(1_000 + COMMIT_DURATION + REVEAL_DURATION + 1);
+
+    let result = hx.client.try_reveal_slot_bid(&m1, &0, &300, &salt);
+    assert!(result.is_err(), "Reveal after reveal_until must be rejected");
+}
+
+/// settle_sealed_slot_auction called before reveal_until returns AuctionWindowClosed (103).
+#[test]
+fn test_early_settle_rejected() {
+    let hx = setup(100);
+    let m1 = hx.members.get(1).unwrap();
+    let salt = BytesN::from_array(&hx.env, &[7u8; 32]);
+
+    hx.client.commit_slot_bid(&m1, &commit_hash(&hx.env, &m1, 300, &salt), &300);
+
+    // Advance into the reveal phase but NOT past it.
+    hx.env.ledger().set_timestamp(1_000 + COMMIT_DURATION + 1);
+    hx.client.reveal_slot_bid(&m1, &0, &300, &salt);
+
+    // Still inside the reveal window — settlement must be rejected.
+    let result = hx.client.try_settle_sealed_slot_auction();
+    assert!(result.is_err(), "Settle during reveal phase must be rejected");
+}
+
+/// A bid revealed within the window is accepted and appears in SealedRevealedBids.
+#[test]
+fn test_reveal_within_window_accepted() {
+    let hx = setup(100);
+    let m1 = hx.members.get(1).unwrap();
+    let salt = BytesN::from_array(&hx.env, &[7u8; 32]);
+
+    hx.client.commit_slot_bid(&m1, &commit_hash(&hx.env, &m1, 300, &salt), &300);
+
+    // Advance to the start of the reveal phase.
+    hx.env.ledger().set_timestamp(1_000 + COMMIT_DURATION + 1);
+    hx.client.reveal_slot_bid(&m1, &0, &300, &salt);
+
+    assert_eq!(hx.client.get_sealed_revealed_bids(&0).len(), 1);
+}


### PR DESCRIPTION
# fix: enforce reveal_until deadline and settle guard with typed errors

## Summary

`reveal_slot_bid` contained a `commit_until` guard but its `reveal_until` guard used `panic!("Reveal phase has closed")` — a plain string panic rather than a typed contract error. `settle_sealed_slot_auction` similarly used `panic!("Reveal phase is still open")`. Both paths should surface `ExtError2::AuctionWindowClosed = 103` so callers can distinguish the error programmatically.

A bidder who missed the reveal window could call `reveal_slot_bid` and, if the guard were absent or mis-coded, inject a valid bid into `DataKey3::SealedRevealedBids(round)` retroactively and influence `settle_sealed_slot_auction` outcome.

## Changes

### `contracts/ahjoor-rosca/src/lib.rs`

| Location | Before | After |
|---|---|---|
| `reveal_slot_bid` — post-reveal window | `panic!("Reveal phase has closed")` | `panic_with_error!(&env, ExtError2::AuctionWindowClosed)` |
| `settle_sealed_slot_auction` — pre-settle guard | `panic!("Reveal phase is still open")` | `panic_with_error!(&env, ExtError2::AuctionWindowClosed)` |

Both changes are one-liner replacements with no logic change — the guard conditions (`now > state.reveal_until` and `timestamp <= state.reveal_until`) were already correct.

### `contracts/ahjoor-rosca/src/test_sealed_slot_auction.rs`

Three new tests added under the `// ── #392` section:

| Test | What it verifies |
|---|---|
| `test_late_reveal_rejected` | `reveal_slot_bid` after `reveal_until` returns an error (AuctionWindowClosed) |
| `test_early_settle_rejected` | `settle_sealed_slot_auction` called inside the reveal window returns an error |
| `test_reveal_within_window_accepted` | A reveal within the window succeeds and appears in `SealedRevealedBids` |

## Acceptance Criteria Coverage

- [x] `reveal_slot_bid` called after `reveal_until` returns `ExtError2::AuctionWindowClosed`
- [x] `settle_sealed_slot_auction` called before `reveal_until` returns an appropriate error
- [x] A bid revealed within the window is accepted and appears in `DataKey3::SealedRevealedBids`
- [x] `test_late_reveal_rejected` added to `test_sealed_slot_auction.rs`
- [x] `test_early_settle_rejected` added to `test_sealed_slot_auction.rs`

closes #392
