### PR TITLE
[codex] Track disbursed bounty funds when cancelling

### DIFF
--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -538,6 +538,8 @@ pub struct BountyData {
     pub submission_hash: Option<BytesN<32>>,
     /// Number of times this bounty has been rejected and re-opened.
     pub rejection_count: u32,
+    /// Bounty funds already paid out before final cancellation.
+    pub fees_disbursed: i128,
 }
 
 // ── #376: Bounty Board Milestone Gating with Verifier Sign-Off Chain ─────────
@@ -2495,6 +2497,7 @@ impl AhjoorEscrowContract {
         if arbiter_fee > 0 {
             client.transfer(&env.current_contract_address(), &arbiter, &arbiter_fee);
             events::emit_arbiter_fee_paid(env, escrow_id, arbiter.clone(), arbiter_fee);
+            Self::record_bounty_disbursement(env, escrow_id, arbiter_fee);
         }
 
         let fee_bps: u32 = env
@@ -2516,6 +2519,7 @@ impl AhjoorEscrowContract {
                 &protocol_fee,
             );
             events::emit_protocol_fee_paid(env, escrow_id, protocol_fee, fee_recipient);
+            Self::record_bounty_disbursement(env, escrow_id, protocol_fee);
         }
 
         let distributable = escrow.amount - protocol_fee - arbiter_fee;
@@ -5126,6 +5130,7 @@ impl AhjoorEscrowContract {
             solver: None,
             submission_hash: None,
             rejection_count: 0,
+            fees_disbursed: 0,
         };
         env.storage()
             .persistent()
@@ -5420,11 +5425,16 @@ impl AhjoorEscrowContract {
             panic!("Cannot cancel bounty in current state");
         }
 
-        let amount = escrow.amount;
+        let refund_amount = escrow
+            .amount
+            .checked_sub(bounty_data.fees_disbursed)
+            .expect("Disbursed fees exceed bounty amount");
         let token_client = token::Client::new(&env, &escrow.token);
 
         // Refund buyer
-        token_client.transfer(&env.current_contract_address(), &buyer, &amount);
+        if refund_amount > 0 {
+            token_client.transfer(&env.current_contract_address(), &buyer, &refund_amount);
+        }
 
         // Update escrow status
         escrow.status = EscrowStatus::Refunded;
@@ -5437,7 +5447,7 @@ impl AhjoorEscrowContract {
             PERSISTENT_BUMP_AMOUNT,
         );
 
-        events::emit_bounty_cancelled(&env, escrow_id, buyer, amount);
+        events::emit_bounty_cancelled(&env, escrow_id, buyer, refund_amount);
 
         env.storage()
             .instance()
@@ -5600,6 +5610,7 @@ impl AhjoorEscrowContract {
             solver: None,
             submission_hash: None,
             rejection_count: 0,
+            fees_disbursed: 0,
         };
         env.storage()
             .persistent()
@@ -5760,6 +5771,7 @@ impl AhjoorEscrowContract {
 
         let token_client = token::Client::new(&env, &escrow.token);
         token_client.transfer(&env.current_contract_address(), &solver, &amount);
+        Self::record_bounty_disbursement(&env, escrow_id, amount);
 
         milestone.status = BountyMilestoneStatus::Paid;
         states.set(index, milestone);
@@ -6601,6 +6613,28 @@ impl AhjoorEscrowContract {
                 .get(&DataKey::DefaultArbiterFeeBps)
                 .unwrap_or(0),
         )
+    }
+
+    fn record_bounty_disbursement(env: &Env, escrow_id: u32, amount: i128) {
+        if amount <= 0 {
+            return;
+        }
+
+        if let Some(mut bounty_data) = env
+            .storage()
+            .persistent()
+            .get::<DataKey2, BountyData>(&DataKey2::BountyData(escrow_id))
+        {
+            bounty_data.fees_disbursed += amount;
+            env.storage()
+                .persistent()
+                .set(&DataKey2::BountyData(escrow_id), &bounty_data);
+            env.storage().persistent().extend_ttl(
+                &DataKey2::BountyData(escrow_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        }
     }
 
     fn is_open_escrow_status(status: EscrowStatus) -> bool {

--- a/contracts/ahjoor-escrow/src/test_bounty_board.rs
+++ b/contracts/ahjoor-escrow/src/test_bounty_board.rs
@@ -1,9 +1,11 @@
 #![cfg(test)]
 
-use crate::{AhjoorEscrowContract, AhjoorEscrowContractClient, BountyData, EscrowStatus};
+use crate::{
+    AhjoorEscrowContract, AhjoorEscrowContractClient, BountyMilestoneInput, EscrowStatus,
+};
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
-    token, Address, BytesN, Env, String,
+    token, vec, Address, BytesN, Env, String, Vec,
 };
 
 fn create_token_contract<'a>(e: &Env, admin: &Address) -> token::StellarAssetClient<'a> {
@@ -607,6 +609,79 @@ fn test_cancel_bounty_unclaimed() {
 
     let buyer_balance_after = token.balance(&buyer);
     assert_eq!(buyer_balance_after - buyer_balance_before, 500);
+}
+
+#[test]
+fn test_cancel_bounty_after_inspection_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let solver = Address::generate(&env);
+    let inspector = Address::generate(&env);
+    let verifier = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token_sac = create_token_contract(&env, &token_admin);
+    token_sac.mint(&buyer, &1000);
+    let token_client = token::Client::new(&env, &token_sac.address);
+
+    let contract_id = env.register_contract(None, AhjoorEscrowContract);
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let current_time = env.ledger().timestamp();
+    let claim_deadline = current_time + 86400;
+    let submission_deadline = current_time + 172800;
+    let inspection_fee = 50;
+    let bounty_remainder = 450;
+    let milestones: Vec<BountyMilestoneInput> = vec![
+        &env,
+        BountyMilestoneInput {
+            description_hash: BytesN::from_array(&env, &[1u8; 32]),
+            verifier: inspector,
+            amount: inspection_fee,
+        },
+        BountyMilestoneInput {
+            description_hash: BytesN::from_array(&env, &[2u8; 32]),
+            verifier,
+            amount: bounty_remainder,
+        },
+    ];
+
+    let escrow_id = client.create_milestone_bounty(
+        &buyer,
+        &token_sac.address,
+        &milestones,
+        &claim_deadline,
+        &submission_deadline,
+    );
+
+    client.claim_bounty(&solver, &escrow_id);
+    client.submit_bounty_milestone(
+        &solver,
+        &escrow_id,
+        &0,
+        &BytesN::from_array(&env, &[3u8; 32]),
+    );
+    client.verify_bounty_milestone(&escrow_id, &0);
+
+    assert_eq!(token_client.balance(&contract_id), bounty_remainder);
+    assert_eq!(token_client.balance(&solver), inspection_fee);
+
+    advance_ledger(&env, 86401);
+
+    let buyer_balance_before = token_client.balance(&buyer);
+    client.cancel_bounty(&buyer, &escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Refunded);
+
+    let buyer_balance_after = token_client.balance(&buyer);
+    assert_eq!(buyer_balance_after - buyer_balance_before, bounty_remainder);
+    assert_eq!(token_client.balance(&contract_id), 0);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #425.

## Summary
- Track bounty funds that have already been disbursed before cancellation.
- Refund only the remaining bounty balance in `cancel_bounty` and emit the adjusted `BountyCancelled.refund_amount`.
- Add `test_cancel_bounty_after_inspection_fee` covering cancellation after a verifier/inspection tranche has already been paid out.

## Validation
- Not run: `cargo test -p ahjoor-escrow test_cancel_bounty_after_inspection_fee -- --nocapture` because this local environment does not have `cargo`, `rustc`, or `rustfmt` available in PATH.
- Static checks: verified all `BountyData` constructors initialize `fees_disbursed` and reviewed the updated refund/disbursement paths with `rg`.