### PR TITLE
docs: Add Mermaid architecture diagram to README

### DIFF
--- a/readMe.md
+++ b/readMe.md
@@ -105,13 +105,31 @@ make lint
 
 ## Architecture
 
-Ahjoor's smart contracts handle:
+Ahjoor is composed of five Soroban smart contracts. The diagram below shows how users, admins, and contracts relate to each other.
 
-- **Group Management**: Create and manage multiple independent ROSCA groups
-- **Access Control**: Only pre-registered participants can contribute to a group
-- **Contribution Tracking**: Immutable record of who has paid each round
-- **Automated Payouts**: Scheduled recipients claim the full pot when their round is due
-- **Round Progression**: Time-based round advancement using Stellar ledger timestamps
+```mermaid
+graph TD
+    User --> ROSCA[ahjoor-rosca\nGroup savings rounds]
+    User --> Escrow[ahjoor-escrow\nEscrow with dispute/arbiter]
+    User --> Payments[ahjoor-payments\nTwo-step auth + capture]
+    User --> Refund[ahjoor-refund\nRefund handling]
+    Admin --> Whitelist[ahjoor-token-whitelist\nControls allowed tokens]
+    Whitelist --> ROSCA
+    Whitelist --> Escrow
+    Whitelist --> Payments
+```
+
+### Contract Responsibilities
+
+| Contract                   | Role                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| **ahjoor-rosca**           | Manages rotating savings groups — round lifecycle, contributions, and payouts  |
+| **ahjoor-escrow**          | Holds funds in escrow with optional arbiter and dispute/timeout resolution     |
+| **ahjoor-payments**        | Two-step authorization and capture flow for merchant-style payments            |
+| **ahjoor-refund**          | Handles refund issuance and claim logic for cancelled or reversed transactions |
+| **ahjoor-token-whitelist** | Admin-controlled registry of tokens permitted across all other contracts       |
+
+The token whitelist sits at the foundation — `ahjoor-rosca`, `ahjoor-escrow`, and `ahjoor-payments` each consult it before accepting any token transfer, giving admins a single control point for token policy across the platform.
 
 ## State Archival & TTL
 
@@ -131,6 +149,6 @@ Stellar/Soroban utilizes State Archival to manage network storage footprint. Idl
 - [Soroban Smart Contracts](https://soroban.stellar.org/)
 - [Stellar CLI Reference](https://developers.stellar.org/docs/tools/developer-tools)
 
-  ## Community
+    ## Community
 
 - [Telegram Group Chat](https://t.me/ahjoor)


### PR DESCRIPTION
## Description
Replaces the text-only Architecture section in `readMe.md` with a Mermaid diagram that renders natively on GitHub — no image hosting needed. A Contract Responsibilities table is added below the diagram for quick reference.

## Type of Change
- [x] Documentation update

## Related Issues
Closes #478

## Changes Made
- Replaced the bullet-list Architecture section with a `mermaid` code block showing:
  - `User` → `ahjoor-rosca`, `ahjoor-escrow`, `ahjoor-payments`, `ahjoor-refund`
  - `Admin` → `ahjoor-token-whitelist`
  - `ahjoor-token-whitelist` → `ahjoor-rosca`, `ahjoor-escrow`, `ahjoor-payments`
- Added a **Contract Responsibilities** table summarising each contract's role
- Added a short prose paragraph explaining the whitelist's central role in token policy

## Testing
- [x] No tests required (documentation only)
- Mermaid syntax validated — renders correctly on GitHub

## Documentation
- [x] Documentation updated

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] No breaking changes