### PR TITLE
Docs/dispute flow timeout edge cases

### DIFF
--- a/docs/escrow-dispute-flow.md
+++ b/docs/escrow-dispute-flow.md
@@ -81,6 +81,20 @@ When an arbiter fails to resolve a dispute within the allocated deadline, the co
   4. **Valid Status**: Escrow status must be `EscrowStatus::Disputed` or `EscrowStatus::PartiallyDisputed`. Calls on `Active` or terminal states (`Resolved`, `Released`, `Refunded`) will panic with `"Escrow is not disputed"`.
   5. **Deadline Expiration**: Ledger timestamp check requires `current_timestamp - deadline_start >= effective_timeout`. Invocations prior to deadline expiry revert with `"Dispute timeout deadline has not passed yet"`.
 
+## Edge Cases & Auto-Resolution Special Behavior
+
+### 1. Single-Dispute Lifecycle & Prevention of Repeated Disputes
+- **Strict State Machine**: Calling `dispute_escrow` requires that the escrow be in an open state (`is_open_escrow_status`).
+- **Terminal Transitions**: Resolution by an arbiter (`resolve_dispute`) or auto-resolution via timeout (`enforce_dispute_timeout`) moves the escrow into terminal statuses (`Resolved`, `Released`, or `Refunded`).
+- **No Repeated Disputes**: Once an escrow reaches a terminal state, further calls to `dispute_escrow` revert with `"Escrow is not active"`. An escrow can only be disputed once in its lifecycle.
+- **Partial Dispute Edge Case**: When a partial dispute is raised, the undisputed portion is released to the seller immediately, leaving only the disputed portion in escrow under `EscrowStatus::PartiallyDisputed`. When this dispute resolves or times out, the disputed portion is transferred to the winner, transitioning the escrow to a terminal state (`Refunded` or `Released`). Neither party can initiate a second dispute for either the released or refunded funds.
+
+### 2. Arbiter Reassignment & Pool Removal Near Deadline
+- **Timer Continuity**: When an arbiter is removed from the pool via `remove_arbiter(admin, arbiter, escrow_ids)`, active escrows using that arbiter are flagged with `DataKey::ArbiterNeedsReplacement(escrow_id)`. **Removing or reassigning an arbiter does NOT pause, reset, or extend `DataKey::DisputeDeadlineStart(escrow_id)`**.
+- **Deadline Strictness**: The dispute deadline timer runs uninterrupted from the original `dispute_escrow` timestamp. If an arbiter is reassigned near the deadline, the newly assigned arbiter must issue a ruling before the original deadline expires.
+- **Enforcement Window**: If the deadline passes without resolution—even if arbiter reassignment was requested or pending—`enforce_dispute_timeout(escrow_id)` can be invoked by anyone to execute default fund distribution.
+- **Penalty Attribution**: When `enforce_dispute_timeout` is executed, the timeout penalty (`ArbiterTimeoutCount`) is credited against the address recorded in `escrow.arbiter` at the time of enforcement.
+
 Examples
 
 - Typical flow with default timeout:

--- a/docs/escrow-dispute-flow.md
+++ b/docs/escrow-dispute-flow.md
@@ -70,6 +70,17 @@ When an arbiter fails to resolve a dispute within the allocated deadline, the co
   - `DisputeTimedOut(escrow_id, arbiter, default_winner, elapsed_seconds)`
   - `ArbitersTimeoutPenaltyApplied(arbiter, new_timeout_count)`
 
+## Timeout Enforcement Caller & Execution Requirements
+
+- **Permissionless Trigger**: `enforce_dispute_timeout(escrow_id)` is a **public, unauthenticated** function (`pub fn`). Any account—including the buyer, seller, admin, or an automated off-chain bot/keeper—can trigger timeout enforcement once the deadline has passed.
+- **No Authentication Required**: The function does not call `require_auth()` for any role.
+- **Enforcement Validation Checks**:
+  1. **Pause Check**: Contract must not be paused (`require_not_paused`).
+  2. **Escrow Existence**: Escrow record must exist (`DataKey::Escrow(escrow_id)`).
+  3. **Active Dispute**: A dispute record must exist (`DataKey::Dispute(escrow_id)`) and `dispute.resolved` must be `false`.
+  4. **Valid Status**: Escrow status must be `EscrowStatus::Disputed` or `EscrowStatus::PartiallyDisputed`. Calls on `Active` or terminal states (`Resolved`, `Released`, `Refunded`) will panic with `"Escrow is not disputed"`.
+  5. **Deadline Expiration**: Ledger timestamp check requires `current_timestamp - deadline_start >= effective_timeout`. Invocations prior to deadline expiry revert with `"Dispute timeout deadline has not passed yet"`.
+
 Examples
 
 - Typical flow with default timeout:

--- a/docs/escrow-dispute-flow.md
+++ b/docs/escrow-dispute-flow.md
@@ -38,6 +38,38 @@ Notes and implementation details
 
 - Arbiter timeout counter: Whenever a dispute is forced via `enforce_dispute_timeout` because the arbiter missed the deadline, the contract increments a per-arbiter counter. This counter can be used by off-chain governance or admin logic to suspend or penalize repeatedly inactive arbiters.
 
+## Timeout Resolution & Fund Distribution Mechanism
+
+When an arbiter fails to resolve a dispute within the allocated deadline, the contract provides an automatic resolution mechanism via `enforce_dispute_timeout(escrow_id)`.
+
+### 1. Timeout Deadline Calculation
+- **Deadline Start**: Recorded in persistent storage (`DataKey::DisputeDeadlineStart(escrow_id)`) as `ledger.timestamp()` when `dispute_escrow` is called.
+- **Effective Timeout Duration**:
+  - **Per-escrow override**: Specified via `create_escrow_w_timeout(...)` or `dispute_timeout_seconds` in `EscrowExtensions`.
+  - **Global default**: Configured via `update_default_dispute_timeout(admin, timeout_seconds)` (queried via `get_default_dispute_timeout()`), defaulting to 7 days (`604,800` seconds).
+- **Expiration Threshold**: Enforceable when `current_ledger_timestamp - deadline_start >= effective_timeout`.
+
+### 2. Default Winner Determination
+- **Global Configuration**: Admin configures global default via `set_default_dispute_winner(admin, winner)` and queries via `get_default_dispute_winner()`. Values are `DisputeDefaultWinner::Buyer` (`0`) or `DisputeDefaultWinner::Seller` (`1`). Defaults to `Buyer`.
+- **Per-escrow Override**: Configured at escrow creation via `dispute_default_winner` in `EscrowCreateRequest` or stored in `escrow.extensions.dispute_default_winner`.
+
+### 3. Fund Distribution & State Execution
+- **Buyer Default Winner (`DisputeDefaultWinner::Buyer`)**:
+  - The remaining disputed escrow amount is refunded to the buyer(s) via `Self::transfer_to_buyers(...)`.
+  - Escrow status transitions to `EscrowStatus::Refunded`.
+- **Seller Default Winner (`DisputeDefaultWinner::Seller`)**:
+  - The remaining disputed escrow amount is released to the seller via token transfer.
+  - Escrow status transitions to `EscrowStatus::Released`.
+- **Partial Dispute Timeout Handling**:
+  - For partial disputes (`dispute_amount < total_amount`), the undisputed portion was already transferred to the seller immediately when `dispute_escrow` was called.
+  - On timeout enforcement, only the locked disputed portion is transferred to the default winner, and the escrow status transitions from `PartiallyDisputed` to `Refunded` (or `Released`).
+- **Receipt NFT Burning**: If an NFT receipt was minted for the escrow, it is burned via `burn_receipt_if_exists`.
+- **Dispute Settlement**: The dispute record (`DataKey::Dispute(escrow_id)`) is updated with `resolved = true`.
+- **Arbiter Reputation Penalty**: The assigned arbiter's penalty counter (`DataKey::ArbiterTimeoutCount(escrow.arbiter)`) is incremented by `1`.
+- **Events Emitted**:
+  - `DisputeTimedOut(escrow_id, arbiter, default_winner, elapsed_seconds)`
+  - `ArbitersTimeoutPenaltyApplied(arbiter, new_timeout_count)`
+
 Examples
 
 - Typical flow with default timeout:


### PR DESCRIPTION
  ### Summary of Additions to escrow-dispute-flow.md

  1. Timeout Resolution & Fund Distribution Mechanism:
      • Deadline Calculation: Details
      DataKey::DisputeDeadlineStart(escrow_id), per-escrow timeout overrides
      (create_escrow_w_timeout), and global default
      (update_default_dispute_timeout, 7 days).
      • Default Winner Determination: Configured globally via
      set_default_dispute_winner or per-escrow (EscrowCreateRequest.
      dispute_default_winner), supporting DisputeDefaultWinner::Buyer and
      DisputeDefaultWinner::Seller.
      • Fund Distribution & State Execution: Documents token transfers,
      status transitions (Refunded vs Released), partial dispute fund
      handling, receipt NFT burning, and arbiter penalty counter increments
      (ArbiterTimeoutCount).
  2. Timeout Enforcement Caller & Execution Requirements:
      • Documents that enforce_dispute_timeout(escrow_id) is a public,
      unauthenticated entrypoint (pub fn) callable by anyone (buyer, seller,
      admin, or automated bot/keeper).
      • Lists all explicit validation checks (pause status, dispute existence,
      status validation, and deadline expiration check).
  3. Edge Cases & Special Behavior:
      • Repeated Disputes: Explains that resolution (manual or auto-timeout)
      moves an escrow into a terminal state, prohibiting subsequent disputes
      ("Escrow is not active"). Also covers partial dispute finality.
      • Arbiter Reassignment / Pool Removal Near Deadline: Documents that
      removing or reassigning an arbiter (remove_arbiter) does not pause or
      reset DisputeDeadlineStart. The deadline clock runs continuously,
      requiring any replacement arbiter to act before the original deadline,
      and attributing penalty counters to whichever arbiter is recorded at
      enforcement time.
      
      closes #519