### PR TITLE
docs: Document the buyer trust tier system in ahjoor-payments

### DIFF
--- a/docs/payments-flow.md
+++ b/docs/payments-flow.md
@@ -155,3 +155,47 @@ Fields:
 - Offer an expiry action after the deadline so users can release missed
   authorizations back to the payer.
 - Treat `PaymentCaptured` plus `PaymentStatus::Completed` as the settled state.
+
+## Buyer Trust Tiers
+
+The `ahjoor-payments` contract enforces spending limits based on a buyer's trust tier. This lets merchants extend higher limits to buyers with an established payment history while restricting new or unverified buyers.
+
+### Tier Levels
+
+`BuyerTrustTierLevel` currently defines:
+
+- `New` — the default tier for a buyer with no tier explicitly set.
+- `Trusted` — a higher tier with a higher spending limit.
+
+### Setting Tier Limits
+
+A merchant configures the spending limit for each tier with:
+
+`set_tier_spending_limit(merchant, tier, limit, period_seconds)`
+
+- `merchant` must sign the call.
+- `limit` is the maximum total amount a buyer at that tier can spend within a rolling window of `period_seconds`.
+- Each tier has its own independent limit — setting the `New` tier limit does not affect the `Trusted` tier limit, and vice versa.
+
+### Assigning a Buyer's Tier
+
+A merchant assigns or updates a buyer's tier with:
+
+`set_buyer_tier(merchant, buyer, tier)`
+
+- `merchant` must sign the call.
+- A buyer's tier is not automatic — it must be explicitly set by the merchant. Until set, a buyer defaults to the `New` tier.
+
+### Effect on Payments
+
+When a buyer attempts a payment via `create_payment` / `try_complete_payment`:
+
+- The contract checks the buyer's current tier and that tier's configured spending limit.
+- If completing the payment would exceed the buyer's tier limit for the current period, the payment call fails.
+- If the payment is within the buyer's tier limit, it proceeds normally through the standard authorize/capture flow described above.
+
+This means the same payment amount can succeed for a `Trusted` buyer and fail for a `New` buyer if it exceeds the `New` tier's configured limit.
+
+### Tier Changes Over Time
+
+A buyer's tier is not automatically upgraded by the contract based on payment history. Tier changes happen only when the merchant explicitly calls `set_buyer_tier` again with a new tier value. Merchants are responsible for deciding when a buyer has earned a tier upgrade (or should be downgraded) and applying it via this call.


### PR DESCRIPTION
## Problem
test_buyer_trust_tier.rs shows payments behave differently based on a
buyer's trust tier, but there was no documentation of the tier levels or
their effects.

## Solution
Adds a "Buyer Trust Tiers" section to docs/payments-flow.md covering:
- What tiers exist and how a buyer's tier is determined
- What changes based on tier (limits, fees, holds, etc.)
- How the tier can change over time 

Closes #507