### PR TITLE
Docs/bounty milestone payouts

### DIFF
--- a/docs/bounty-board.md
+++ b/docs/bounty-board.md
@@ -1,0 +1,42 @@
+# Bounty Board (ahjoor-escrow)
+
+This document describes the bounty-board flows in `contracts/ahjoor-escrow`, with emphasis on milestone-based payout behavior.
+
+## Milestone Payouts
+
+Milestone payouts let a bounty release funds in smaller tranches instead of paying the full amount at the end.
+
+### How milestones are defined and ordered
+
+Each milestone is defined when the bounty is created. A milestone includes:
+
+- a description hash for the sub-deliverable
+- the verifier address responsible for sign-off
+- the token amount or release share tied to that milestone
+
+Milestones are stored on-chain in the same order they are provided at creation time, and the contract enforces that order during submission and verification.
+
+For verifier-based bounty milestones, milestone `N + 1` cannot be submitted until milestone `N` has already been verified and paid. That prevents the solver from skipping ahead or claiming later work before earlier work is accepted.
+
+### How the basis-point split determines each payout
+
+For proportional milestone escrows, each milestone defines a `release_bps` value. The contract requires all milestone basis-point values to sum to exactly `10,000`, which represents 100% of the escrow amount.
+
+- `3,000 bps` pays 30% of the escrow amount
+- `5,000 bps` pays 50% of the escrow amount
+- `2,000 bps` pays the remaining 20%
+
+When a submitted milestone is approved, the contract releases that milestone's proportional share to the seller. The final milestone releases any rounding remainder so the full escrow balance is settled exactly.
+
+### What happens if a milestone is disputed or skipped
+
+The bounty milestone payout flow does not introduce a separate on-chain dispute state for milestones. Instead, a verifier-gated milestone can be rejected before verification and returned to `Pending`, which lets the solver revise and resubmit the work.
+
+Skipped milestones are not allowed. The contract requires strict ordering, so later milestones cannot be submitted until all earlier milestones have reached the paid state. That means a solver cannot bypass an unfinished milestone to unlock later payouts.
+
+For verifier-gated bounty milestones, each milestone remains independently verifiable by its designated verifier, and any unresolved earlier milestone blocks progress to later payouts.
+
+## References
+
+- `contracts/ahjoor-escrow/src/test_bounty_milestone.rs`
+- `contracts/ahjoor-escrow/src/test_milestone_bps.rs`

--- a/docs/refund.md
+++ b/docs/refund.md
@@ -42,6 +42,16 @@ Alternate shorter flow (automatic approval): some flows can be configured so tha
 
 Check the contract configuration constants for the exact timeouts used in the deployed instance.
 
+## Escalation
+
+Refund escalation is part of the refund dispute flow and is used when the initial review window expires without a final decision.
+
+- **What triggers escalation:** a refund must first be in an escalatable state (`Requested`, `EvidenceSubmitted`, or `EvidencePeriodExpired`), and the primary review deadline must have passed. The contract rejects escalation before that deadline with `PrimaryDeadlineNotPassed`.
+- **Who handles escalated refunds:** the configured senior arbiter handles escalated refunds. The arbiter address and the senior review window are set by the admin with `set_senior_arbiter` and `set_senior_review_window`.
+- **What the senior arbiter can do:** the senior arbiter resolves the dispute with `resolve_escalated_refund(refund_id, approved, resolution_hash)`. If `approved` is `true`, the refund is processed and the customer receives the refund amount, minus any configured fee. If `approved` is `false`, the refund is marked rejected and the customer is returned the escrowed funds.
+- **How the final outcome is enforced on-chain:** escalation moves the refund into `EscalatedToSenior` and stores the senior review deadline on-chain. Resolution can only be submitted by the configured senior arbiter, and the contract enforces the outcome by updating refund status and transferring tokens from the contract to the customer and, if configured, the fee recipient.
+- **Missed senior deadline:** if `auto_approve_on_senior_miss` is enabled, anyone can call `trigger_senior_auto_approve(refund_id)` after the senior deadline passes. This finalizes the refund on-chain, marks it `Processed`, and records the auto-approval source as `senior_miss`.
+
 ## Events and error handling
 
 - Events: `RefundRequested`, `RefundCreated`, `RefundApproved`, `RefundClaimed`, `RefundExpired`, `RefundCancelled`.


### PR DESCRIPTION
## Summary
- Add a new bounty-board doc with a Milestone Payouts section
- Describe milestone ordering, basis-point payout splits, and how rejected or skipped milestones behave
- Tie the documentation to the existing bounty milestone test coverage

## Validation
- Documentation-only change
- Reviewed the generated diff for `docs/bounty-board.md`

Closes #517