### PR TITLE
Docs/526 cosigner guarantee docs

### DIFF
--- a/docs/dao-mediation.md
+++ b/docs/dao-mediation.md
@@ -1,0 +1,70 @@
+# DAO Mediation for Disputed Payments
+
+This document explains the on-chain DAO mediation path used by the payments contract when a disputed payment needs an impartial resolution.
+
+## When a dispute is escalated
+
+A payment enters the DAO mediation flow only after the payment has already been marked as disputed.
+
+The escalation step is initiated by either:
+
+- the payment customer, or
+- the contract admin.
+
+The contract requires the payment to be in the `Disputed` state before the case can be opened. If the payment is still pending, authorized, completed, or already refunded, escalation fails.
+
+Once escalation succeeds:
+
+- a new mediation case is created for the disputed payment,
+- the case receives a unique case ID,
+- the vote window starts immediately, and
+- the case remains pending until the window closes or the verdict is executed.
+
+## Who can participate
+
+DAO mediation is enabled by the admin through contract configuration.
+
+The admin sets:
+
+- the list of DAO member addresses,
+- the vote window duration in seconds, and
+- the minimum number of votes required before a verdict can be executed.
+
+Only registered DAO members may vote. Each DAO member may cast one vote per mediation case, and each vote is either:
+
+- for the merchant, or
+- for the customer.
+
+## How a resolution is reached
+
+A mediation case remains open until the configured vote window closes.
+
+The resolution rules are:
+
+1. The vote window must expire before the verdict can be executed.
+2. A minimum number of votes must have been cast.
+3. The side with more votes wins.
+4. If the vote count is tied, the customer side wins by default.
+
+This means a tied outcome results in a refund to the customer rather than settlement to the merchant.
+
+## What happens to funds during mediation
+
+While the mediation case is active, the disputed payment stays in its existing escrowed/dispute state. No final settlement is applied until the DAO verdict is executed.
+
+After the vote window closes and the verdict is executed:
+
+- If the merchant wins, the payment is finalized as completed and the funds are settled to the merchant.
+- If the customer wins, the contract refunds the outstanding escrowed amount back to the customer and marks the payment as refunded.
+
+The contract also clears the temporary dispute record once the verdict is executed.
+
+## Practical summary
+
+In short, the DAO mediation process is a structured dispute resolution path for disputed payments:
+
+- the payment is escalated from a dispute into a DAO case,
+- registered DAO members vote on the outcome,
+- the vote window closes,
+- the verdict is executed,
+- and funds are either settled to the merchant or refunded to the customer depending on the result.

--- a/docs/rosca-cosigner-guarantee.md
+++ b/docs/rosca-cosigner-guarantee.md
@@ -1,0 +1,41 @@
+# Cosigner Guarantee in ROSCA
+
+This document explains the co-signer guarantee mechanism in the ROSCA contract. The feature lets a member nominate a trusted co-signer to cover a missed contribution when the member defaults.
+
+## How a co-signer is attached to a member
+
+A member can designate a co-signer by calling `set_co_signer(member, group_id, co_signer)`.
+
+The designation is created in a pending state. The nominated co-signer must then accept the assignment by calling `accept_co_signer(co_signer, group_id, member)`.
+
+Once accepted, the guarantee becomes active. If the co-signer never accepts the designation, the guarantee does not become active and the member is treated as a normal defaulter.
+
+## What the co-signer is liable for
+
+If a member misses a contribution and is marked as a defaulter, the contract checks whether that member has an active co-signer guarantee.
+
+When an active co-signer guarantee exists, the contract opens a short grace window for that member instead of applying the default penalty immediately. During that window, the co-signer may contribute on the member's behalf using `co_signer_contribute(...)`.
+
+If the co-signer makes the contribution in time, the member's missed contribution is covered and the member is not penalized for that round.
+
+If the co-signer does not act before the window expires, the member is treated as a defaulter and the default count is increased.
+
+## How the guarantee is discharged
+
+The guarantee is discharged in one of the following ways:
+
+- The co-signer successfully contributes on the member's behalf during the open grace window.
+- The member removes the designation between rounds by calling `remove_co_signer(member, group_id)`.
+- The guarantee is never accepted, in which case it remains inactive and has no effect.
+
+A successful co-signer contribution clears the temporary window state for that member. A removed designation clears the stored co-signer record entirely.
+
+## Practical summary
+
+The co-signer guarantee is a fallback mechanism for missed ROSCA contributions:
+
+- a member nominates a co-signer,
+- the co-signer accepts the guarantee,
+- the contract opens a short window after a default,
+- the co-signer can cover the missed contribution,
+- and if that does not happen in time, the member still incurs the normal default handling.


### PR DESCRIPTION
# docs: document cosigner guarantee in ROSCA

## Summary
This PR adds documentation for the ROSCA co-signer guarantee mechanism.

## What’s included
- Explains how a co-signer is attached to a member
- Documents what the co-signer is liable for if the member defaults
- Describes how the guarantee is discharged

## Related issue
Closes #526

