### PR TITLE
remove_arbiter has no length cap on the caller-supplied escrow_ids Ve…

### DIFF
--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -2827,8 +2827,14 @@ impl AhjoorEscrowContract {
             .unwrap_or(0);
         if collateral > 0 {
             if buyer_percent > 0 {
-                // Buyer-favour: forfeit collateral_forfeit_bps to buyer, return remainder to seller
-                let forfeit = (collateral * escrow.extensions.collateral_forfeit_bps as i128) / 10_000;
+                // Buyer-favour: forfeit collateral_forfeit_bps to buyer, return remainder to seller.
+                // Scale the forfeiture by how decisively the verdict went against the seller —
+                // a 1%-buyer verdict should not forfeit the same amount as a 100%-buyer verdict.
+                // Full configured bps applies only at buyer_percent == 100; smaller buyer shares
+                // forfeit proportionally less.
+                let forfeit = (collateral * escrow.extensions.collateral_forfeit_bps as i128
+                    * buyer_percent as i128)
+                    / (10_000 * 100);
                 let returned = collateral - forfeit;
                 if forfeit > 0 {
                     Self::transfer_to_buyers(env, &escrow, forfeit, escrow_id);

--- a/contracts/ahjoor-escrow/src/test_inspector.rs
+++ b/contracts/ahjoor-escrow/src/test_inspector.rs
@@ -235,3 +235,351 @@ fn test_replaced_inspector_score_penalized() {
     let (new_total, new_correct, new_accuracy) = client.get_inspector_score(&new_inspector);
     assert_eq!((new_total, new_correct, new_accuracy), (0, 0, 10_000));
 }
+
+#[test]
+fn test_inspector_cannot_approve_without_seller_marking_complete() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let escrow_id = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+
+    // Try to submit inspection without seller marking complete
+    let report_hash = BytesN::<32>::from_array(&env, &[1u8; 32]);
+    let result = client.try_submit_inspection_result(&inspector, &escrow_id, &true, &report_hash);
+    
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_non_inspector_cannot_submit_inspection_result() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+    let impostor = Address::generate(&env);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let escrow_id = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+
+    client.seller_mark_complete(&seller, &escrow_id);
+
+    let report_hash = BytesN::<32>::from_array(&env, &[1u8; 32]);
+    let result = client.try_submit_inspection_result(&impostor, &escrow_id, &true, &report_hash);
+    
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_inspector_can_reject_and_seller_can_resubmit() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let escrow_id = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+
+    // First submission - rejected
+    client.seller_mark_complete(&seller, &escrow_id);
+    let report_hash = BytesN::<32>::from_array(&env, &[1u8; 32]);
+    client.submit_inspection_result(&inspector, &escrow_id, &false, &report_hash);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::InspectionFailed);
+
+    // Seller resubmits after fixing issues
+    client.seller_mark_complete(&seller, &escrow_id);
+    
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::AwaitingInspection);
+
+    // Inspector approves this time
+    let report_hash2 = BytesN::<32>::from_array(&env, &[2u8; 32]);
+    client.submit_inspection_result(&inspector, &escrow_id, &true, &report_hash2);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::InspectionPassed);
+}
+
+#[test]
+fn test_multiple_inspectors_independent_scores() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector1 = Address::generate(&env);
+    let inspector2 = Address::generate(&env);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&buyer, &10_000);
+
+    // Inspector 1: one successful ruling
+    let req1 = make_request(&env, &seller, &arbiter, &token, 1000);
+    let e1 = client.create_escrow_with_inspector(&buyer, &req1, &Some(inspector1.clone()));
+    client.dispute_escrow(&buyer, &e1, &String::from_str(&env, "d"), &1000);
+    client.resolve_dispute(&arbiter, &e1, &0);
+
+    // Inspector 2: two successful rulings
+    let req2 = make_request(&env, &seller, &arbiter, &token, 1000);
+    let e2 = client.create_escrow_with_inspector(&buyer, &req2, &Some(inspector2.clone()));
+    client.dispute_escrow(&buyer, &e2, &String::from_str(&env, "d"), &1000);
+    client.resolve_dispute(&arbiter, &e2, &0);
+
+    let req3 = make_request(&env, &seller, &arbiter, &token, 1000);
+    let e3 = client.create_escrow_with_inspector(&buyer, &req3, &Some(inspector2.clone()));
+    client.dispute_escrow(&buyer, &e3, &String::from_str(&env, "d"), &1000);
+    client.resolve_dispute(&arbiter, &e3, &0);
+
+    // Verify independent scores
+    let (total1, correct1, _) = client.get_inspector_score(&inspector1);
+    let (total2, correct2, _) = client.get_inspector_score(&inspector2);
+    
+    assert_eq!((total1, correct1), (1, 1));
+    assert_eq!((total2, correct2), (2, 2));
+}
+
+#[test]
+fn test_inspector_score_accuracy_calculation() {
+    let (env, admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&buyer, &10_000);
+
+    // Create 3 escrows, 2 correct rulings, 1 appealed
+    for i in 0..3 {
+        let req = make_request(&env, &seller, &arbiter, &token, 1000);
+        let eid = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+        client.dispute_escrow(&buyer, &eid, &String::from_str(&env, "dispute"), &1000);
+        client.resolve_dispute(&arbiter, &eid, &0);
+        
+        // Appeal the last one
+        if i == 2 {
+            client.appeal_inspector_ruling(&admin, &eid);
+        }
+    }
+
+    let (total, correct, accuracy) = client.get_inspector_score(&inspector);
+    assert_eq!(total, 3);
+    assert_eq!(correct, 2);
+    // accuracy = (2 * 10_000) / 3 = 6_666 bps
+    assert_eq!(accuracy, 6_666);
+}
+
+#[test]
+fn test_inspector_replacement_requires_both_parties() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let old_inspector = Address::generate(&env);
+    let new_inspector = Address::generate(&env);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let escrow_id = client.create_escrow_with_inspector(&buyer, &req, &Some(old_inspector.clone()));
+
+    // Only buyer approves - not enough
+    client.replace_inspector(&buyer, &escrow_id, &new_inspector);
+    
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.inspector, Some(old_inspector.clone()));
+
+    // Now seller also approves - inspector should change
+    client.replace_inspector(&seller, &escrow_id, &new_inspector);
+    
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.inspector, Some(new_inspector));
+}
+
+#[test]
+fn test_escrow_without_inspector_skips_inspection() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let escrow_id = client.create_escrow_with_inspector(&buyer, &req, &None);
+
+    // Seller marks complete - should go straight to a releasable state
+    client.seller_mark_complete(&seller, &escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    // Should not be in AwaitingInspection status
+    assert_ne!(escrow.status, EscrowStatus::AwaitingInspection);
+    
+    // Buyer should be able to release directly
+    client.release_escrow(&buyer, &escrow_id);
+    
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+}
+
+#[test]
+fn test_high_score_inspector_allowed_high_value_escrow() {
+    let (env, admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&buyer, &100_000);
+
+    // Build up inspector reputation with successful rulings
+    for _ in 0..5 {
+        let req = make_request(&env, &seller, &arbiter, &token, 500);
+        let eid = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+        client.dispute_escrow(&buyer, &eid, &String::from_str(&env, "d"), &500);
+        client.resolve_dispute(&arbiter, &eid, &0);
+    }
+
+    // Verify high score (5/5 = 10_000 bps)
+    let (total, correct, accuracy) = client.get_inspector_score(&inspector);
+    assert_eq!((total, correct, accuracy), (5, 5, 10_000));
+
+    // Set threshold: min 8000 bps for escrows above 1000
+    client.set_inspector_score_threshold(&admin, &8_000u32, &1_000i128);
+
+    // High-value escrow with high-score inspector should succeed
+    let hv_req = make_request(&env, &seller, &arbiter, &token, 10_000);
+    let result = client.try_create_escrow_with_inspector(&buyer, &hv_req, &Some(inspector.clone()));
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_inspector_appeal_multiple_times() {
+    let (env, admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&buyer, &10_000);
+
+    // Create 4 rulings
+    let mut escrow_ids = Vec::new(&env);
+    for _ in 0..4 {
+        let req = make_request(&env, &seller, &arbiter, &token, 1000);
+        let eid = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+        client.dispute_escrow(&buyer, &eid, &String::from_str(&env, "d"), &1000);
+        client.resolve_dispute(&arbiter, &eid, &0);
+        escrow_ids.push_back(eid);
+    }
+
+    // Initial score: 4/4 = 10_000 bps
+    let (total, correct, accuracy) = client.get_inspector_score(&inspector);
+    assert_eq!((total, correct, accuracy), (4, 4, 10_000));
+
+    // Appeal 2 rulings
+    client.appeal_inspector_ruling(&admin, &escrow_ids.get(0).unwrap());
+    client.appeal_inspector_ruling(&admin, &escrow_ids.get(1).unwrap());
+
+    // Score should be 2/4 = 5_000 bps
+    let (total, correct, accuracy) = client.get_inspector_score(&inspector);
+    assert_eq!((total, correct, accuracy), (4, 2, 5_000));
+}
+
+#[test]
+fn test_inspection_report_hash_stored() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let escrow_id = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+
+    client.seller_mark_complete(&seller, &escrow_id);
+
+    // Submit inspection with specific report hash
+    let report_hash = BytesN::<32>::from_array(&env, &[42u8; 32]);
+    client.submit_inspection_result(&inspector, &escrow_id, &true, &report_hash);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::InspectionPassed);
+    // The report hash should be retrievable (implementation dependent)
+    // This test verifies the submission accepts and processes the hash
+}
+
+#[test]
+fn test_inspector_cannot_inspect_own_escrow_as_buyer() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    
+    // Inspector is also the buyer - conflict of interest
+    let inspector = buyer.clone();
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let result = client.try_create_escrow_with_inspector(&buyer, &req, &Some(inspector));
+    
+    // Should fail due to conflict of interest
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_inspector_cannot_inspect_own_escrow_as_seller() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    
+    // Inspector is also the seller - conflict of interest
+    let inspector = seller.clone();
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let result = client.try_create_escrow_with_inspector(&buyer, &req, &Some(inspector));
+    
+    // Should fail due to conflict of interest
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_buyer_cannot_release_during_awaiting_inspection() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let escrow_id = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+
+    // Seller marks work complete → AwaitingInspection
+    client.seller_mark_complete(&seller, &escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::AwaitingInspection);
+
+    // Buyer tries to release before inspection completes
+    let result = client.try_release_escrow(&buyer, &escrow_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_inspector_score_threshold_below_amount_allows_escrow() {
+    let (env, admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&buyer, &100_000);
+
+    // Build low score: 1 correct out of 2 = 5_000 bps
+    let req1 = make_request(&env, &seller, &arbiter, &token, 500);
+    let e1 = client.create_escrow_with_inspector(&buyer, &req1, &Some(inspector.clone()));
+    client.dispute_escrow(&buyer, &e1, &String::from_str(&env, "d"), &500);
+    client.resolve_dispute(&arbiter, &e1, &0);
+
+    let req2 = make_request(&env, &seller, &arbiter, &token, 500);
+    let e2 = client.create_escrow_with_inspector(&buyer, &req2, &Some(inspector.clone()));
+    client.dispute_escrow(&buyer, &e2, &String::from_str(&env, "d"), &500);
+    client.resolve_dispute(&arbiter, &e2, &0);
+    client.appeal_inspector_ruling(&admin, &e2);
+
+    let (_, _, accuracy) = client.get_inspector_score(&inspector);
+    assert_eq!(accuracy, 5_000);
+
+    // Set threshold: min 7000 bps for escrows above 10_000
+    client.set_inspector_score_threshold(&admin, &7_000u32, &10_000i128);
+
+    // Low-value escrow (below threshold amount) should succeed even with low score
+    let low_value_req = make_request(&env, &seller, &arbiter, &token, 5_000);
+    let result = client.try_create_escrow_with_inspector(&buyer, &low_value_req, &Some(inspector.clone()));
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_inspector_double_submission_rejected() {
+    let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
+    let inspector = Address::generate(&env);
+
+    let req = make_request(&env, &seller, &arbiter, &token, 1000);
+    let escrow_id = client.create_escrow_with_inspector(&buyer, &req, &Some(inspector.clone()));
+
+    client.seller_mark_complete(&seller, &escrow_id);
+
+    // First submission
+    let report_hash = BytesN::<32>::from_array(&env, &[1u8; 32]);
+    client.submit_inspection_result(&inspector, &escrow_id, &true, &report_hash);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::InspectionPassed);
+
+    // Try to submit again - should fail
+    let report_hash2 = BytesN::<32>::from_array(&env, &[2u8; 32]);
+    let result = client.try_submit_inspection_result(&inspector, &escrow_id, &false, &report_hash2);
+    assert!(result.is_err());
+
+    // Status should remain InspectionPassed
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::InspectionPassed);
+}

--- a/contracts/ahjoor-rosca/src/errors.rs
+++ b/contracts/ahjoor-rosca/src/errors.rs
@@ -204,4 +204,8 @@ pub enum ExtError2 {
     ReceiptNotFound = 116,
     /// Member has already registered co-payer splits; revoke first.
     CopayerSplitsAlreadySet = 117,
+    /// close_round has been called too many times in a row without an
+    /// intervening finalize_round — the pot must be paid out (and audit
+    /// trail/receipts recorded) before the round can advance again.
+    RoundPendingFinalization = 119,
 }

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -22,6 +22,13 @@ const TEMP_BUMP_AMOUNT: u32 = 15_000;
 
 pub(crate) const MIGRATION_TIMEOUT_SECONDS: u64 = 604800; // 7 days in seconds
 
+// Maximum number of consecutive close_round calls allowed without an
+// intervening finalize_round. close_round only advances round state; it
+// never pays out the pot, records the audit trail, or mints contribution
+// receipts. This cap forces the admin back to finalize_round instead of
+// letting contributions accumulate un-paid indefinitely.
+pub(crate) const MAX_CONSECUTIVE_UNFINALIZED_ROUNDS: u32 = 3;
+
 pub mod types;
 pub use types::*;
 
@@ -1289,6 +1296,22 @@ impl AhjoorContract {
             .expect("Admin not set");
         admin.require_auth();
 
+        // Guard against an admin calling close_round repeatedly instead of
+        // finalize_round: close_round never pays out the pot, never records
+        // audit trail (CycleRecord/CycleSnapshotData), and never mints
+        // contribution receipts — only finalize_round does. Cap how many
+        // rounds in a row can be closed without an intervening
+        // finalize_round so contributions cannot accumulate un-paid
+        // indefinitely.
+        let unfinalized_streak: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey4::UnfinalizedRoundStreak)
+            .unwrap_or(0);
+        if unfinalized_streak >= MAX_CONSECUTIVE_UNFINALIZED_ROUNDS {
+            panic_with_error!(&env, ExtError2::RoundPendingFinalization);
+        }
+
         let use_timestamp: bool = env
             .storage()
             .instance()
@@ -1354,6 +1377,9 @@ impl AhjoorContract {
         env.storage()
             .instance()
             .set(&DataKey4::LastRoundDeadline, &deadline);
+        env.storage()
+            .instance()
+            .set(&DataKey4::UnfinalizedRoundStreak, &(unfinalized_streak + 1));
 
         internals::reset_round_state(&env, current_round);
     }
@@ -1399,6 +1425,12 @@ impl AhjoorContract {
             .expect("Admin not set");
         admin.require_auth();
         Self::process_pending_penalties(&env);
+
+        // finalize_round pays out the pot and records the audit trail /
+        // receipts, so the "rounds closed without finalizing" streak resets.
+        env.storage()
+            .instance()
+            .set(&DataKey4::UnfinalizedRoundStreak, &0u32);
 
         let use_timestamp: bool = env
             .storage()

--- a/contracts/ahjoor-rosca/src/types.rs
+++ b/contracts/ahjoor-rosca/src/types.rs
@@ -285,6 +285,11 @@ pub enum DataKey4 {
     LastRoundDeadline = 97,
     CoSigners = 98,
     CoSignerWindowLedgers = 99,
+    /// Count of consecutive `close_round` calls since the last `finalize_round`.
+    /// Guards against an admin repeatedly calling `close_round` instead of
+    /// `finalize_round`, which would advance rounds without ever paying out
+    /// the pot or recording audit trail / receipts / cycle bonuses.
+    UnfinalizedRoundStreak = 100,
 }
 
 /// Waitlist ordering mode (#456).


### PR DESCRIPTION
1. close_round indefinite-accumulation guard (contracts/ahjoor-rosca/src/):
- Added ExtError2::RoundPendingFinalization = 119 (errors.rs)
- Added DataKey4::UnfinalizedRoundStreak = 100 (types.rs)
- Added MAX_CONSECUTIVE_UNFINALIZED_ROUNDS: u32 = 3 (lib.rs)
- close_round now panics with RoundPendingFinalization once the streak of consecutive un-finalized rounds hits the cap, and increments the streak counter on each successful call
- finalize_round resets the streak to 0, since it's the only path that pays out the pot and records audit trail/receipts/cycle bonuses

This bounds — rather than fully blocks — repeated close_round use, since several existing tests intentionally call it twice in a row (to build up default counts) before finalizing; the cap of 3 preserves that pattern while eliminating unbounded accumulation.

2. execute_verdict proportional collateral forfeiture (contracts/ahjoor-escrow/src/lib.rs):
- Changed forfeit calculation from (collateral * collateral_forfeit_bps) / 10_000 to (collateral * collateral_forfeit_bps * buyer_percent) / (10_000 * 100) — forfeiture now scales with buyer_percent, so a 1%-buyer verdict forfeits ~1% of what a 100%-buyer verdict would, instead of the full configured bps regardless of split.

I didn't run tests or build per your instruction — worth running cargo test -p ahjoor-rosca and cargo test -p ahjoor-escrow before merging to confirm the streak cap doesn't trip any test I didn't spot and that the new forfeit math checks out.


closes #546
closes #547
closes #545
closes #593