### PR TITLE
Feat/590 591 592 594 token whitelist improvements

### DIFF
--- a/contracts/ahjoor-errors/src/lib.rs
+++ b/contracts/ahjoor-errors/src/lib.rs
@@ -284,9 +284,45 @@ pub static ALL_ERRORS: &[ErrorEntry] = &[
     ErrorEntry { code: whitelist::TOKEN_NOT_WHITELISTED, name: "TokenNotWhitelisted", contract: "ahjoor-token-whitelist" },
 ];
 
+/// Look up an `ErrorEntry` by its numeric code.
+///
+/// Performs the linear search over `ALL_ERRORS` once, for reuse by off-chain
+/// tooling and tests instead of every caller writing its own scan.
+pub fn error_name_from_code(code: u32) -> Option<&'static ErrorEntry> {
+    ALL_ERRORS.iter().find(|entry| entry.code == code)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn error_name_from_code_returns_known_entries() {
+        let entry = error_name_from_code(rosca::ALREADY_INITIALIZED).expect("known code");
+        assert_eq!(entry.name, "AlreadyInitialized");
+        assert_eq!(entry.contract, "ahjoor-rosca");
+
+        let entry = error_name_from_code(payments::RATE_LIMIT_EXCEEDED).expect("known code");
+        assert_eq!(entry.name, "RateLimitExceeded");
+        assert_eq!(entry.contract, "ahjoor-payments");
+
+        let entry = error_name_from_code(escrow::INVALID_DEADLINE).expect("known code");
+        assert_eq!(entry.name, "InvalidDeadline");
+        assert_eq!(entry.contract, "ahjoor-escrow");
+
+        let entry = error_name_from_code(refund::ALREADY_INITIALIZED).expect("known code");
+        assert_eq!(entry.name, "AlreadyInitialized");
+        assert_eq!(entry.contract, "ahjoor-refund");
+
+        let entry = error_name_from_code(whitelist::NOT_INITIALIZED).expect("known code");
+        assert_eq!(entry.name, "NotInitialized");
+        assert_eq!(entry.contract, "ahjoor-token-whitelist");
+    }
+
+    #[test]
+    fn error_name_from_code_returns_none_for_unrecognized_code() {
+        assert!(error_name_from_code(9_999_999).is_none());
+    }
 
     #[test]
     fn no_duplicate_codes() {

--- a/contracts/ahjoor-token-whitelist/src/client.rs
+++ b/contracts/ahjoor-token-whitelist/src/client.rs
@@ -29,7 +29,14 @@ pub trait TokenWhitelistInterface {
 
     fn add_token(env: Env, admin: Address, token: Address);
 
+    fn batch_add_tokens(env: Env, admin: Address, tokens: soroban_sdk::Vec<Address>);
+
     fn remove_token(env: Env, admin: Address, token: Address);
+
+    fn cleanup_allowlist_entries(
+        env: Env,
+        entries: soroban_sdk::Vec<(Address, Address)>,
+    );
 
     fn get_whitelisted_tokens(env: Env) -> soroban_sdk::Vec<Address>;
 

--- a/contracts/ahjoor-token-whitelist/src/lib.rs
+++ b/contracts/ahjoor-token-whitelist/src/lib.rs
@@ -10,6 +10,7 @@ const PERSISTENT_LIFETIME_THRESHOLD: u32 = 100_000;
 const PERSISTENT_BUMP_AMOUNT: u32 = 120_000;
 
 const SUSPENSION_HISTORY_LIMIT: u32 = 10;
+const MAX_BATCH_ADD_TOKENS: u32 = 20;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -88,6 +89,7 @@ pub enum DataKey {
     QuorumBps,
     ListingProposal(u32),
     VoteRecord(u32, Address),
+    VoteWeightSnapshot(u32, Address),
 }
 
 #[contracttype]
@@ -120,6 +122,14 @@ const DEFAULT_QUORUM_BPS: u32 = 5_000;
 
 mod events;
 mod client;
+#[cfg(test)]
+mod test;
+#[cfg(test)]
+mod test_contract_allowlist;
+#[cfg(test)]
+mod test_governance;
+#[cfg(test)]
+mod test_suspension;
 
 pub use client::TokenWhitelistClient;
 
@@ -165,6 +175,42 @@ impl TokenWhitelistContract {
         );
         env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         events::emit_token_whitelisted(&env, token, admin);
+    }
+
+    /// Onboard multiple tokens in a single transaction. Admin-gated.
+    /// Reverts before adding any token if the batch is empty, exceeds the
+    /// length cap, or contains a token already on the whitelist.
+    pub fn batch_add_tokens(env: Env, admin: Address, tokens: Vec<Address>) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        if tokens.is_empty() {
+            panic!("Batch cannot be empty");
+        }
+        if tokens.len() > MAX_BATCH_ADD_TOKENS {
+            panic!("Batch size exceeds maximum allowed");
+        }
+        let mut whitelist: Vec<Address> = env
+            .storage().persistent()
+            .get(&DataKey::WhitelistedTokens)
+            .unwrap_or_else(|| Vec::new(&env));
+        for token in tokens.iter() {
+            for existing_token in whitelist.iter() {
+                if existing_token == token {
+                    panic!("Token already whitelisted");
+                }
+            }
+            whitelist.push_back(token.clone());
+        }
+        env.storage().persistent().set(&DataKey::WhitelistedTokens, &whitelist);
+        env.storage().persistent().extend_ttl(
+            &DataKey::WhitelistedTokens,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        for token in tokens.iter() {
+            events::emit_token_whitelisted(&env, token, admin.clone());
+        }
     }
 
     pub fn remove_token(env: Env, admin: Address, token: Address) {
@@ -540,6 +586,26 @@ impl TokenWhitelistContract {
         events::emit_contract_token_allowlist_updated(&env, contract_id, token, false, None);
     }
 
+    /// Remove contract-token allowlist entries whose `expiry_ledger` has passed.
+    /// Permissionless: safe to call repeatedly, and has no effect on entries
+    /// that are still active or already absent.
+    pub fn cleanup_allowlist_entries(
+        env: Env,
+        entries: Vec<(Address, Address)>,
+    ) {
+        let current_ledger = env.ledger().sequence();
+        for (contract_id, token) in entries.iter() {
+            let key = DataKey::ContractTokenAllowlist(contract_id.clone(), token.clone());
+            if let Some(Some(expiry)) = env.storage().persistent().get::<_, Option<u32>>(&key) {
+                if current_ledger >= expiry {
+                    env.storage().persistent().remove(&key);
+                    events::emit_contract_token_allowlist_updated(&env, contract_id, token, false, None);
+                }
+            }
+        }
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
     pub fn get_contract_token_entry(env: Env, contract_id: Address, token: Address) -> Option<Option<u32>> {
         let key = DataKey::ContractTokenAllowlist(contract_id, token);
         env.storage().persistent().get::<_, Option<u32>>(&key)
@@ -754,12 +820,21 @@ impl TokenWhitelistContract {
     pub fn vote_listing(env: Env, voter: Address, proposal_id: u32, approve: bool, weight: i128) {
         voter.require_auth();
         if weight <= 0 { panic!("weight must be positive"); }
-        let governance_token: Address = env
-            .storage().instance()
-            .get(&DataKey::GovernanceToken)
-            .expect("GovernanceTokenNotConfigured");
-        let voter_balance = token::Client::new(&env, &governance_token).balance(&voter);
-        if weight > voter_balance { panic!("VoteWeightExceedsBalance"); }
+        let snapshot_key = DataKey::VoteWeightSnapshot(proposal_id, voter.clone());
+        let snapshot_balance: i128 = match env.storage().persistent().get(&snapshot_key) {
+            Some(balance) => balance,
+            None => {
+                let governance_token: Address = env
+                    .storage().instance()
+                    .get(&DataKey::GovernanceToken)
+                    .expect("GovernanceTokenNotConfigured");
+                let balance = token::Client::new(&env, &governance_token).balance(&voter);
+                env.storage().persistent().set(&snapshot_key, &balance);
+                env.storage().persistent().extend_ttl(&snapshot_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+                balance
+            }
+        };
+        if weight > snapshot_balance { panic!("VoteWeightExceedsBalance"); }
         let mut proposal: ListingProposal = env
             .storage().persistent()
             .get(&DataKey::ListingProposal(proposal_id))

--- a/contracts/ahjoor-token-whitelist/src/test.rs
+++ b/contracts/ahjoor-token-whitelist/src/test.rs
@@ -399,3 +399,99 @@ fn test_suspend_nonwhitelisted_token_fails() {
     let reason = BytesN::from_array(&env, &[1u8; 32]);
     client.suspend_token_timed(&admin, &token, &50u32, &reason);
 }
+
+// ─── batch_add_tokens (#592) ─────────────────────────────────────────────────
+
+#[test]
+fn test_batch_add_tokens_full_valid_batch() {
+    let (env, admin, client) = setup_test();
+    let tokens = soroban_sdk::vec![
+        &env,
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+    ];
+
+    client.batch_add_tokens(&admin, &tokens);
+
+    for token in tokens.iter() {
+        assert!(client.is_token_allowed(&token));
+    }
+    assert_eq!(client.get_whitelisted_tokens().len(), 3);
+}
+
+#[test]
+#[should_panic(expected = "Batch size exceeds maximum allowed")]
+fn test_batch_add_tokens_oversized_batch_reverts_before_any_added() {
+    let (env, admin, client) = setup_test();
+    let mut tokens = soroban_sdk::Vec::new(&env);
+    for _ in 0..21 {
+        tokens.push_back(Address::generate(&env));
+    }
+
+    client.batch_add_tokens(&admin, &tokens);
+}
+
+#[test]
+#[should_panic(expected = "Batch cannot be empty")]
+fn test_batch_add_tokens_empty_batch_fails() {
+    let (env, admin, client) = setup_test();
+    let tokens: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+
+    client.batch_add_tokens(&admin, &tokens);
+}
+
+#[test]
+#[should_panic(expected = "Token already whitelisted")]
+fn test_batch_add_tokens_duplicate_within_batch_reverts_before_any_added() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    let tokens = soroban_sdk::vec![&env, token.clone(), token];
+
+    client.batch_add_tokens(&admin, &tokens);
+}
+
+// ─── cleanup_allowlist_entries (#590) ────────────────────────────────────────
+
+#[test]
+fn test_cleanup_allowlist_entries_removes_only_expired() {
+    let (env, admin, client) = setup_test();
+    let contract_a = Address::generate(&env);
+    let contract_b = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let current = env.ledger().sequence();
+    client.set_contract_token(&admin, &contract_a, &token, &Some(current + 10));
+    client.set_contract_token(&admin, &contract_b, &token, &None); // permanent, never expires
+
+    env.ledger().with_mut(|l| l.sequence_number += 20);
+
+    let entries = soroban_sdk::vec![
+        &env,
+        (contract_a.clone(), token.clone()),
+        (contract_b.clone(), token.clone()),
+    ];
+    client.cleanup_allowlist_entries(&entries);
+
+    assert_eq!(client.get_contract_token_entry(&contract_a, &token), None);
+    // Permanent (contract_b) entry is untouched by cleanup.
+    assert!(client.is_token_allowed_for_contract(&contract_b, &token));
+}
+
+#[test]
+fn test_cleanup_allowlist_entries_no_effect_when_nothing_expired() {
+    let (env, admin, client) = setup_test();
+    let contract_id = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let current = env.ledger().sequence();
+    client.set_contract_token(&admin, &contract_id, &token, &Some(current + 100));
+
+    let entries = soroban_sdk::vec![&env, (contract_id.clone(), token.clone())];
+    client.cleanup_allowlist_entries(&entries);
+    assert!(client.is_token_allowed_for_contract(&contract_id, &token));
+
+    // Calling again is a no-op.
+    client.cleanup_allowlist_entries(&entries);
+    assert!(client.is_token_allowed_for_contract(&contract_id, &token));
+}

--- a/contracts/ahjoor-token-whitelist/src/test_governance.rs
+++ b/contracts/ahjoor-token-whitelist/src/test_governance.rs
@@ -240,3 +240,61 @@ fn test_cannot_enact_before_delay() {
     // Enactment delay not elapsed yet
     client.enact_listing(&proposal_id);
 }
+
+// ─── #591: balance snapshot at first vote ────────────────────────────────────
+
+#[test]
+fn test_balance_change_after_vote_does_not_affect_recorded_weight() {
+    let (env, admin, client, gov_token) = setup_governance();
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    let new_token = Address::generate(&env);
+
+    mint_gov_tokens(&env, &gov_token, &admin, &proposer, 200);
+    mint_gov_tokens(&env, &gov_token, &admin, &voter, 600);
+
+    let rationale = BytesN::from_array(&env, &[9u8; 32]);
+    let proposal_id = client.propose_token_listing(&proposer, &new_token, &rationale);
+
+    // Voter casts a vote using their full balance at the time.
+    client.vote_listing(&voter, &proposal_id, &true, &600i128);
+
+    // Voter's balance changes after voting (e.g. they transfer tokens away).
+    // A flash-loan style balance manipulation must not affect the already
+    // recorded weight, since weight is fixed at first-vote time.
+    mint_gov_tokens(&env, &gov_token, &admin, &voter, 5_000);
+
+    env.ledger().set_sequence_number(env.ledger().sequence() + 101);
+    client.finalise_listing_proposal(&proposal_id);
+
+    let proposal = client.get_listing_proposal(&proposal_id);
+    // Recorded weight remains 600, not affected by the post-vote balance increase.
+    assert_eq!(proposal.approve_weight, 600);
+    assert_eq!(proposal.status, ProposalStatus::PendingEnactment);
+}
+
+#[test]
+#[should_panic(expected = "VoteWeightExceedsBalance")]
+fn test_vote_weight_capped_by_snapshot_not_live_balance_on_revote() {
+    let (env, admin, client, gov_token) = setup_governance();
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    let new_token = Address::generate(&env);
+
+    mint_gov_tokens(&env, &gov_token, &admin, &proposer, 200);
+    mint_gov_tokens(&env, &gov_token, &admin, &voter, 300);
+
+    let rationale = BytesN::from_array(&env, &[10u8; 32]);
+    let proposal_id = client.propose_token_listing(&proposer, &new_token, &rationale);
+
+    // First vote establishes the snapshot at balance 300.
+    client.vote_listing(&voter, &proposal_id, &true, &300i128);
+
+    // Balance later increases, but a re-vote weight above the snapshot must
+    // still be rejected — the snapshot, not the live balance, is the cap.
+    mint_gov_tokens(&env, &gov_token, &admin, &voter, 1_000);
+
+    client.vote_listing(&voter, &proposal_id, &true, &1_000i128);
+}


### PR DESCRIPTION
## Summary

- Add `batch_add_tokens` to `ahjoor-token-whitelist` for onboarding multiple tokens in one admin-gated tx (capped at 20, all-or-nothing).
- Add `cleanup_allowlist_entries` to remove expired `ContractTokenAllowlist` entries; permissionless, no-op on active/absent entries.
- Snapshot each voter's governance-token balance at first vote per proposal in `vote_listing`, closing the flash-loan voting-weight manipulation window in `finalise_listing_proposal`.
- Add `error_name_from_code(code: u32) -> Option<&'static ErrorEntry>` to `ahjoor-errors` for single-lookup error decoding.
- Wired up previously-orphaned test modules (`test`, `test_contract_allowlist`, `test_governance`, `test_suspension`) in `ahjoor-token-whitelist` so they actually compile and run.

Note: `cleanup_expired_contract_allowlist_entries` was renamed to `cleanup_allowlist_entries` — Soroban caps contract function names at 32 chars.

Note: wiring up the test modules surfaced 2 pre-existing failing tests in `test_contract_allowlist.rs` (`get_contract_token_entry` mishandles `Option<Option<u32>>` for permanent entries) unrelated to these changes — left as-is, out of scope here.

## Test plan

- `cargo test -p ahjoor-token-whitelist` — 69 passed, 2 pre-existing unrelated failures
- `cargo test -p ahjoor-errors` — all passed
- `cargo test` on all CI-matrix contracts (escrow, payments, refund, rosca) — all passed, no regressions
- `cargo build --target wasm32-unknown-unknown --release` for token-whitelist — clean

Closes #590
Closes #591
Closes #592
Closes #594
