### PR TITLE
Feat/586 587 588 589 escalations pagination quota validation

### DIFF
--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -4602,6 +4602,36 @@ impl AhjoorRefundContract {
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 
+    /// #586: Admin view of refunds currently awaiting senior review.
+    /// Only refunds with status `EscalatedToSenior` are returned (resolved
+    /// escalations move to `Processed`/`Rejected` and drop out of this view).
+    /// `limit` is capped at 50 per call.
+    pub fn list_pending_senior_escalations(env: Env, offset: u32, limit: u32) -> Vec<u32> {
+        let effective_limit = limit.min(50);
+        let counter: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundCounter)
+            .unwrap_or(0);
+
+        let mut result = Vec::new(&env);
+        let mut matched: u32 = 0;
+        for refund_id in 0..counter {
+            let refund: Refund = match env.storage().persistent().get(&DataKey::Refund(refund_id)) {
+                Some(r) => r,
+                None => continue,
+            };
+            if refund.status != RefundStatus::EscalatedToSenior {
+                continue;
+            }
+            if matched >= offset && result.len() < effective_limit {
+                result.push_back(refund_id);
+            }
+            matched += 1;
+        }
+        result
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Feature: Refund Customer Abuse Score
     // ─────────────────────────────────────────────────────────────────────────

--- a/contracts/ahjoor-refund/src/test_escalation.rs
+++ b/contracts/ahjoor-refund/src/test_escalation.rs
@@ -251,3 +251,76 @@ fn test_non_senior_cannot_resolve_escalated() {
     let hash = BytesN::from_array(&env, &[0u8; 32]);
     refund_client.resolve_escalated_refund(&impostor, &rid, &true, &hash);
 }
+
+// ── #586: list_pending_senior_escalations ────────────────────────────────────
+
+#[test]
+fn test_list_pending_senior_escalations_mix_of_pending_and_resolved() {
+    let (env, refund_client, payment_client, _admin, senior, token_addr, _tc, token_admin) =
+        setup_escalation();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    // Three refunds escalated to senior review.
+    let mut rids = soroban_sdk::Vec::new(&env);
+    for _ in 0..3 {
+        let pid = make_completed_payment(&env, &payment_client, &token_admin, &customer, &merchant, &token_addr, 1000);
+        token_admin.mint(&customer, &500);
+        let rid = refund_client.request_refund(
+            &customer, &pid, &500, &String::from_str(&env, "defective"), &0,
+        );
+        env.ledger().set_sequence_number(env.ledger().sequence() + 501);
+        refund_client.escalate_to_senior(&caller, &rid);
+        rids.push_back(rid);
+    }
+
+    // Resolve the second one — it must drop out of the pending list.
+    let hash = BytesN::from_array(&env, &[9u8; 32]);
+    refund_client.resolve_escalated_refund(&senior, &rids.get(1).unwrap(), &true, &hash);
+
+    let pending = refund_client.list_pending_senior_escalations(&0, &10);
+    assert_eq!(pending.len(), 2);
+    assert_eq!(pending.get(0).unwrap(), rids.get(0).unwrap());
+    assert_eq!(pending.get(1).unwrap(), rids.get(2).unwrap());
+}
+
+#[test]
+fn test_list_pending_senior_escalations_paginated() {
+    let (env, refund_client, payment_client, _admin, _senior, token_addr, _tc, token_admin) =
+        setup_escalation();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    let mut rids = soroban_sdk::Vec::new(&env);
+    for _ in 0..4 {
+        let pid = make_completed_payment(&env, &payment_client, &token_admin, &customer, &merchant, &token_addr, 1000);
+        token_admin.mint(&customer, &500);
+        let rid = refund_client.request_refund(
+            &customer, &pid, &500, &String::from_str(&env, "defective"), &0,
+        );
+        env.ledger().set_sequence_number(env.ledger().sequence() + 501);
+        refund_client.escalate_to_senior(&caller, &rid);
+        rids.push_back(rid);
+    }
+
+    let page1 = refund_client.list_pending_senior_escalations(&0, &2);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1.get(0).unwrap(), rids.get(0).unwrap());
+    assert_eq!(page1.get(1).unwrap(), rids.get(1).unwrap());
+
+    let page2 = refund_client.list_pending_senior_escalations(&2, &2);
+    assert_eq!(page2.len(), 2);
+    assert_eq!(page2.get(0).unwrap(), rids.get(2).unwrap());
+    assert_eq!(page2.get(1).unwrap(), rids.get(3).unwrap());
+}
+
+#[test]
+fn test_list_pending_senior_escalations_empty_when_none_escalated() {
+    let (_env, refund_client, _payment_client, _admin, _senior, _token_addr, _tc, _token_admin) =
+        setup_escalation();
+
+    let pending = refund_client.list_pending_senior_escalations(&0, &10);
+    assert_eq!(pending.len(), 0);
+}

--- a/contracts/ahjoor-token-whitelist/src/client.rs
+++ b/contracts/ahjoor-token-whitelist/src/client.rs
@@ -31,7 +31,7 @@ pub trait TokenWhitelistInterface {
 
     fn remove_token(env: Env, admin: Address, token: Address);
 
-    fn get_whitelisted_tokens(env: Env) -> soroban_sdk::Vec<Address>;
+    fn get_whitelisted_tokens(env: Env, offset: u32, limit: u32) -> soroban_sdk::Vec<Address>;
 
     fn get_admin(env: Env) -> Address;
 

--- a/contracts/ahjoor-token-whitelist/src/lib.rs
+++ b/contracts/ahjoor-token-whitelist/src/lib.rs
@@ -11,6 +11,9 @@ const PERSISTENT_BUMP_AMOUNT: u32 = 120_000;
 
 const SUSPENSION_HISTORY_LIMIT: u32 = 10;
 
+/// #589: Default/maximum page size for `get_whitelisted_tokens`.
+const DEFAULT_WHITELIST_PAGE_SIZE: u32 = 50;
+
 /// #588: Maximum allowed `period_ledgers` for a token quota (~30 days at 5s ledgers).
 const MAX_QUOTA_PERIOD_LEDGERS: u32 = 518_400;
 
@@ -345,7 +348,9 @@ impl TokenWhitelistContract {
         true
     }
 
-    pub fn get_whitelisted_tokens(env: Env) -> Vec<Address> {
+    /// #589: Returns a bounded page of the whitelist instead of the full list.
+    /// `limit` is capped at `DEFAULT_WHITELIST_PAGE_SIZE` (50) per call.
+    pub fn get_whitelisted_tokens(env: Env, offset: u32, limit: u32) -> Vec<Address> {
         let whitelist: Vec<Address> = env
             .storage().persistent()
             .get(&DataKey::WhitelistedTokens)
@@ -355,7 +360,14 @@ impl TokenWhitelistContract {
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
         );
-        whitelist
+        let wlen = whitelist.len();
+        let start = offset.min(wlen);
+        let l = limit.min(DEFAULT_WHITELIST_PAGE_SIZE).min(wlen - start);
+        let mut page = Vec::new(&env);
+        for i in start..start + l {
+            page.push_back(whitelist.get(i).unwrap());
+        }
+        page
     }
 
     pub fn get_admin(env: Env) -> Address {

--- a/contracts/ahjoor-token-whitelist/src/lib.rs
+++ b/contracts/ahjoor-token-whitelist/src/lib.rs
@@ -11,6 +11,13 @@ const PERSISTENT_BUMP_AMOUNT: u32 = 120_000;
 
 const SUSPENSION_HISTORY_LIMIT: u32 = 10;
 
+/// #588: Maximum allowed `period_ledgers` for a token quota (~30 days at 5s ledgers).
+const MAX_QUOTA_PERIOD_LEDGERS: u32 = 518_400;
+
+/// Companion fix: maximum allowed `to_ledger - from_ledger` window for `get_token_volume`.
+/// Bounded to keep the per-ledger storage-read loop within the host's CPU/memory budget.
+const MAX_VOLUME_QUERY_RANGE: u32 = 500;
+
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -120,6 +127,9 @@ const DEFAULT_QUORUM_BPS: u32 = 5_000;
 
 mod events;
 mod client;
+
+#[cfg(test)]
+mod test;
 
 pub use client::TokenWhitelistClient;
 
@@ -583,6 +593,7 @@ impl TokenWhitelistContract {
         }
         if max_volume_per_period <= 0 { panic!("max_volume_per_period must be positive"); }
         if period_ledgers == 0 { panic!("period_ledgers must be positive"); }
+        if period_ledgers > MAX_QUOTA_PERIOD_LEDGERS { panic!("period_ledgers exceeds maximum allowed"); }
         let quota = TokenQuota { max_volume_per_period, period_ledgers };
         env.storage().persistent().set(&DataKey::TokenQuota(token.clone()), &quota);
         env.storage().persistent().extend_ttl(&DataKey::TokenQuota(token.clone()), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
@@ -600,6 +611,7 @@ impl TokenWhitelistContract {
         Self::require_admin(&env, &admin);
         if max_volume_per_period <= 0 { panic!("max_volume_per_period must be positive"); }
         if period_ledgers == 0 { panic!("period_ledgers must be positive"); }
+        if period_ledgers > MAX_QUOTA_PERIOD_LEDGERS { panic!("period_ledgers exceeds maximum allowed"); }
         if !env.storage().persistent().has(&DataKey::TokenQuota(token.clone())) {
             panic!("Token has no quota");
         }
@@ -650,6 +662,12 @@ impl TokenWhitelistContract {
     }
 
     pub fn get_token_volume(env: Env, token: Address, from_ledger: u32, to_ledger: u32) -> i128 {
+        if from_ledger > to_ledger {
+            panic!("from_ledger must not exceed to_ledger");
+        }
+        if to_ledger - from_ledger > MAX_VOLUME_QUERY_RANGE {
+            panic!("ledger range exceeds maximum allowed");
+        }
         let mut volume: i128 = 0;
         for bucket_ledger in from_ledger..=to_ledger {
             let bucket_volume: i128 = env

--- a/contracts/ahjoor-token-whitelist/src/test.rs
+++ b/contracts/ahjoor-token-whitelist/src/test.rs
@@ -30,7 +30,7 @@ fn test_initialize() {
     assert_eq!(client.get_admin(), admin);
 
     // Verify whitelist is empty initially
-    let tokens = client.get_whitelisted_tokens();
+    let tokens = client.get_whitelisted_tokens(&0, &50);
     assert_eq!(tokens.len(), 0);
 
     // Check initialization event
@@ -59,7 +59,7 @@ fn test_add_token() {
     assert!(client.is_token_allowed(&token));
 
     // Verify it's in the whitelist
-    let tokens = client.get_whitelisted_tokens();
+    let tokens = client.get_whitelisted_tokens(&0, &50);
     assert_eq!(tokens.len(), 1);
     assert_eq!(tokens.get(0).unwrap(), token);
 
@@ -101,7 +101,7 @@ fn test_remove_token() {
     assert!(!client.is_token_allowed(&token));
 
     // Verify it's not in the whitelist
-    let tokens = client.get_whitelisted_tokens();
+    let tokens = client.get_whitelisted_tokens(&0, &50);
     assert_eq!(tokens.len(), 0);
 
     // Check events were emitted
@@ -154,7 +154,7 @@ fn test_multiple_tokens() {
     assert!(client.is_token_allowed(&token2));
     assert!(client.is_token_allowed(&token3));
 
-    let tokens = client.get_whitelisted_tokens();
+    let tokens = client.get_whitelisted_tokens(&0, &50);
     assert_eq!(tokens.len(), 3);
 
     // Remove one token
@@ -163,7 +163,7 @@ fn test_multiple_tokens() {
     assert!(!client.is_token_allowed(&token2));
     assert!(client.is_token_allowed(&token3));
 
-    let tokens = client.get_whitelisted_tokens();
+    let tokens = client.get_whitelisted_tokens(&0, &50);
     assert_eq!(tokens.len(), 2);
 }
 
@@ -364,7 +364,7 @@ fn test_non_suspended_baseline() {
     client.add_token(&admin, &token);
     assert!(client.is_token_allowed(&token));
 
-    let tokens = client.get_whitelisted_tokens();
+    let tokens = client.get_whitelisted_tokens(&0, &50);
     assert_eq!(tokens.len(), 1);
 
     client.remove_token(&admin, &token);
@@ -401,6 +401,48 @@ fn test_suspend_nonwhitelisted_token_fails() {
 
     let reason = BytesN::from_array(&env, &[1u8; 32]);
     client.suspend_token_timed(&admin, &token, &50u32, &reason);
+}
+
+// ── #589: get_whitelisted_tokens pagination ──────────────────────────────────
+
+#[test]
+fn test_get_whitelisted_tokens_paginated() {
+    let (env, admin, client) = setup_test();
+    let mut tokens: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    for _ in 0..5 {
+        let t = Address::generate(&env);
+        client.add_token(&admin, &t);
+        tokens.push_back(t);
+    }
+
+    let page1 = client.get_whitelisted_tokens(&0, &2);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1.get(0).unwrap(), tokens.get(0).unwrap());
+    assert_eq!(page1.get(1).unwrap(), tokens.get(1).unwrap());
+
+    let page2 = client.get_whitelisted_tokens(&2, &2);
+    assert_eq!(page2.len(), 2);
+    assert_eq!(page2.get(0).unwrap(), tokens.get(2).unwrap());
+    assert_eq!(page2.get(1).unwrap(), tokens.get(3).unwrap());
+
+    let page3 = client.get_whitelisted_tokens(&4, &2);
+    assert_eq!(page3.len(), 1);
+    assert_eq!(page3.get(0).unwrap(), tokens.get(4).unwrap());
+
+    let past_end = client.get_whitelisted_tokens(&10, &2);
+    assert_eq!(past_end.len(), 0);
+}
+
+#[test]
+fn test_get_whitelisted_tokens_limit_capped() {
+    let (env, admin, client) = setup_test();
+    for _ in 0..3 {
+        let t = Address::generate(&env);
+        client.add_token(&admin, &t);
+    }
+    // Requesting a limit above the max page size still only returns what's available.
+    let page = client.get_whitelisted_tokens(&0, &10_000);
+    assert_eq!(page.len(), 3);
 }
 
 // ── #588: set_token_quota / update_token_quota period_ledgers upper bound ────

--- a/contracts/ahjoor-token-whitelist/src/test.rs
+++ b/contracts/ahjoor-token-whitelist/src/test.rs
@@ -1,6 +1,9 @@
 #![cfg(test)]
 
-use crate::{TokenWhitelistContract, TokenWhitelistContractClient};
+use crate::{
+    TokenWhitelistContract, TokenWhitelistContractClient, MAX_QUOTA_PERIOD_LEDGERS,
+    MAX_VOLUME_QUERY_RANGE,
+};
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     Address, BytesN, Env,
@@ -398,4 +401,70 @@ fn test_suspend_nonwhitelisted_token_fails() {
 
     let reason = BytesN::from_array(&env, &[1u8; 32]);
     client.suspend_token_timed(&admin, &token, &50u32, &reason);
+}
+
+// ── #588: set_token_quota / update_token_quota period_ledgers upper bound ────
+
+#[test]
+#[should_panic(expected = "period_ledgers exceeds maximum allowed")]
+fn test_set_token_quota_rejects_oversized_period() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    client.set_token_quota(&admin, &token, &1_000i128, &(MAX_QUOTA_PERIOD_LEDGERS + 1));
+}
+
+#[test]
+fn test_set_token_quota_accepts_max_period() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    client.set_token_quota(&admin, &token, &1_000i128, &MAX_QUOTA_PERIOD_LEDGERS);
+    let quota = client.get_token_quota(&token).unwrap();
+    assert_eq!(quota.period_ledgers, MAX_QUOTA_PERIOD_LEDGERS);
+}
+
+#[test]
+#[should_panic(expected = "period_ledgers exceeds maximum allowed")]
+fn test_update_token_quota_rejects_oversized_period() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+    client.set_token_quota(&admin, &token, &1_000i128, &100u32);
+
+    client.update_token_quota(&admin, &token, &1_000i128, &(MAX_QUOTA_PERIOD_LEDGERS + 1));
+}
+
+// ── Companion: get_token_volume bounded range ────────────────────────────────
+
+#[test]
+#[should_panic(expected = "ledger range exceeds maximum allowed")]
+fn test_get_token_volume_rejects_oversized_range() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    client.get_token_volume(&token, &0u32, &(MAX_VOLUME_QUERY_RANGE + 1));
+}
+
+#[test]
+fn test_get_token_volume_accepts_max_range() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    let volume = client.get_token_volume(&token, &0u32, &MAX_VOLUME_QUERY_RANGE);
+    assert_eq!(volume, 0);
+}
+
+#[test]
+#[should_panic(expected = "from_ledger must not exceed to_ledger")]
+fn test_get_token_volume_rejects_inverted_range() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    client.get_token_volume(&token, &10u32, &5u32);
 }


### PR DESCRIPTION
# Escalations pagination, quota validation & whitelist pagination

## Summary

- Adds `list_pending_senior_escalations` to `ahjoor-refund` so admins can page through refunds currently awaiting senior review instead of scanning all refunds off-chain.
- Bounds `period_ledgers` on `set_token_quota` / `update_token_quota` in `ahjoor-token-whitelist`, and adds a companion bound on `get_token_volume`'s ledger range, so neither can force an unbounded storage-read loop.
- Paginates `get_whitelisted_tokens` in `ahjoor-token-whitelist` (`offset`/`limit`, capped at 50 per call) instead of returning the entire whitelist in one call.

## Changes

### `ahjoor-refund`
- `list_pending_senior_escalations(env, offset, limit)` — returns refund IDs with status `EscalatedToSenior`, paginated, limit capped at 50.

### `ahjoor-token-whitelist`
- `set_token_quota` / `update_token_quota` now reject `period_ledgers > MAX_QUOTA_PERIOD_LEDGERS` (~30 days at 5s ledgers).
- `get_token_volume` now rejects an inverted range (`from_ledger > to_ledger`) and a range wider than `MAX_VOLUME_QUERY_RANGE` (500 ledgers), keeping its per-ledger read loop bounded.
- `get_whitelisted_tokens(env, offset, limit)` — now paginated, limit capped at `DEFAULT_WHITELIST_PAGE_SIZE` (50). **Breaking change**: callers must update from `get_whitelisted_tokens()` to `get_whitelisted_tokens(offset, limit)`.

## Test plan

- [x] `cargo test -p ahjoor-refund` — 116 passed
- [x] `cargo test -p ahjoor-token-whitelist` — 32 passed
- [x] New tests cover: mixed pending/resolved escalations, pagination across pages, empty-list case, oversized/inverted volume ranges, oversized quota periods, whitelist pagination and limit capping.

closes #586
closes #587
closes #588
closes #589
