### PR TITLE
feat(escrow): add typed contracterror enum, namespace in ahjoor-errors

### DIFF
--- a/contracts/ahjoor-errors/src/lib.rs
+++ b/contracts/ahjoor-errors/src/lib.rs
@@ -209,11 +209,256 @@ pub mod payments {
 
 pub mod escrow {
     /// See [`crate::rosca::COUNT`] for why this exists.
-    pub const COUNT: usize = 3;
+    pub const COUNT: usize = 248;
 
     pub const INVALID_DEADLINE: u32        = 3001;
     pub const INVALID_TRANCHE_INDEX: u32   = 3002;
     pub const TRANCHE_ALREADY_CLAIMED: u32 = 3003;
+    pub const ALREADY_INITIALIZED: u32 = 3004;
+    pub const AT_LEAST_ONE_BUYER_IS_REQUIRED: u32 = 3005;
+    pub const DEADLINE_MUST_BE_FUTURE: u32 = 3006;
+    pub const BUYER_CONTRIBUTION_MUST_BE_POSITIVE: u32 = 3007;
+    pub const DUPLICATE_BUYER_IN_LIST: u32 = 3008;
+    pub const BATCH_MUST_CONTAIN_AT_LEAST_ONE_ESCROW_CONFIG: u32 = 3009;
+    pub const BATCH_SIZE_EXCEEDS_MAXIMUM_10_ESCROWS: u32 = 3010;
+    pub const ONLY_SELLER_CAN_MARK_COMPLETE: u32 = 3011;
+    pub const ESCROW_IS_NOT_ACTIVE: u32 = 3012;
+    pub const NO_INSPECTOR_SET_USE_RELEASE_ESCROW_DIRECTLY: u32 = 3013;
+    pub const ESCROW_IS_NOT_AWAITING_INSPECTION: u32 = 3014;
+    pub const ONLY_ASSIGNED_INSPECTOR_CAN_SUBMIT_REPORT: u32 = 3015;
+    pub const ONLY_BUYER_OR_SELLER_CAN_PROPOSE_INSPECTOR_REPLACEMENT: u32 = 3016;
+    pub const NO_INSPECTOR_SET_ESCROW: u32 = 3017;
+    pub const ONLY_ADMIN_CAN_SET_INSPECTOR_SCORE_THRESHOLD: u32 = 3018;
+    pub const MIN_SCORE_BPS_EXCEEDS_MAXIMUM: u32 = 3019;
+    pub const ONLY_ADMIN_CAN_APPEAL_INSPECTOR_RULING: u32 = 3020;
+    pub const INSPECTOR_RULING_ALREADY_APPEALED_ESCROW: u32 = 3021;
+    pub const INSPECTOR_SCORE_BELOW_MINIMUM_THRESHOLD_HIGH_VALUE_ESCROW: u32 = 3022;
+    pub const ESCROW_AMOUNT_MUST_BE_POSITIVE: u32 = 3023;
+    pub const DEADLINE_MUST_BE_AFTER_MIN_LOCK_UNTIL: u32 = 3024;
+    pub const ARBITER_FEE_EXCEEDS_MAXIMUM_1000_BPS: u32 = 3025;
+    pub const INCOMPLETE_RELEASE_CONDITION: u32 = 3026;
+    pub const RELEASE_CONDITION_THRESHOLD_MUST_BE_POSITIVE: u32 = 3027;
+    pub const INVALID_RELEASE_COMPARISON: u32 = 3028;
+    pub const MAXIMUM_5_SELLERS_ALLOWED: u32 = 3029;
+    pub const SELLER_ALLOCATIONS_MUST_SUM_TO_10000_BPS: u32 = 3030;
+    pub const DISPUTE_TIMEOUT_SECONDS_MUST_BE_POSITIVE: u32 = 3031;
+    pub const ONLY_CURRENT_HOLDER_CAN_TRANSFER_RECEIPT: u32 = 3032;
+    pub const ACTIVE_MILESTONE_IN_PROGRESS: u32 = 3033;
+    pub const INSPECTION_PENDING: u32 = 3034;
+    pub const ONLY_LISTED_BUYER_CAN_APPROVE_MULTI_BUYER_RELEASE: u32 = 3035;
+    pub const BUYER_HAS_ALREADY_APPROVED_RELEASE: u32 = 3036;
+    pub const ONLY_BUYER_OR_ARBITER_CAN_RELEASE_ESCROW: u32 = 3037;
+    pub const SELLER_VETO_ACTIVE: u32 = 3038;
+    pub const SELLER_VETO_ACTIVE_2: u32 = 3039;
+    pub const CONDITION_NOT_MET: u32 = 3040;
+    pub const ONLY_BUYER_OR_SELLER_CAN_WAIVE_CONDITION: u32 = 3041;
+    pub const NO_CONDITIONAL_RELEASE_SET_ESCROW: u32 = 3042;
+    pub const ONLY_BUYER_OR_SELLER_CAN_SUBMIT_EVIDENCE: u32 = 3043;
+    pub const MAXIMUM_EVIDENCE_ENTRIES_REACHED_PARTY: u32 = 3044;
+    pub const ONLY_BUYER_CAN_SET_RENEWAL_ALLOWANCE: u32 = 3045;
+    pub const AUTO_RENEW_IS_NOT_ENABLED_ESCROW: u32 = 3046;
+    pub const ONLY_BUYER_CAN_CANCEL_AUTO_RENEW: u32 = 3047;
+    pub const ONLY_BUYER_CAN_CANCEL_AUTO_RENEWAL: u32 = 3048;
+    pub const NO_AUTO_RENEW_CONFIG_SET_ESCROW: u32 = 3049;
+    pub const RELEASE_AMOUNT_MUST_BE_POSITIVE: u32 = 3050;
+    pub const RELEASE_AMOUNT_EXCEEDS_ESCROW_BALANCE: u32 = 3051;
+    pub const AT_LEAST_ONE_MILESTONE_REQUIRED: u32 = 3052;
+    pub const TOO_MANY_MILESTONES: u32 = 3053;
+    pub const MILESTONE_AMOUNT_MUST_BE_POSITIVE: u32 = 3054;
+    pub const NEW_MILESTONES_MUST_START_AS_PENDING: u32 = 3055;
+    pub const ESCROW_ALREADY_TERMINAL: u32 = 3056;
+    pub const ONLY_BUYER_OR_ARBITER_CAN_APPROVE_MILESTONES: u32 = 3057;
+    pub const MILESTONE_INDEX_OUT_RANGE: u32 = 3058;
+    pub const MILESTONE_NOT_PENDING: u32 = 3059;
+    pub const ONLY_BUYER_OR_SELLER_CAN_DISPUTE_ESCROW: u32 = 3060;
+    pub const DISPUTE_AMOUNT_OUT_OF_RANGE: u32 = 3061;
+    pub const BUYER_PERCENT_MUST_BE_BETWEEN_0_AND_100: u32 = 3062;
+    pub const ESCROW_IS_NOT_DISPUTED: u32 = 3063;
+    pub const ONLY_ARBITER_CAN_RESOLVE_DISPUTE: u32 = 3064;
+    pub const ESCROW_IS_NOT_COOLING_OFF_STATE: u32 = 3065;
+    pub const ONLY_BUYER_OR_SELLER_CAN_FLAG_RESOLUTION_ERROR: u32 = 3066;
+    pub const COOLING_OFF_WINDOW_HAS_EXPIRED: u32 = 3067;
+    pub const RESOLUTION_ALREADY_FLAGGED: u32 = 3068;
+    pub const COOLING_OFF_WINDOW_HAS_NOT_ELAPSED: u32 = 3069;
+    pub const RESOLUTION_IS_FLAGGED_ADMIN_MUST_REVIEW_BEFORE_FINALIZATION: u32 = 3070;
+    pub const ONLY_ADMIN_CAN_CLEAR_RESOLUTION_FLAGS: u32 = 3071;
+    pub const NO_FLAG_TO_CLEAR: u32 = 3072;
+    pub const ONLY_ADMIN_CAN_CONFIGURE_COOLING_OFF_PERIOD: u32 = 3073;
+    pub const FEE_CONFIGURATION_EXCEEDS_ESCROW_AMOUNT: u32 = 3074;
+    pub const TIMEOUT_MUST_BE_POSITIVE: u32 = 3075;
+    pub const MULTIPLIER_MUST_BE_POSITIVE: u32 = 3076;
+    pub const DEADLINE_MUST_BE_POSITIVE: u32 = 3077;
+    pub const DISPUTE_ALREADY_RESOLVED: u32 = 3078;
+    pub const DISPUTE_TIMEOUT_DEADLINE_HAS_NOT_PASSED_YET: u32 = 3079;
+    pub const MAX_ORACLE_AGE_MUST_BE_POSITIVE: u32 = 3080;
+    pub const INSURANCE_TRIGGER_DAYS_MUST_BE_POSITIVE: u32 = 3081;
+    pub const INSURANCE_CONTRIBUTION_MUST_BE_POSITIVE: u32 = 3082;
+    pub const ONLY_BUYER_OR_SELLER_CAN_CLAIM_INSURANCE: u32 = 3083;
+    pub const INSURANCE_ALREADY_CLAIMED: u32 = 3084;
+    pub const ADMIN_CONFIRMATION_REQUIRED: u32 = 3085;
+    pub const INSURANCE_TRIGGER_PERIOD_NOT_REACHED: u32 = 3086;
+    pub const ESCROW_TOKEN_NOT_COVERED_BY_INSURANCE_POOL: u32 = 3087;
+    pub const INSURANCE_POOL_HAS_INSUFFICIENT_BALANCE: u32 = 3088;
+    pub const FEE_EXCEEDS_MAXIMUM_200_BPS: u32 = 3089;
+    pub const WITHDRAWAL_AMOUNT_MUST_BE_POSITIVE: u32 = 3090;
+    pub const INSUFFICIENT_ACCRUED_FEES: u32 = 3091;
+    pub const RELEASE_CONDITION_NOT_MET: u32 = 3092;
+    pub const ESCROW_HAS_NOT_EXPIRED_YET: u32 = 3093;
+    pub const ONLY_BUYER_OR_SELLER_CAN_PROPOSE_DEADLINE_EXTENSION: u32 = 3094;
+    pub const CANNOT_EXTEND_DEADLINE_WHILE_ESCROW_IS_DISPUTED: u32 = 3095;
+    pub const NEW_DEADLINE_MUST_BE_GREATER_THAN_CURRENT_DEADLINE: u32 = 3096;
+    pub const ONLY_BUYER_OR_SELLER_CAN_ACCEPT_DEADLINE_EXTENSION: u32 = 3097;
+    pub const PROPOSER_CANNOT_ACCEPT_THEIR_OWN_DEADLINE_EXTENSION: u32 = 3098;
+    pub const DEADLINE_EXTENSION_PROPOSAL_HAS_EXPIRED: u32 = 3099;
+    pub const ONLY_BUYER_OR_SELLER_CAN_PROPOSE_AMENDMENT: u32 = 3100;
+    pub const CANNOT_AMEND_TERMINAL_ESCROW: u32 = 3101;
+    pub const NEW_AMOUNT_MUST_BE_POSITIVE: u32 = 3102;
+    pub const ONLY_BUYER_OR_SELLER_CAN_SIGN_AMENDMENT: u32 = 3103;
+    pub const AMENDMENT_NONCE_MISMATCH: u32 = 3104;
+    pub const AMENDMENT_PROPOSAL_HAS_EXPIRED: u32 = 3105;
+    pub const AMENDMENT_REQUIRES_BUYER_AND_SELLER_SIGNATURES: u32 = 3106;
+    pub const ONLY_BUYER_CAN_TOP_UP_ESCROW: u32 = 3107;
+    pub const ESCROW_IS_NOT_ACTIVE_OR_AWAITING_INSPECTION: u32 = 3108;
+    pub const ADDITIONAL_AMOUNT_MUST_BE_POSITIVE: u32 = 3109;
+    pub const TOP_UP_LIMIT_EXCEEDED: u32 = 3110;
+    pub const ONLY_SELLER_CAN_ACKNOWLEDGE_TOP_UP: u32 = 3111;
+    pub const ONLY_SELLER_CAN_REQUEST_PARTIAL_RELEASE: u32 = 3112;
+    pub const PARTIAL_RELEASE_ONLY_ALLOWED_ACTIVE_ESCROW: u32 = 3113;
+    pub const PARTIAL_RELEASE_AMOUNT_MUST_BE_POSITIVE: u32 = 3114;
+    pub const PARTIAL_RELEASE_AMOUNT_CANNOT_EXCEED_ESCROW_AMOUNT: u32 = 3115;
+    pub const REQUEST_ALREADY_PENDING: u32 = 3116;
+    pub const ONLY_BUYER_CAN_APPROVE_PARTIAL_RELEASE: u32 = 3117;
+    pub const INVALID_REQUEST_ID: u32 = 3118;
+    pub const DELEGATE_MUST_BE_DIFFERENT_FROM_SELLER: u32 = 3119;
+    pub const SELLER_NOT_PART_OF_ESCROW: u32 = 3120;
+    pub const CAN_ONLY_DELEGATE_BEFORE_ESCROW_IS_RELEASED: u32 = 3121;
+    pub const ONLY_BUYER_CAN_REJECT_PARTIAL_RELEASE: u32 = 3122;
+    pub const ONLY_SELLER_CAN_ESCALATE_PARTIAL_RELEASE: u32 = 3123;
+    pub const RESPONSE_DEADLINE_NOT_YET_PASSED: u32 = 3124;
+    pub const NEW_BUYER_MUST_BE_DIFFERENT_FROM_CURRENT_BUYER: u32 = 3125;
+    pub const BUYER_TRANSFER_ONLY_ALLOWED_ACTIVE_ESCROWS: u32 = 3126;
+    pub const ONLY_CURRENT_BUYER_CAN_TRANSFER_BUYER_ROLE: u32 = 3127;
+    pub const ONLY_BUYER_OR_SELLER_CAN_UPDATE_METADATA: u32 = 3128;
+    pub const ONLY_ADMIN_CAN_UPGRADE_CONTRACT: u32 = 3129;
+    pub const ONLY_ADMIN_CAN_MIGRATE_CONTRACT: u32 = 3130;
+    pub const MIGRATION_ALREADY_COMPLETED_VERSION: u32 = 3131;
+    pub const UNLOCK_AT_MUST_BE_FUTURE: u32 = 3132;
+    pub const ALREADY_CLAIMED: u32 = 3133;
+    pub const ONLY_BENEFICIARY_CAN_CLAIM: u32 = 3134;
+    pub const UNLOCK_TIME_HAS_NOT_PASSED: u32 = 3135;
+    pub const ESCROW_NOT_ACTIVE: u32 = 3136;
+    pub const PAST_UNLOCK_TIME_USE_CLAIM_TIMELOCKED: u32 = 3137;
+    pub const ONLY_BUYER_CAN_CANCEL: u32 = 3138;
+    pub const DISPUTE_ACTIVE: u32 = 3139;
+    pub const ONLY_ADMIN_CAN_SET_TOKEN_WHITELIST_CONTRACT: u32 = 3140;
+    pub const CONTRACT_ALREADY_PAUSED: u32 = 3141;
+    pub const CONTRACT_IS_NOT_PAUSED: u32 = 3142;
+    pub const TOKEN_NOT_ALLOWED: u32 = 3143;
+    pub const DEADLINE_DURATION_MUST_BE_POSITIVE: u32 = 3144;
+    pub const TEMPLATE_IS_DEACTIVATED: u32 = 3145;
+    pub const ARBITER_ALREADY_POOL: u32 = 3146;
+    pub const ARBITER_NOT_POOL: u32 = 3147;
+    pub const ARBITER_POOL_IS_EMPTY: u32 = 3148;
+    pub const ONLY_TEMPLATE_CREATOR_CAN_UPDATE: u32 = 3149;
+    pub const ONLY_TEMPLATE_CREATOR_CAN_DEACTIVATE: u32 = 3150;
+    pub const TEMPLATE_ALREADY_DEACTIVATED: u32 = 3151;
+    pub const INACTIVITY_RELEASE_IS_NOT_ENABLED_ESCROW: u32 = 3152;
+    pub const ONLY_ESCROW_SELLER_CAN_CLAIM_INACTIVITY_RELEASE: u32 = 3153;
+    pub const BUYER_INACTIVITY_WINDOW_HAS_NOT_ELAPSED: u32 = 3154;
+    pub const PENALTY_CANNOT_EXCEED_10000_BPS: u32 = 3155;
+    pub const RESPONSE_WINDOW_MUST_BE_POSITIVE: u32 = 3156;
+    pub const ONLY_BUYER_OR_SELLER_CAN_REQUEST_CANCELLATION: u32 = 3157;
+    pub const NO_PENDING_CANCELLATION_ESCROW: u32 = 3158;
+    pub const INITIATOR_CANNOT_ACCEPT_THEIR_OWN_CANCELLATION_REQUEST: u32 = 3159;
+    pub const ONLY_BUYER_OR_SELLER_CAN_ACCEPT_CANCELLATION: u32 = 3160;
+    pub const INITIATOR_CANNOT_REJECT_THEIR_OWN_CANCELLATION_REQUEST: u32 = 3161;
+    pub const ONLY_BUYER_OR_SELLER_CAN_REJECT_CANCELLATION: u32 = 3162;
+    pub const RESPONSE_WINDOW_HAS_NOT_ELAPSED: u32 = 3163;
+    pub const BOUNTY_AMOUNT_MUST_BE_POSITIVE: u32 = 3164;
+    pub const CLAIM_DEADLINE_MUST_BE_FUTURE: u32 = 3165;
+    pub const SUBMISSION_DEADLINE_MUST_BE_AFTER_CLAIM_DEADLINE: u32 = 3166;
+    pub const TOKEN_NOT_WHITELISTED: u32 = 3167;
+    pub const BOUNTY_IS_NOT_AVAILABLE_CLAIMING: u32 = 3168;
+    pub const CLAIM_DEADLINE_HAS_PASSED: u32 = 3169;
+    pub const BOUNTY_IS_NOT_CLAIMED_STATUS: u32 = 3170;
+    pub const ONLY_ASSIGNED_SOLVER_CAN_SUBMIT_WORK: u32 = 3171;
+    pub const SUBMISSION_DEADLINE_HAS_PASSED: u32 = 3172;
+    pub const ONLY_BUYER_CAN_APPROVE_SUBMISSION: u32 = 3173;
+    pub const NO_SUBMISSION_HAS_BEEN_MADE: u32 = 3174;
+    pub const ONLY_BUYER_CAN_REJECT_SUBMISSION: u32 = 3175;
+    pub const MAXIMUM_REJECTION_ROUNDS_REACHED: u32 = 3176;
+    pub const ONLY_BUYER_CAN_CANCEL_BOUNTY: u32 = 3177;
+    pub const CANNOT_CANCEL_BOUNTY_CURRENT_STATE: u32 = 3178;
+    pub const ONLY_ADMIN_CAN_SET_MAX_BOUNTY_REJECTION_ROUNDS: u32 = 3179;
+    pub const BOUNTY_MUST_HAVE_AT_LEAST_ONE_MILESTONE: u32 = 3180;
+    pub const BOUNTY_MUST_BE_CLAIMED_BEFORE_SUBMITTING_MILESTONES: u32 = 3181;
+    pub const ONLY_SOLVER_CAN_SUBMIT_MILESTONES: u32 = 3182;
+    pub const MILESTONE_INDEX_OUT_BOUNDS: u32 = 3183;
+    pub const PREVIOUS_MILESTONE_NOT_YET_VERIFIED: u32 = 3184;
+    pub const MILESTONE_IS_NOT_AWAITING_SUBMISSION: u32 = 3185;
+    pub const MILESTONE_IS_NOT_AWAITING_VERIFICATION: u32 = 3186;
+    pub const ONLY_BOUNTY_CREATOR_CAN_REPLACE_VERIFIER: u32 = 3187;
+    pub const VERIFIER_CAN_ONLY_BE_REPLACED_BEFORE_MILESTONE_IS_SUBMITTED: u32 = 3188;
+    pub const ONLY_BUYER_CAN_CONFIGURE_COLLATERAL_HEALTH: u32 = 3189;
+    pub const MIN_COLLATERAL_RATIO_BPS_OUT_OF_RANGE: u32 = 3190;
+    pub const TOP_UP_AMOUNT_MUST_BE_POSITIVE: u32 = 3191;
+    pub const ESCROW_IS_NOT_ACTIVE_OR_UNDER_COLLATERALIZED: u32 = 3192;
+    pub const ONLY_BUYER_CAN_CONFIGURE_MULTI_PARTY_APPROVAL: u32 = 3193;
+    pub const APPROVERS_COUNT_MUST_BE_BETWEEN_2_AND_10: u32 = 3194;
+    pub const THRESHOLD_MUST_BE_BETWEEN_1_AND_APPROVERS_COUNT: u32 = 3195;
+    pub const CANNOT_RECONFIGURE_APPROVALS_ALREADY_PROGRESS: u32 = 3196;
+    pub const CALLER_IS_NOT_AUTHORIZED_APPROVER_ESCROW: u32 = 3197;
+    pub const APPROVER_HAS_ALREADY_APPROVED_ESCROW: u32 = 3198;
+    pub const RELEASE_SCHEDULE_MUST_CONTAIN_AT_LEAST_ONE_TRANCHE: u32 = 3199;
+    pub const EACH_TRANCHE_AMOUNT_MUST_BE_POSITIVE: u32 = 3200;
+    pub const EACH_TRANCHE_UNLOCK_AT_MUST_BE_FUTURE: u32 = 3201;
+    pub const ONLY_BENEFICIARY_SELLER_CAN_CLAIM_SCHEDULED_RELEASES: u32 = 3202;
+    pub const ESCROW_IS_NOT_CLAIMABLE_STATE: u32 = 3203;
+    pub const NO_TRANCHES_ARE_CURRENTLY_CLAIMABLE: u32 = 3204;
+    pub const CONTRACT_IS_PAUSED: u32 = 3205;
+    pub const ONLY_ADMIN_CAN_PAUSE_CONTRACT: u32 = 3206;
+    pub const ONLY_ADMIN_CAN_RESUME_CONTRACT: u32 = 3207;
+    pub const ESCROW_STILL_LOCKED: u32 = 3208;
+    pub const ORACLE_PRICE_IS_STALE: u32 = 3209;
+    pub const INVALID_ORACLE_PRICE: u32 = 3210;
+    pub const INSUFFICIENT_RENEWAL_ALLOWANCE: u32 = 3211;
+    pub const ESCROW_RENEWAL_DURATION_MUST_BE_POSITIVE: u32 = 3212;
+    pub const ONLY_ADMIN_CAN_SET_MAX_TOP_UP_BPS: u32 = 3213;
+    pub const COLLATERAL_FORFEIT_BPS_CANNOT_EXCEED_10000: u32 = 3214;
+    pub const AT_LEAST_ONE_SELLER_REQUIRED: u32 = 3215;
+    pub const ONLY_SELLER_CAN_DEPOSIT_COLLATERAL: u32 = 3216;
+    pub const ESCROW_IS_NOT_AWAITING_COLLATERAL: u32 = 3217;
+    pub const COLLATERAL_DEPOSIT_WINDOW_HAS_EXPIRED: u32 = 3218;
+    pub const RATING_MUST_BE_BETWEEN_1_AND_5: u32 = 3219;
+    pub const RATING_ONLY_ALLOWED_AFTER_ESCROW_IS_RELEASED_OR_RESOLVED: u32 = 3220;
+    pub const ONLY_BUYER_OR_SELLER_CAN_SUBMIT_RATING: u32 = 3221;
+    pub const RATING_ALREADY_SUBMITTED_ESCROW: u32 = 3222;
+    pub const ONLY_SELLER_CAN_SUBMIT_DELIVERY_PROOF: u32 = 3223;
+    pub const PROOF_SUBMISSION_LOCKED_ESCROW_IS_UNDER_DISPUTE: u32 = 3224;
+    pub const INVALID_DELIVERY_PROOF: u32 = 3225;
+    pub const ONLY_ESCROW_SELLER_CAN_RAISE_VETO: u32 = 3226;
+    pub const VETO_COOLDOWN_ACTIVE: u32 = 3227;
+    pub const ONLY_BUYER_CAN_APPROVE: u32 = 3228;
+    pub const NO_PENDING_SELLER_TRANSFER: u32 = 3229;
+    pub const ONLY_ADMIN_CAN_SET_VETO_OVERRIDE_WINDOW: u32 = 3230;
+    pub const WINDOW_SECONDS_MUST_BE_POSITIVE: u32 = 3231;
+    pub const ONLY_ESCROW_SELLER_CAN_CANCEL_VETO: u32 = 3232;
+    pub const VETO_WINDOW_ELAPSED: u32 = 3233;
+    pub const ONLY_ADMIN_CAN_OVERRIDE_SELLER_VETO: u32 = 3234;
+    pub const ACTIVE_DISPUTE_EXISTS: u32 = 3235;
+    pub const VETO_WINDOW_NOT_ELAPSED: u32 = 3236;
+    pub const VETO_WINDOW_HAS_NOT_EXPIRED_YET: u32 = 3237;
+    pub const ONLY_CURRENT_SELLER_CAN_INITIATE_TRANSFER: u32 = 3238;
+    pub const ESCROW_MUST_BE_ACTIVE_TO_TRANSFER_SELLER_ROLE: u32 = 3239;
+    pub const ONLY_BUYER_CAN_VETO: u32 = 3240;
+    pub const ONLY_ADMIN_CAN_SET_VETO_WINDOW: u32 = 3241;
+    pub const RELEASE_BPS_MUST_BE_POSITIVE_EACH_MILESTONE: u32 = 3242;
+    pub const MILESTONE_RELEASE_BPS_MUST_SUM_TO_10000: u32 = 3243;
+    pub const ONLY_ESCROW_SELLER_MAY_SUBMIT_MILESTONES: u32 = 3244;
+    pub const MILESTONE_MUST_BE_PENDING_OR_REJECTED_TO_SUBMIT: u32 = 3245;
+    pub const MILESTONE_MUST_BE_SUBMITTED_BEFORE_APPROVAL: u32 = 3246;
+    pub const ONLY_ESCROW_BUYER_MAY_REJECT_MILESTONES: u32 = 3247;
+    pub const ONLY_SUBMITTED_MILESTONE_CAN_BE_REJECTED: u32 = 3248;
 }
 
 // ---------------------------------------------------------------------------
@@ -427,10 +672,255 @@ pub static ALL_ERRORS: &[ErrorEntry] = &[
     ErrorEntry { code: payments::DAO_VOTE_WINDOW_CLOSED, name: "DaoVoteWindowClosed", contract: "ahjoor-payments" },
     ErrorEntry { code: payments::DAO_ALREADY_VOTED, name: "DaoAlreadyVoted", contract: "ahjoor-payments" },
 
-    // escrow (3 entries — must match escrow::COUNT)
+    // escrow (248 entries — must match escrow::COUNT)
     ErrorEntry { code: escrow::INVALID_DEADLINE, name: "InvalidDeadline", contract: "ahjoor-escrow" },
     ErrorEntry { code: escrow::INVALID_TRANCHE_INDEX, name: "InvalidTrancheIndex", contract: "ahjoor-escrow" },
     ErrorEntry { code: escrow::TRANCHE_ALREADY_CLAIMED, name: "TrancheAlreadyClaimed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ALREADY_INITIALIZED, name: "AlreadyInitialized", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::AT_LEAST_ONE_BUYER_IS_REQUIRED, name: "AtLeastOneBuyerIsRequired", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DEADLINE_MUST_BE_FUTURE, name: "DeadlineMustBeFuture", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BUYER_CONTRIBUTION_MUST_BE_POSITIVE, name: "BuyerContributionMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DUPLICATE_BUYER_IN_LIST, name: "DuplicateBuyerInList", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BATCH_MUST_CONTAIN_AT_LEAST_ONE_ESCROW_CONFIG, name: "BatchMustContainAtLeastOneEscrowConfig", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BATCH_SIZE_EXCEEDS_MAXIMUM_10_ESCROWS, name: "BatchSizeExceedsMaximum10Escrows", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_SELLER_CAN_MARK_COMPLETE, name: "OnlySellerCanMarkComplete", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_IS_NOT_ACTIVE, name: "EscrowIsNotActive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NO_INSPECTOR_SET_USE_RELEASE_ESCROW_DIRECTLY, name: "NoInspectorSetUseReleaseEscrowDirectly", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_IS_NOT_AWAITING_INSPECTION, name: "EscrowIsNotAwaitingInspection", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ASSIGNED_INSPECTOR_CAN_SUBMIT_REPORT, name: "OnlyAssignedInspectorCanSubmitReport", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_PROPOSE_INSPECTOR_REPLACEMENT, name: "OnlyBuyerOrSellerCanProposeInspectorReplacement", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NO_INSPECTOR_SET_ESCROW, name: "NoInspectorSetEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_SET_INSPECTOR_SCORE_THRESHOLD, name: "OnlyAdminCanSetInspectorScoreThreshold", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MIN_SCORE_BPS_EXCEEDS_MAXIMUM, name: "MinScoreBpsExceedsMaximum", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_APPEAL_INSPECTOR_RULING, name: "OnlyAdminCanAppealInspectorRuling", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSPECTOR_RULING_ALREADY_APPEALED_ESCROW, name: "InspectorRulingAlreadyAppealedEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSPECTOR_SCORE_BELOW_MINIMUM_THRESHOLD_HIGH_VALUE_ESCROW, name: "InspectorScoreBelowMinimumThresholdHighValueEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_AMOUNT_MUST_BE_POSITIVE, name: "EscrowAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DEADLINE_MUST_BE_AFTER_MIN_LOCK_UNTIL, name: "DeadlineMustBeAfterMinLockUntil", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ARBITER_FEE_EXCEEDS_MAXIMUM_1000_BPS, name: "ArbiterFeeExceedsMaximum1000Bps", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INCOMPLETE_RELEASE_CONDITION, name: "IncompleteReleaseCondition", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RELEASE_CONDITION_THRESHOLD_MUST_BE_POSITIVE, name: "ReleaseConditionThresholdMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INVALID_RELEASE_COMPARISON, name: "InvalidReleaseComparison", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MAXIMUM_5_SELLERS_ALLOWED, name: "Maximum5SellersAllowed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::SELLER_ALLOCATIONS_MUST_SUM_TO_10000_BPS, name: "SellerAllocationsMustSumTo10000Bps", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DISPUTE_TIMEOUT_SECONDS_MUST_BE_POSITIVE, name: "DisputeTimeoutSecondsMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_CURRENT_HOLDER_CAN_TRANSFER_RECEIPT, name: "OnlyCurrentHolderCanTransferReceipt", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ACTIVE_MILESTONE_IN_PROGRESS, name: "ActiveMilestoneInProgress", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSPECTION_PENDING, name: "InspectionPending", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_LISTED_BUYER_CAN_APPROVE_MULTI_BUYER_RELEASE, name: "OnlyListedBuyerCanApproveMultiBuyerRelease", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BUYER_HAS_ALREADY_APPROVED_RELEASE, name: "BuyerHasAlreadyApprovedRelease", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_ARBITER_CAN_RELEASE_ESCROW, name: "OnlyBuyerOrArbiterCanReleaseEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::SELLER_VETO_ACTIVE, name: "SellerVetoActive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::SELLER_VETO_ACTIVE_2, name: "SellerVetoActive2", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CONDITION_NOT_MET, name: "ConditionNotMet", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_WAIVE_CONDITION, name: "OnlyBuyerOrSellerCanWaiveCondition", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NO_CONDITIONAL_RELEASE_SET_ESCROW, name: "NoConditionalReleaseSetEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_SUBMIT_EVIDENCE, name: "OnlyBuyerOrSellerCanSubmitEvidence", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MAXIMUM_EVIDENCE_ENTRIES_REACHED_PARTY, name: "MaximumEvidenceEntriesReachedParty", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_SET_RENEWAL_ALLOWANCE, name: "OnlyBuyerCanSetRenewalAllowance", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::AUTO_RENEW_IS_NOT_ENABLED_ESCROW, name: "AutoRenewIsNotEnabledEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_CANCEL_AUTO_RENEW, name: "OnlyBuyerCanCancelAutoRenew", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_CANCEL_AUTO_RENEWAL, name: "OnlyBuyerCanCancelAutoRenewal", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NO_AUTO_RENEW_CONFIG_SET_ESCROW, name: "NoAutoRenewConfigSetEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RELEASE_AMOUNT_MUST_BE_POSITIVE, name: "ReleaseAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RELEASE_AMOUNT_EXCEEDS_ESCROW_BALANCE, name: "ReleaseAmountExceedsEscrowBalance", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::AT_LEAST_ONE_MILESTONE_REQUIRED, name: "AtLeastOneMilestoneRequired", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::TOO_MANY_MILESTONES, name: "TooManyMilestones", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MILESTONE_AMOUNT_MUST_BE_POSITIVE, name: "MilestoneAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NEW_MILESTONES_MUST_START_AS_PENDING, name: "NewMilestonesMustStartAsPending", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_ALREADY_TERMINAL, name: "EscrowAlreadyTerminal", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_ARBITER_CAN_APPROVE_MILESTONES, name: "OnlyBuyerOrArbiterCanApproveMilestones", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MILESTONE_INDEX_OUT_RANGE, name: "MilestoneIndexOutRange", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MILESTONE_NOT_PENDING, name: "MilestoneNotPending", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_DISPUTE_ESCROW, name: "OnlyBuyerOrSellerCanDisputeEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DISPUTE_AMOUNT_OUT_OF_RANGE, name: "DisputeAmountOutOfRange", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BUYER_PERCENT_MUST_BE_BETWEEN_0_AND_100, name: "BuyerPercentMustBeBetween0And100", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_IS_NOT_DISPUTED, name: "EscrowIsNotDisputed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ARBITER_CAN_RESOLVE_DISPUTE, name: "OnlyArbiterCanResolveDispute", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_IS_NOT_COOLING_OFF_STATE, name: "EscrowIsNotCoolingOffState", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_FLAG_RESOLUTION_ERROR, name: "OnlyBuyerOrSellerCanFlagResolutionError", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::COOLING_OFF_WINDOW_HAS_EXPIRED, name: "CoolingOffWindowHasExpired", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RESOLUTION_ALREADY_FLAGGED, name: "ResolutionAlreadyFlagged", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::COOLING_OFF_WINDOW_HAS_NOT_ELAPSED, name: "CoolingOffWindowHasNotElapsed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RESOLUTION_IS_FLAGGED_ADMIN_MUST_REVIEW_BEFORE_FINALIZATION, name: "ResolutionIsFlaggedAdminMustReviewBeforeFinalization", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_CLEAR_RESOLUTION_FLAGS, name: "OnlyAdminCanClearResolutionFlags", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NO_FLAG_TO_CLEAR, name: "NoFlagToClear", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_CONFIGURE_COOLING_OFF_PERIOD, name: "OnlyAdminCanConfigureCoolingOffPeriod", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::FEE_CONFIGURATION_EXCEEDS_ESCROW_AMOUNT, name: "FeeConfigurationExceedsEscrowAmount", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::TIMEOUT_MUST_BE_POSITIVE, name: "TimeoutMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MULTIPLIER_MUST_BE_POSITIVE, name: "MultiplierMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DEADLINE_MUST_BE_POSITIVE, name: "DeadlineMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DISPUTE_ALREADY_RESOLVED, name: "DisputeAlreadyResolved", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DISPUTE_TIMEOUT_DEADLINE_HAS_NOT_PASSED_YET, name: "DisputeTimeoutDeadlineHasNotPassedYet", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MAX_ORACLE_AGE_MUST_BE_POSITIVE, name: "MaxOracleAgeMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSURANCE_TRIGGER_DAYS_MUST_BE_POSITIVE, name: "InsuranceTriggerDaysMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSURANCE_CONTRIBUTION_MUST_BE_POSITIVE, name: "InsuranceContributionMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_CLAIM_INSURANCE, name: "OnlyBuyerOrSellerCanClaimInsurance", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSURANCE_ALREADY_CLAIMED, name: "InsuranceAlreadyClaimed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ADMIN_CONFIRMATION_REQUIRED, name: "AdminConfirmationRequired", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSURANCE_TRIGGER_PERIOD_NOT_REACHED, name: "InsuranceTriggerPeriodNotReached", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_TOKEN_NOT_COVERED_BY_INSURANCE_POOL, name: "EscrowTokenNotCoveredByInsurancePool", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSURANCE_POOL_HAS_INSUFFICIENT_BALANCE, name: "InsurancePoolHasInsufficientBalance", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::FEE_EXCEEDS_MAXIMUM_200_BPS, name: "FeeExceedsMaximum200Bps", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::WITHDRAWAL_AMOUNT_MUST_BE_POSITIVE, name: "WithdrawalAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSUFFICIENT_ACCRUED_FEES, name: "InsufficientAccruedFees", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RELEASE_CONDITION_NOT_MET, name: "ReleaseConditionNotMet", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_HAS_NOT_EXPIRED_YET, name: "EscrowHasNotExpiredYet", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_PROPOSE_DEADLINE_EXTENSION, name: "OnlyBuyerOrSellerCanProposeDeadlineExtension", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CANNOT_EXTEND_DEADLINE_WHILE_ESCROW_IS_DISPUTED, name: "CannotExtendDeadlineWhileEscrowIsDisputed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NEW_DEADLINE_MUST_BE_GREATER_THAN_CURRENT_DEADLINE, name: "NewDeadlineMustBeGreaterThanCurrentDeadline", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_ACCEPT_DEADLINE_EXTENSION, name: "OnlyBuyerOrSellerCanAcceptDeadlineExtension", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::PROPOSER_CANNOT_ACCEPT_THEIR_OWN_DEADLINE_EXTENSION, name: "ProposerCannotAcceptTheirOwnDeadlineExtension", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DEADLINE_EXTENSION_PROPOSAL_HAS_EXPIRED, name: "DeadlineExtensionProposalHasExpired", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_PROPOSE_AMENDMENT, name: "OnlyBuyerOrSellerCanProposeAmendment", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CANNOT_AMEND_TERMINAL_ESCROW, name: "CannotAmendTerminalEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NEW_AMOUNT_MUST_BE_POSITIVE, name: "NewAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_SIGN_AMENDMENT, name: "OnlyBuyerOrSellerCanSignAmendment", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::AMENDMENT_NONCE_MISMATCH, name: "AmendmentNonceMismatch", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::AMENDMENT_PROPOSAL_HAS_EXPIRED, name: "AmendmentProposalHasExpired", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::AMENDMENT_REQUIRES_BUYER_AND_SELLER_SIGNATURES, name: "AmendmentRequiresBuyerAndSellerSignatures", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_TOP_UP_ESCROW, name: "OnlyBuyerCanTopUpEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_IS_NOT_ACTIVE_OR_AWAITING_INSPECTION, name: "EscrowIsNotActiveOrAwaitingInspection", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ADDITIONAL_AMOUNT_MUST_BE_POSITIVE, name: "AdditionalAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::TOP_UP_LIMIT_EXCEEDED, name: "TopUpLimitExceeded", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_SELLER_CAN_ACKNOWLEDGE_TOP_UP, name: "OnlySellerCanAcknowledgeTopUp", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_SELLER_CAN_REQUEST_PARTIAL_RELEASE, name: "OnlySellerCanRequestPartialRelease", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::PARTIAL_RELEASE_ONLY_ALLOWED_ACTIVE_ESCROW, name: "PartialReleaseOnlyAllowedActiveEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::PARTIAL_RELEASE_AMOUNT_MUST_BE_POSITIVE, name: "PartialReleaseAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::PARTIAL_RELEASE_AMOUNT_CANNOT_EXCEED_ESCROW_AMOUNT, name: "PartialReleaseAmountCannotExceedEscrowAmount", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::REQUEST_ALREADY_PENDING, name: "RequestAlreadyPending", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_APPROVE_PARTIAL_RELEASE, name: "OnlyBuyerCanApprovePartialRelease", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INVALID_REQUEST_ID, name: "InvalidRequestID", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DELEGATE_MUST_BE_DIFFERENT_FROM_SELLER, name: "DelegateMustBeDifferentFromSeller", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::SELLER_NOT_PART_OF_ESCROW, name: "SellerNotPartOfEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CAN_ONLY_DELEGATE_BEFORE_ESCROW_IS_RELEASED, name: "CanOnlyDelegateBeforeEscrowIsReleased", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_REJECT_PARTIAL_RELEASE, name: "OnlyBuyerCanRejectPartialRelease", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_SELLER_CAN_ESCALATE_PARTIAL_RELEASE, name: "OnlySellerCanEscalatePartialRelease", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RESPONSE_DEADLINE_NOT_YET_PASSED, name: "ResponseDeadlineNotYetPassed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NEW_BUYER_MUST_BE_DIFFERENT_FROM_CURRENT_BUYER, name: "NewBuyerMustBeDifferentFromCurrentBuyer", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BUYER_TRANSFER_ONLY_ALLOWED_ACTIVE_ESCROWS, name: "BuyerTransferOnlyAllowedActiveEscrows", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_CURRENT_BUYER_CAN_TRANSFER_BUYER_ROLE, name: "OnlyCurrentBuyerCanTransferBuyerRole", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_UPDATE_METADATA, name: "OnlyBuyerOrSellerCanUpdateMetadata", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_UPGRADE_CONTRACT, name: "OnlyAdminCanUpgradeContract", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_MIGRATE_CONTRACT, name: "OnlyAdminCanMigrateContract", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MIGRATION_ALREADY_COMPLETED_VERSION, name: "MigrationAlreadyCompletedVersion", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::UNLOCK_AT_MUST_BE_FUTURE, name: "UnlockAtMustBeFuture", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ALREADY_CLAIMED, name: "AlreadyClaimed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BENEFICIARY_CAN_CLAIM, name: "OnlyBeneficiaryCanClaim", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::UNLOCK_TIME_HAS_NOT_PASSED, name: "UnlockTimeHasNotPassed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_NOT_ACTIVE, name: "EscrowNotActive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::PAST_UNLOCK_TIME_USE_CLAIM_TIMELOCKED, name: "PastUnlockTimeUseClaimTimelocked", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_CANCEL, name: "OnlyBuyerCanCancel", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DISPUTE_ACTIVE, name: "DisputeActive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_SET_TOKEN_WHITELIST_CONTRACT, name: "OnlyAdminCanSetTokenWhitelistContract", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CONTRACT_ALREADY_PAUSED, name: "ContractAlreadyPaused", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CONTRACT_IS_NOT_PAUSED, name: "ContractIsNotPaused", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::TOKEN_NOT_ALLOWED, name: "TokenNotAllowed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::DEADLINE_DURATION_MUST_BE_POSITIVE, name: "DeadlineDurationMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::TEMPLATE_IS_DEACTIVATED, name: "TemplateIsDeactivated", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ARBITER_ALREADY_POOL, name: "ArbiterAlreadyPool", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ARBITER_NOT_POOL, name: "ArbiterNotPool", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ARBITER_POOL_IS_EMPTY, name: "ArbiterPoolIsEmpty", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_TEMPLATE_CREATOR_CAN_UPDATE, name: "OnlyTemplateCreatorCanUpdate", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_TEMPLATE_CREATOR_CAN_DEACTIVATE, name: "OnlyTemplateCreatorCanDeactivate", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::TEMPLATE_ALREADY_DEACTIVATED, name: "TemplateAlreadyDeactivated", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INACTIVITY_RELEASE_IS_NOT_ENABLED_ESCROW, name: "InactivityReleaseIsNotEnabledEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ESCROW_SELLER_CAN_CLAIM_INACTIVITY_RELEASE, name: "OnlyEscrowSellerCanClaimInactivityRelease", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BUYER_INACTIVITY_WINDOW_HAS_NOT_ELAPSED, name: "BuyerInactivityWindowHasNotElapsed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::PENALTY_CANNOT_EXCEED_10000_BPS, name: "PenaltyCannotExceed10000Bps", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RESPONSE_WINDOW_MUST_BE_POSITIVE, name: "ResponseWindowMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_REQUEST_CANCELLATION, name: "OnlyBuyerOrSellerCanRequestCancellation", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NO_PENDING_CANCELLATION_ESCROW, name: "NoPendingCancellationEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INITIATOR_CANNOT_ACCEPT_THEIR_OWN_CANCELLATION_REQUEST, name: "InitiatorCannotAcceptTheirOwnCancellationRequest", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_ACCEPT_CANCELLATION, name: "OnlyBuyerOrSellerCanAcceptCancellation", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INITIATOR_CANNOT_REJECT_THEIR_OWN_CANCELLATION_REQUEST, name: "InitiatorCannotRejectTheirOwnCancellationRequest", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_REJECT_CANCELLATION, name: "OnlyBuyerOrSellerCanRejectCancellation", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RESPONSE_WINDOW_HAS_NOT_ELAPSED, name: "ResponseWindowHasNotElapsed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BOUNTY_AMOUNT_MUST_BE_POSITIVE, name: "BountyAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CLAIM_DEADLINE_MUST_BE_FUTURE, name: "ClaimDeadlineMustBeFuture", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::SUBMISSION_DEADLINE_MUST_BE_AFTER_CLAIM_DEADLINE, name: "SubmissionDeadlineMustBeAfterClaimDeadline", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::TOKEN_NOT_WHITELISTED, name: "TokenNotWhitelisted", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BOUNTY_IS_NOT_AVAILABLE_CLAIMING, name: "BountyIsNotAvailableClaiming", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CLAIM_DEADLINE_HAS_PASSED, name: "ClaimDeadlineHasPassed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BOUNTY_IS_NOT_CLAIMED_STATUS, name: "BountyIsNotClaimedStatus", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ASSIGNED_SOLVER_CAN_SUBMIT_WORK, name: "OnlyAssignedSolverCanSubmitWork", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::SUBMISSION_DEADLINE_HAS_PASSED, name: "SubmissionDeadlineHasPassed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_APPROVE_SUBMISSION, name: "OnlyBuyerCanApproveSubmission", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NO_SUBMISSION_HAS_BEEN_MADE, name: "NoSubmissionHasBeenMade", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_REJECT_SUBMISSION, name: "OnlyBuyerCanRejectSubmission", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MAXIMUM_REJECTION_ROUNDS_REACHED, name: "MaximumRejectionRoundsReached", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_CANCEL_BOUNTY, name: "OnlyBuyerCanCancelBounty", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CANNOT_CANCEL_BOUNTY_CURRENT_STATE, name: "CannotCancelBountyCurrentState", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_SET_MAX_BOUNTY_REJECTION_ROUNDS, name: "OnlyAdminCanSetMaxBountyRejectionRounds", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BOUNTY_MUST_HAVE_AT_LEAST_ONE_MILESTONE, name: "BountyMustHaveAtLeastOneMilestone", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::BOUNTY_MUST_BE_CLAIMED_BEFORE_SUBMITTING_MILESTONES, name: "BountyMustBeClaimedBeforeSubmittingMilestones", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_SOLVER_CAN_SUBMIT_MILESTONES, name: "OnlySolverCanSubmitMilestones", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MILESTONE_INDEX_OUT_BOUNDS, name: "MilestoneIndexOutBounds", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::PREVIOUS_MILESTONE_NOT_YET_VERIFIED, name: "PreviousMilestoneNotYetVerified", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MILESTONE_IS_NOT_AWAITING_SUBMISSION, name: "MilestoneIsNotAwaitingSubmission", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MILESTONE_IS_NOT_AWAITING_VERIFICATION, name: "MilestoneIsNotAwaitingVerification", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BOUNTY_CREATOR_CAN_REPLACE_VERIFIER, name: "OnlyBountyCreatorCanReplaceVerifier", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::VERIFIER_CAN_ONLY_BE_REPLACED_BEFORE_MILESTONE_IS_SUBMITTED, name: "VerifierCanOnlyBeReplacedBeforeMilestoneIsSubmitted", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_CONFIGURE_COLLATERAL_HEALTH, name: "OnlyBuyerCanConfigureCollateralHealth", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MIN_COLLATERAL_RATIO_BPS_OUT_OF_RANGE, name: "MinCollateralRatioBpsOutOfRange", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::TOP_UP_AMOUNT_MUST_BE_POSITIVE, name: "TopUpAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_IS_NOT_ACTIVE_OR_UNDER_COLLATERALIZED, name: "EscrowIsNotActiveOrUnderCollateralized", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_CONFIGURE_MULTI_PARTY_APPROVAL, name: "OnlyBuyerCanConfigureMultiPartyApproval", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::APPROVERS_COUNT_MUST_BE_BETWEEN_2_AND_10, name: "ApproversCountMustBeBetween2And10", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::THRESHOLD_MUST_BE_BETWEEN_1_AND_APPROVERS_COUNT, name: "ThresholdMustBeBetween1AndApproversCount", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CANNOT_RECONFIGURE_APPROVALS_ALREADY_PROGRESS, name: "CannotReconfigureApprovalsAlreadyProgress", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CALLER_IS_NOT_AUTHORIZED_APPROVER_ESCROW, name: "CallerIsNotAuthorizedApproverEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::APPROVER_HAS_ALREADY_APPROVED_ESCROW, name: "ApproverHasAlreadyApprovedEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RELEASE_SCHEDULE_MUST_CONTAIN_AT_LEAST_ONE_TRANCHE, name: "ReleaseScheduleMustContainAtLeastOneTranche", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::EACH_TRANCHE_AMOUNT_MUST_BE_POSITIVE, name: "EachTrancheAmountMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::EACH_TRANCHE_UNLOCK_AT_MUST_BE_FUTURE, name: "EachTrancheUnlockAtMustBeFuture", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BENEFICIARY_SELLER_CAN_CLAIM_SCHEDULED_RELEASES, name: "OnlyBeneficiarySellerCanClaimScheduledReleases", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_IS_NOT_CLAIMABLE_STATE, name: "EscrowIsNotClaimableState", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NO_TRANCHES_ARE_CURRENTLY_CLAIMABLE, name: "NoTranchesAreCurrentlyClaimable", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::CONTRACT_IS_PAUSED, name: "ContractIsPaused", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_PAUSE_CONTRACT, name: "OnlyAdminCanPauseContract", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_RESUME_CONTRACT, name: "OnlyAdminCanResumeContract", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_STILL_LOCKED, name: "EscrowStillLocked", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ORACLE_PRICE_IS_STALE, name: "OraclePriceIsStale", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INVALID_ORACLE_PRICE, name: "InvalidOraclePrice", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INSUFFICIENT_RENEWAL_ALLOWANCE, name: "InsufficientRenewalAllowance", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_RENEWAL_DURATION_MUST_BE_POSITIVE, name: "EscrowRenewalDurationMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_SET_MAX_TOP_UP_BPS, name: "OnlyAdminCanSetMaxTopUpBps", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::COLLATERAL_FORFEIT_BPS_CANNOT_EXCEED_10000, name: "CollateralForfeitBpsCannotExceed10000", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::AT_LEAST_ONE_SELLER_REQUIRED, name: "AtLeastOneSellerRequired", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_SELLER_CAN_DEPOSIT_COLLATERAL, name: "OnlySellerCanDepositCollateral", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_IS_NOT_AWAITING_COLLATERAL, name: "EscrowIsNotAwaitingCollateral", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::COLLATERAL_DEPOSIT_WINDOW_HAS_EXPIRED, name: "CollateralDepositWindowHasExpired", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RATING_MUST_BE_BETWEEN_1_AND_5, name: "RatingMustBeBetween1And5", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RATING_ONLY_ALLOWED_AFTER_ESCROW_IS_RELEASED_OR_RESOLVED, name: "RatingOnlyAllowedAfterEscrowIsReleasedOrResolved", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_OR_SELLER_CAN_SUBMIT_RATING, name: "OnlyBuyerOrSellerCanSubmitRating", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RATING_ALREADY_SUBMITTED_ESCROW, name: "RatingAlreadySubmittedEscrow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_SELLER_CAN_SUBMIT_DELIVERY_PROOF, name: "OnlySellerCanSubmitDeliveryProof", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::PROOF_SUBMISSION_LOCKED_ESCROW_IS_UNDER_DISPUTE, name: "ProofSubmissionLockedEscrowIsUnderDispute", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::INVALID_DELIVERY_PROOF, name: "InvalidDeliveryProof", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ESCROW_SELLER_CAN_RAISE_VETO, name: "OnlyEscrowSellerCanRaiseVeto", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::VETO_COOLDOWN_ACTIVE, name: "VetoCooldownActive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_APPROVE, name: "OnlyBuyerCanApprove", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::NO_PENDING_SELLER_TRANSFER, name: "NoPendingSellerTransfer", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_SET_VETO_OVERRIDE_WINDOW, name: "OnlyAdminCanSetVetoOverrideWindow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::WINDOW_SECONDS_MUST_BE_POSITIVE, name: "WindowSecondsMustBePositive", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ESCROW_SELLER_CAN_CANCEL_VETO, name: "OnlyEscrowSellerCanCancelVeto", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::VETO_WINDOW_ELAPSED, name: "VetoWindowElapsed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_OVERRIDE_SELLER_VETO, name: "OnlyAdminCanOverrideSellerVeto", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ACTIVE_DISPUTE_EXISTS, name: "ActiveDisputeExists", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::VETO_WINDOW_NOT_ELAPSED, name: "VetoWindowNotElapsed", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::VETO_WINDOW_HAS_NOT_EXPIRED_YET, name: "VetoWindowHasNotExpiredYet", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_CURRENT_SELLER_CAN_INITIATE_TRANSFER, name: "OnlyCurrentSellerCanInitiateTransfer", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ESCROW_MUST_BE_ACTIVE_TO_TRANSFER_SELLER_ROLE, name: "EscrowMustBeActiveToTransferSellerRole", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_BUYER_CAN_VETO, name: "OnlyBuyerCanVeto", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ADMIN_CAN_SET_VETO_WINDOW, name: "OnlyAdminCanSetVetoWindow", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::RELEASE_BPS_MUST_BE_POSITIVE_EACH_MILESTONE, name: "ReleaseBpsMustBePositiveEachMilestone", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MILESTONE_RELEASE_BPS_MUST_SUM_TO_10000, name: "MilestoneReleaseBpsMustSumTo10000", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ESCROW_SELLER_MAY_SUBMIT_MILESTONES, name: "OnlyEscrowSellerMaySubmitMilestones", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MILESTONE_MUST_BE_PENDING_OR_REJECTED_TO_SUBMIT, name: "MilestoneMustBePendingOrRejectedToSubmit", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::MILESTONE_MUST_BE_SUBMITTED_BEFORE_APPROVAL, name: "MilestoneMustBeSubmittedBeforeApproval", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_ESCROW_BUYER_MAY_REJECT_MILESTONES, name: "OnlyEscrowBuyerMayRejectMilestones", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_SUBMITTED_MILESTONE_CAN_BE_REJECTED, name: "OnlySubmittedMilestoneCanBeRejected", contract: "ahjoor-escrow" },
 
     // refund (8 entries — must match refund::COUNT)
     ErrorEntry { code: refund::ALREADY_INITIALIZED, name: "AlreadyInitialized", contract: "ahjoor-refund" },

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -23,6 +23,279 @@ pub enum EscrowError {
     InvalidDeadline = 1,
     InvalidTrancheIndex = 2,
     TrancheAlreadyClaimed = 3,
+    AlreadyInitialized = 4,
+    AtLeastOneBuyerIsRequired = 5,
+    DeadlineMustBeFuture = 6,
+    BuyerContributionMustBePositive = 7,
+    DuplicateBuyerInList = 8,
+    BatchMustContainAtLeastOneEscrowConfig = 9,
+    BatchSizeExceedsMaximum10Escrows = 10,
+    OnlySellerCanMarkComplete = 11,
+    EscrowIsNotActive = 12,
+    NoInspectorSetUseReleaseEscrowDirectly = 13,
+    EscrowIsNotAwaitingInspection = 14,
+    OnlyAssignedInspectorCanSubmitReport = 15,
+    OnlyBuyerOrSellerCanProposeInspectorReplacement = 16,
+    NoInspectorSetEscrow = 17,
+    OnlyAdminCanSetInspectorScoreThreshold = 18,
+    MinScoreBpsExceedsMaximum = 19,
+    OnlyAdminCanAppealInspectorRuling = 20,
+    InspectorRulingAlreadyAppealedEscrow = 21,
+    InspectorScoreBelowMinimumThresholdHighValueEscrow = 22,
+    EscrowAmountMustBePositive = 23,
+    DeadlineMustBeAfterMinLockUntil = 24,
+    ArbiterFeeExceedsMaximum1000Bps = 25,
+    IncompleteReleaseCondition = 26,
+    ReleaseConditionThresholdMustBePositive = 27,
+    InvalidReleaseComparison = 28,
+    Maximum5SellersAllowed = 29,
+    SellerAllocationsMustSumTo10000Bps = 30,
+    DisputeTimeoutSecondsMustBePositive = 31,
+    OnlyCurrentHolderCanTransferReceipt = 32,
+    ActiveMilestoneInProgress = 33,
+    InspectionPending = 34,
+    OnlyListedBuyerCanApproveMultiBuyerRelease = 35,
+    BuyerHasAlreadyApprovedRelease = 36,
+    OnlyBuyerOrArbiterCanReleaseEscrow = 37,
+    SellerVetoActive = 38,
+    SellerVetoActive2 = 39,
+    ConditionNotMet = 40,
+    OnlyBuyerOrSellerCanWaiveCondition = 41,
+    NoConditionalReleaseSetEscrow = 42,
+    OnlyBuyerOrSellerCanSubmitEvidence = 43,
+    MaximumEvidenceEntriesReachedParty = 44,
+    OnlyBuyerCanSetRenewalAllowance = 45,
+    AutoRenewIsNotEnabledEscrow = 46,
+    OnlyBuyerCanCancelAutoRenew = 47,
+    OnlyBuyerCanCancelAutoRenewal = 48,
+    NoAutoRenewConfigSetEscrow = 49,
+    ReleaseAmountMustBePositive = 50,
+}
+
+/// Extension error codes — split from EscrowError because #[contracterror]
+/// is bounded by the soroban XDR 50-case limit.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EscrowErrorExt {
+    ReleaseAmountExceedsEscrowBalance = 1,
+    AtLeastOneMilestoneRequired = 2,
+    TooManyMilestones = 3,
+    MilestoneAmountMustBePositive = 4,
+    NewMilestonesMustStartAsPending = 5,
+    EscrowAlreadyTerminal = 6,
+    OnlyBuyerOrArbiterCanApproveMilestones = 7,
+    MilestoneIndexOutRange = 8,
+    MilestoneNotPending = 9,
+    OnlyBuyerOrSellerCanDisputeEscrow = 10,
+    DisputeAmountOutOfRange = 11,
+    BuyerPercentMustBeBetween0And100 = 12,
+    EscrowIsNotDisputed = 13,
+    OnlyArbiterCanResolveDispute = 14,
+    EscrowIsNotCoolingOffState = 15,
+    OnlyBuyerOrSellerCanFlagResolutionError = 16,
+    CoolingOffWindowHasExpired = 17,
+    ResolutionAlreadyFlagged = 18,
+    CoolingOffWindowHasNotElapsed = 19,
+    ResolutionIsFlaggedAdminMustReviewBeforeFinalization = 20,
+    OnlyAdminCanClearResolutionFlags = 21,
+    NoFlagToClear = 22,
+    OnlyAdminCanConfigureCoolingOffPeriod = 23,
+    FeeConfigurationExceedsEscrowAmount = 24,
+    TimeoutMustBePositive = 25,
+    MultiplierMustBePositive = 26,
+    DeadlineMustBePositive = 27,
+    DisputeAlreadyResolved = 28,
+    DisputeTimeoutDeadlineHasNotPassedYet = 29,
+    MaxOracleAgeMustBePositive = 30,
+    InsuranceTriggerDaysMustBePositive = 31,
+    InsuranceContributionMustBePositive = 32,
+    OnlyBuyerOrSellerCanClaimInsurance = 33,
+    InsuranceAlreadyClaimed = 34,
+    AdminConfirmationRequired = 35,
+    InsuranceTriggerPeriodNotReached = 36,
+    EscrowTokenNotCoveredByInsurancePool = 37,
+    InsurancePoolHasInsufficientBalance = 38,
+    FeeExceedsMaximum200Bps = 39,
+    WithdrawalAmountMustBePositive = 40,
+    InsufficientAccruedFees = 41,
+    ReleaseConditionNotMet = 42,
+    EscrowHasNotExpiredYet = 43,
+    OnlyBuyerOrSellerCanProposeDeadlineExtension = 44,
+    CannotExtendDeadlineWhileEscrowIsDisputed = 45,
+    NewDeadlineMustBeGreaterThanCurrentDeadline = 46,
+    OnlyBuyerOrSellerCanAcceptDeadlineExtension = 47,
+    ProposerCannotAcceptTheirOwnDeadlineExtension = 48,
+    DeadlineExtensionProposalHasExpired = 49,
+    OnlyBuyerOrSellerCanProposeAmendment = 50,
+}
+
+/// Extension error codes — split from EscrowError because #[contracterror]
+/// is bounded by the soroban XDR 50-case limit.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EscrowErrorExt2 {
+    CannotAmendTerminalEscrow = 1,
+    NewAmountMustBePositive = 2,
+    OnlyBuyerOrSellerCanSignAmendment = 3,
+    AmendmentNonceMismatch = 4,
+    AmendmentProposalHasExpired = 5,
+    AmendmentRequiresBuyerAndSellerSignatures = 6,
+    OnlyBuyerCanTopUpEscrow = 7,
+    EscrowIsNotActiveOrAwaitingInspection = 8,
+    AdditionalAmountMustBePositive = 9,
+    TopUpLimitExceeded = 10,
+    OnlySellerCanAcknowledgeTopUp = 11,
+    OnlySellerCanRequestPartialRelease = 12,
+    PartialReleaseOnlyAllowedActiveEscrow = 13,
+    PartialReleaseAmountMustBePositive = 14,
+    PartialReleaseAmountCannotExceedEscrowAmount = 15,
+    RequestAlreadyPending = 16,
+    OnlyBuyerCanApprovePartialRelease = 17,
+    InvalidRequestID = 18,
+    DelegateMustBeDifferentFromSeller = 19,
+    SellerNotPartOfEscrow = 20,
+    CanOnlyDelegateBeforeEscrowIsReleased = 21,
+    OnlyBuyerCanRejectPartialRelease = 22,
+    OnlySellerCanEscalatePartialRelease = 23,
+    ResponseDeadlineNotYetPassed = 24,
+    NewBuyerMustBeDifferentFromCurrentBuyer = 25,
+    BuyerTransferOnlyAllowedActiveEscrows = 26,
+    OnlyCurrentBuyerCanTransferBuyerRole = 27,
+    OnlyBuyerOrSellerCanUpdateMetadata = 28,
+    OnlyAdminCanUpgradeContract = 29,
+    OnlyAdminCanMigrateContract = 30,
+    MigrationAlreadyCompletedVersion = 31,
+    UnlockAtMustBeFuture = 32,
+    AlreadyClaimed = 33,
+    OnlyBeneficiaryCanClaim = 34,
+    UnlockTimeHasNotPassed = 35,
+    EscrowNotActive = 36,
+    PastUnlockTimeUseClaimTimelocked = 37,
+    OnlyBuyerCanCancel = 38,
+    DisputeActive = 39,
+    OnlyAdminCanSetTokenWhitelistContract = 40,
+    ContractAlreadyPaused = 41,
+    ContractIsNotPaused = 42,
+    TokenNotAllowed = 43,
+    DeadlineDurationMustBePositive = 44,
+    TemplateIsDeactivated = 45,
+    ArbiterAlreadyPool = 46,
+    ArbiterNotPool = 47,
+    ArbiterPoolIsEmpty = 48,
+    OnlyTemplateCreatorCanUpdate = 49,
+    OnlyTemplateCreatorCanDeactivate = 50,
+}
+
+/// Extension error codes — split from EscrowError because #[contracterror]
+/// is bounded by the soroban XDR 50-case limit.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EscrowErrorExt3 {
+    TemplateAlreadyDeactivated = 1,
+    InactivityReleaseIsNotEnabledEscrow = 2,
+    OnlyEscrowSellerCanClaimInactivityRelease = 3,
+    BuyerInactivityWindowHasNotElapsed = 4,
+    PenaltyCannotExceed10000Bps = 5,
+    ResponseWindowMustBePositive = 6,
+    OnlyBuyerOrSellerCanRequestCancellation = 7,
+    NoPendingCancellationEscrow = 8,
+    InitiatorCannotAcceptTheirOwnCancellationRequest = 9,
+    OnlyBuyerOrSellerCanAcceptCancellation = 10,
+    InitiatorCannotRejectTheirOwnCancellationRequest = 11,
+    OnlyBuyerOrSellerCanRejectCancellation = 12,
+    ResponseWindowHasNotElapsed = 13,
+    BountyAmountMustBePositive = 14,
+    ClaimDeadlineMustBeFuture = 15,
+    SubmissionDeadlineMustBeAfterClaimDeadline = 16,
+    TokenNotWhitelisted = 17,
+    BountyIsNotAvailableClaiming = 18,
+    ClaimDeadlineHasPassed = 19,
+    BountyIsNotClaimedStatus = 20,
+    OnlyAssignedSolverCanSubmitWork = 21,
+    SubmissionDeadlineHasPassed = 22,
+    OnlyBuyerCanApproveSubmission = 23,
+    NoSubmissionHasBeenMade = 24,
+    OnlyBuyerCanRejectSubmission = 25,
+    MaximumRejectionRoundsReached = 26,
+    OnlyBuyerCanCancelBounty = 27,
+    CannotCancelBountyCurrentState = 28,
+    OnlyAdminCanSetMaxBountyRejectionRounds = 29,
+    BountyMustHaveAtLeastOneMilestone = 30,
+    BountyMustBeClaimedBeforeSubmittingMilestones = 31,
+    OnlySolverCanSubmitMilestones = 32,
+    MilestoneIndexOutBounds = 33,
+    PreviousMilestoneNotYetVerified = 34,
+    MilestoneIsNotAwaitingSubmission = 35,
+    MilestoneIsNotAwaitingVerification = 36,
+    OnlyBountyCreatorCanReplaceVerifier = 37,
+    VerifierCanOnlyBeReplacedBeforeMilestoneIsSubmitted = 38,
+    OnlyBuyerCanConfigureCollateralHealth = 39,
+    MinCollateralRatioBpsOutOfRange = 40,
+    TopUpAmountMustBePositive = 41,
+    EscrowIsNotActiveOrUnderCollateralized = 42,
+    OnlyBuyerCanConfigureMultiPartyApproval = 43,
+    ApproversCountMustBeBetween2And10 = 44,
+    ThresholdMustBeBetween1AndApproversCount = 45,
+    CannotReconfigureApprovalsAlreadyProgress = 46,
+    CallerIsNotAuthorizedApproverEscrow = 47,
+    ApproverHasAlreadyApprovedEscrow = 48,
+    ReleaseScheduleMustContainAtLeastOneTranche = 49,
+    EachTrancheAmountMustBePositive = 50,
+}
+
+/// Extension error codes — split from EscrowError because #[contracterror]
+/// is bounded by the soroban XDR 50-case limit.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EscrowErrorExt4 {
+    EachTrancheUnlockAtMustBeFuture = 1,
+    OnlyBeneficiarySellerCanClaimScheduledReleases = 2,
+    EscrowIsNotClaimableState = 3,
+    NoTranchesAreCurrentlyClaimable = 4,
+    ContractIsPaused = 5,
+    OnlyAdminCanPauseContract = 6,
+    OnlyAdminCanResumeContract = 7,
+    EscrowStillLocked = 8,
+    OraclePriceIsStale = 9,
+    InvalidOraclePrice = 10,
+    InsufficientRenewalAllowance = 11,
+    EscrowRenewalDurationMustBePositive = 12,
+    OnlyAdminCanSetMaxTopUpBps = 13,
+    CollateralForfeitBpsCannotExceed10000 = 14,
+    AtLeastOneSellerRequired = 15,
+    OnlySellerCanDepositCollateral = 16,
+    EscrowIsNotAwaitingCollateral = 17,
+    CollateralDepositWindowHasExpired = 18,
+    RatingMustBeBetween1And5 = 19,
+    RatingOnlyAllowedAfterEscrowIsReleasedOrResolved = 20,
+    OnlyBuyerOrSellerCanSubmitRating = 21,
+    RatingAlreadySubmittedEscrow = 22,
+    OnlySellerCanSubmitDeliveryProof = 23,
+    ProofSubmissionLockedEscrowIsUnderDispute = 24,
+    InvalidDeliveryProof = 25,
+    OnlyEscrowSellerCanRaiseVeto = 26,
+    VetoCooldownActive = 27,
+    OnlyBuyerCanApprove = 28,
+    NoPendingSellerTransfer = 29,
+    OnlyAdminCanSetVetoOverrideWindow = 30,
+    WindowSecondsMustBePositive = 31,
+    OnlyEscrowSellerCanCancelVeto = 32,
+    VetoWindowElapsed = 33,
+    OnlyAdminCanOverrideSellerVeto = 34,
+    ActiveDisputeExists = 35,
+    VetoWindowNotElapsed = 36,
+    VetoWindowHasNotExpiredYet = 37,
+    OnlyCurrentSellerCanInitiateTransfer = 38,
+    EscrowMustBeActiveToTransferSellerRole = 39,
+    OnlyBuyerCanVeto = 40,
+    OnlyAdminCanSetVetoWindow = 41,
+    ReleaseBpsMustBePositiveEachMilestone = 42,
+    MilestoneReleaseBpsMustSumTo10000 = 43,
+    OnlyEscrowSellerMaySubmitMilestones = 44,
+    MilestoneMustBePendingOrRejectedToSubmit = 45,
+    MilestoneMustBeSubmittedBeforeApproval = 46,
+    OnlyEscrowBuyerMayRejectMilestones = 47,
+    OnlySubmittedMilestoneCanBeRejected = 48,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -693,7 +966,7 @@ impl AhjoorEscrowContract {
     /// Initialize upgrade admin and contract versioning state.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("Already initialized");
+            panic_with_error!(&env, EscrowError::AlreadyInitialized);
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -876,10 +1149,10 @@ impl AhjoorEscrowContract {
         Self::require_token_allowed(&env, &token);
 
         if buyers.is_empty() {
-            panic!("At least one buyer is required");
+            panic_with_error!(&env, EscrowError::AtLeastOneBuyerIsRequired);
         }
         if deadline <= env.ledger().timestamp() {
-            panic!("Deadline must be in the future");
+            panic_with_error!(&env, EscrowError::DeadlineMustBeFuture);
         }
 
         let token_client = token::Client::new(&env, &token);
@@ -891,10 +1164,10 @@ impl AhjoorEscrowContract {
         for i in 0..buyers.len() {
             let (buyer, amount) = buyers.get(i).unwrap();
             if amount <= 0 {
-                panic!("Buyer contribution must be positive");
+                panic_with_error!(&env, EscrowError::BuyerContributionMustBePositive);
             }
             if seen.contains(&buyer) {
-                panic!("Duplicate buyer in buyer list");
+                panic_with_error!(&env, EscrowError::DuplicateBuyerInList);
             }
             seen.push_back(buyer.clone());
             buyer_list.push_back(buyer.clone());
@@ -1041,10 +1314,10 @@ impl AhjoorEscrowContract {
         buyer.require_auth();
 
         if escrow_configs.is_empty() {
-            panic!("Batch must contain at least one escrow config");
+            panic_with_error!(&env, EscrowError::BatchMustContainAtLeastOneEscrowConfig);
         }
         if escrow_configs.len() > MAX_BATCH_ESCROWS {
-            panic!("Batch size exceeds maximum of 10 escrows");
+            panic_with_error!(&env, EscrowError::BatchSizeExceedsMaximum10Escrows);
         }
 
         let mut created_ids: Vec<u32> = Vec::new(&env);
@@ -1132,9 +1405,9 @@ impl AhjoorEscrowContract {
         seller.require_auth();
         let mut escrow: Escrow = env
             .storage().persistent().get(&DataKey::Escrow(escrow_id)).expect("Escrow not found");
-        if escrow.seller != seller { panic!("Only seller can mark complete"); }
-        if !Self::is_open_escrow_status(escrow.status) { panic!("Escrow is not active"); }
-        if escrow.extensions.inspector.is_none() { panic!("No inspector set; use release_escrow directly"); }
+        if escrow.seller != seller { panic_with_error!(&env, EscrowError::OnlySellerCanMarkComplete); }
+        if !Self::is_open_escrow_status(escrow.status) { panic_with_error!(&env, EscrowError::EscrowIsNotActive); }
+        if escrow.extensions.inspector.is_none() { panic_with_error!(&env, EscrowError::NoInspectorSetUseReleaseEscrowDirectly); }
         escrow.status = EscrowStatus::AwaitingInspection;
         env.storage().persistent().set(&DataKey::Escrow(escrow_id), &escrow);
         env.storage().persistent().extend_ttl(
@@ -1157,10 +1430,10 @@ impl AhjoorEscrowContract {
         let mut escrow: Escrow = env
             .storage().persistent().get(&DataKey::Escrow(escrow_id)).expect("Escrow not found");
         if escrow.status != EscrowStatus::AwaitingInspection {
-            panic!("Escrow is not awaiting inspection");
+            panic_with_error!(&env, EscrowError::EscrowIsNotAwaitingInspection);
         }
         let stored_inspector = escrow.extensions.inspector.clone().expect("No inspector set");
-        if inspector != stored_inspector { panic!("Only the assigned inspector can submit a report"); }
+        if inspector != stored_inspector { panic_with_error!(&env, EscrowError::OnlyAssignedInspectorCanSubmitReport); }
         let report = InspectorReport {
             inspector: inspector.clone(),
             approved,
@@ -1187,9 +1460,9 @@ impl AhjoorEscrowContract {
         let escrow: Escrow = env
             .storage().persistent().get(&DataKey::Escrow(escrow_id)).expect("Escrow not found");
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can propose inspector replacement");
+            panic_with_error!(&env, EscrowError::OnlyBuyerOrSellerCanProposeInspectorReplacement);
         }
-        if escrow.extensions.inspector.is_none() { panic!("No inspector set on this escrow"); }
+        if escrow.extensions.inspector.is_none() { panic_with_error!(&env, EscrowError::NoInspectorSetEscrow); }
         let key = DataKey2::InspectorReplacement(escrow_id);
         let mut replacement: InspectorReplacement = env
             .storage().persistent().get(&key)
@@ -1244,8 +1517,8 @@ impl AhjoorEscrowContract {
         admin.require_auth();
         let stored_admin: Address = env
             .storage().instance().get(&DataKey::Admin).expect("Not initialized");
-        if admin != stored_admin { panic!("Only admin can set inspector score threshold"); }
-        if min_score_bps > 10_000 { panic!("min_score_bps must be <= 10000"); }
+        if admin != stored_admin { panic_with_error!(&env, EscrowError::OnlyAdminCanSetInspectorScoreThreshold); }
+        if min_score_bps > 10_000 { panic_with_error!(&env, EscrowError::MinScoreBpsExceedsMaximum); }
         env.storage().instance().set(&DataKey2::MinInspectorScoreBps, &min_score_bps);
         env.storage().instance().set(&DataKey2::InspectorScoreValueThreshold, &value_threshold);
         env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
@@ -1276,7 +1549,7 @@ impl AhjoorEscrowContract {
         admin.require_auth();
         let stored_admin: Address = env
             .storage().instance().get(&DataKey::Admin).expect("Not initialized");
-        if admin != stored_admin { panic!("Only admin can appeal inspector ruling"); }
+        if admin != stored_admin { panic_with_error!(&env, EscrowError::OnlyAdminCanAppealInspectorRuling); }
 
         // Ensure an inspector was involved
         let escrow: Escrow = env
@@ -1289,7 +1562,7 @@ impl AhjoorEscrowContract {
             .persistent()
             .get(&DataKey2::InspectorRulingAppealed(escrow_id))
             .unwrap_or(false);
-        if already_appealed { panic!("Inspector ruling already appealed for this escrow"); }
+        if already_appealed { panic_with_error!(&env, EscrowError::InspectorRulingAlreadyAppealedEscrow); }
 
         // Decrement correct_rulings (floor at 0)
         let key = DataKey2::InspectorScore(inspector.clone());
@@ -1391,7 +1664,7 @@ impl AhjoorEscrowContract {
 
         let accuracy_bps = (score.correct_rulings * 10_000) / score.total_rulings;
         if accuracy_bps < min_score_bps {
-            panic!("Inspector score below minimum threshold for high-value escrow");
+            panic_with_error!(&env, EscrowError::InspectorScoreBelowMinimumThresholdHighValueEscrow);
         }
     }
 
@@ -1419,22 +1692,22 @@ impl AhjoorEscrowContract {
         } = request;
 
         if amount <= 0 {
-            panic!("Escrow amount must be positive");
+            panic_with_error!(&env, EscrowError::EscrowAmountMustBePositive);
         }
 
         if deadline <= env.ledger().timestamp() {
-            panic!("Deadline must be in the future");
+            panic_with_error!(&env, EscrowError::DeadlineMustBeFuture);
         }
 
         if let Some(lock_until) = min_lock_until {
             if deadline <= lock_until {
-                panic!("Deadline must be after min_lock_until");
+                panic_with_error!(&env, EscrowError::DeadlineMustBeAfterMinLockUntil);
             }
         }
 
         if let Some(fee_bps) = arbiter_fee_bps {
             if fee_bps > MAX_ARBITER_FEE_BPS {
-                panic!("Arbiter fee exceeds maximum of 1000 bps");
+                panic_with_error!(&env, EscrowError::ArbiterFeeExceedsMaximum1000Bps);
             }
         }
 
@@ -1447,12 +1720,12 @@ impl AhjoorEscrowContract {
             && release_comparison.is_some()
             && release_threshold_price.is_some();
         if has_any_release_condition && !has_full_release_condition {
-            panic!("Incomplete release condition");
+            panic_with_error!(&env, EscrowError::IncompleteReleaseCondition);
         }
 
         if let Some(threshold) = release_threshold_price {
             if threshold <= 0 {
-                panic!("Release condition threshold must be positive");
+                panic_with_error!(&env, EscrowError::ReleaseConditionThresholdMustBePositive);
             }
         }
 
@@ -1460,7 +1733,7 @@ impl AhjoorEscrowContract {
             if comparison != ORACLE_COMPARISON_LESS_OR_EQUAL
                 && comparison != ORACLE_COMPARISON_GREATER_OR_EQUAL
             {
-                panic!("Invalid release comparison");
+                panic_with_error!(&env, EscrowError::InvalidReleaseComparison);
             }
         }
 
@@ -1475,7 +1748,7 @@ impl AhjoorEscrowContract {
             v
         } else {
             if sellers.len() > 5 {
-                panic!("Maximum 5 sellers allowed");
+                panic_with_error!(&env, EscrowError::Maximum5SellersAllowed);
             }
             let mut total_bps: u32 = 0;
             for i in 0..sellers.len() {
@@ -1483,7 +1756,7 @@ impl AhjoorEscrowContract {
                 total_bps += bps;
             }
             if total_bps != 10_000 {
-                panic!("Seller allocations must sum to 10000 bps");
+                panic_with_error!(&env, EscrowError::SellerAllocationsMustSumTo10000Bps);
             }
             sellers
         };
@@ -1641,7 +1914,7 @@ impl AhjoorEscrowContract {
         dispute_timeout_seconds: u64,
     ) -> u32 {
         if dispute_timeout_seconds == 0 {
-            panic!("dispute_timeout_seconds must be positive");
+            panic_with_error!(&env, EscrowError::DisputeTimeoutSecondsMustBePositive);
         }
 
         let auto_renew = renewal_count > 0;
@@ -1690,15 +1963,15 @@ impl AhjoorEscrowContract {
             .expect("Receipt not found");
 
         if caller != receipt.holder {
-            panic!("Only current holder can transfer receipt");
+            panic_with_error!(&env, EscrowError::OnlyCurrentHolderCanTransferReceipt);
         }
 
         // Block transfers for milestone escrows or pending partial releases
         if env.storage().persistent().has(&DataKey::EscrowMilestones(receipt.escrow_id)) {
-            panic!("ActiveMilestoneInProgress");
+            panic_with_error!(&env, EscrowError::ActiveMilestoneInProgress);
         }
         if env.storage().persistent().has(&DataKey::PendingPartialRelease(receipt.escrow_id)) {
-            panic!("ActiveMilestoneInProgress");
+            panic_with_error!(&env, EscrowError::ActiveMilestoneInProgress);
         }
 
         let old = receipt.holder.clone();
@@ -1735,13 +2008,13 @@ impl AhjoorEscrowContract {
 
         // #272: Block release if inspection is pending
         if escrow.status == EscrowStatus::AwaitingInspection {
-            panic!("InspectionPending: inspector must submit report before release");
+            panic_with_error!(&env, EscrowError::InspectionPending);
         }
 
         if escrow.status == EscrowStatus::InspectionPassed {
             // Allow release from InspectionPassed — fall through
         } else if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         let multi_buyers_opt: Option<Vec<Address>> = env
@@ -1758,7 +2031,7 @@ impl AhjoorEscrowContract {
                 }
             }
             if !is_buyer {
-                panic!("Only a listed buyer can approve multi-buyer release");
+                panic_with_error!(&env, EscrowError::OnlyListedBuyerCanApproveMultiBuyerRelease);
             }
 
             let mut approvals: Vec<Address> = env
@@ -1768,7 +2041,7 @@ impl AhjoorEscrowContract {
                 .unwrap_or(Vec::new(&env));
             for a in approvals.iter() {
                 if a == caller {
-                    panic!("Buyer has already approved release");
+                    panic_with_error!(&env, EscrowError::BuyerHasAlreadyApprovedRelease);
                 }
             }
             approvals.push_back(caller.clone());
@@ -1788,7 +2061,7 @@ impl AhjoorEscrowContract {
                 return;
             }
         } else if caller != escrow.buyer && caller != escrow.arbiter {
-            panic!("Only buyer or arbiter can release escrow");
+            panic_with_error!(&env, EscrowError::OnlyBuyerOrArbiterCanReleaseEscrow);
         }
 
         // #420: Block release if an active seller veto is present.
@@ -1804,7 +2077,7 @@ impl AhjoorEscrowContract {
                 .get(&DataKey2::VetoCooldownSeconds)
                 .unwrap_or(DEFAULT_VETO_COOLDOWN_SECONDS);
             if env.ledger().timestamp() < veto_ts + cooldown {
-                panic!("SellerVetoActive: admin must override_seller_veto before release");
+                panic_with_error!(&env, EscrowError::SellerVetoActive);
             }
         }
 
@@ -1814,7 +2087,7 @@ impl AhjoorEscrowContract {
             .persistent()
             .get(&DataKey2::VetoTimestamp(escrow_id));
         if veto_ts.is_some() {
-            panic!("SellerVetoActive: seller has blocked fund release");
+            panic_with_error!(&env, EscrowError::SellerVetoActive2);
         }
 
         Self::require_unlocked(&env, &escrow);
@@ -1901,7 +2174,7 @@ impl AhjoorEscrowContract {
             .unwrap_or(0);
 
         if condition_value < condition.expected_value {
-            panic!("Condition not met");
+            panic_with_error!(&env, EscrowError::ConditionNotMet);
         }
 
         events::emit_conditional_release_triggered(
@@ -1938,7 +2211,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can waive condition");
+            panic_with_error!(&env, EscrowError::OnlyBuyerOrSellerCanWaiveCondition);
         }
 
         // Check if condition exists
@@ -1948,7 +2221,7 @@ impl AhjoorEscrowContract {
             .get::<_, ConditionalRelease>(&DataKey2::ConditionalReleaseCondition(escrow_id))
             .is_none()
         {
-            panic!("No conditional release set for this escrow");
+            panic_with_error!(&env, EscrowError::NoConditionalReleaseSetEscrow);
         }
 
         // Track signatures
@@ -2012,7 +2285,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if party != escrow.buyer && party != escrow.seller {
-            panic!("Only buyer or seller can submit evidence");
+            panic_with_error!(&env, EscrowError::OnlyBuyerOrSellerCanSubmitEvidence);
         }
 
         // #150: Track buyer activity
@@ -2028,7 +2301,7 @@ impl AhjoorEscrowContract {
             .unwrap_or(Vec::new(&env));
 
         if entries.len() >= MAX_EVIDENCE_ENTRIES_PER_PARTY {
-            panic!("Maximum evidence entries reached for this party");
+            panic_with_error!(&env, EscrowError::MaximumEvidenceEntriesReachedParty);
         }
 
         entries.push_back(EvidenceSubmission {
@@ -2092,11 +2365,11 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if buyer != escrow.buyer {
-            panic!("Only buyer can set renewal allowance");
+            panic_with_error!(&env, EscrowError::OnlyBuyerCanSetRenewalAllowance);
         }
 
         if !escrow.extensions.auto_renew {
-            panic!("Auto-renew is not enabled for this escrow");
+            panic_with_error!(&env, EscrowError::AutoRenewIsNotEnabledEscrow);
         }
 
         let total_amount = escrow.amount * total_renewals as i128;
@@ -2131,7 +2404,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if buyer != escrow.buyer {
-            panic!("Only buyer can cancel auto-renew");
+            panic_with_error!(&env, EscrowError::OnlyBuyerCanCancelAutoRenew);
         }
 
         escrow.extensions.auto_renew = false;
@@ -2157,11 +2430,11 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if buyer != escrow.buyer {
-            panic!("Only buyer can cancel auto-renewal");
+            panic_with_error!(&env, EscrowError::OnlyBuyerCanCancelAutoRenewal);
         }
 
         if escrow.extensions.auto_renew_max_renewals.is_none() {
-            panic!("No AutoRenewConfig set on this escrow");
+            panic_with_error!(&env, EscrowError::NoAutoRenewConfigSetEscrow);
         }
 
         env.storage()
@@ -2201,21 +2474,21 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         if caller != escrow.buyer && caller != escrow.arbiter {
-            panic!("Only buyer or arbiter can release escrow");
+            panic_with_error!(&env, EscrowError::OnlyBuyerOrArbiterCanReleaseEscrow);
         }
 
         Self::require_unlocked(&env, &escrow);
 
         if release_amount <= 0 {
-            panic!("Release amount must be positive");
+            panic_with_error!(&env, EscrowError::ReleaseAmountMustBePositive);
         }
 
         if release_amount > escrow.amount {
-            panic!("Release amount exceeds escrow balance");
+            panic_with_error!(&env, EscrowErrorExt::ReleaseAmountExceedsEscrowBalance);
         }
 
         let client = token::Client::new(&env, &escrow.token);
@@ -2269,20 +2542,20 @@ impl AhjoorEscrowContract {
         buyer.require_auth();
 
         if milestones.is_empty() {
-            panic!("At least one milestone required");
+            panic_with_error!(&env, EscrowErrorExt::AtLeastOneMilestoneRequired);
         }
         if milestones.len() > MAX_MILESTONES {
-            panic!("Too many milestones");
+            panic_with_error!(&env, EscrowErrorExt::TooManyMilestones);
         }
 
         let mut total_amount: i128 = 0;
         for i in 0..milestones.len() {
             let m = milestones.get(i).unwrap();
             if m.amount <= 0 {
-                panic!("Milestone amount must be positive");
+                panic_with_error!(&env, EscrowErrorExt::MilestoneAmountMustBePositive);
             }
             if m.status != MilestoneStatus::Pending {
-                panic!("New milestones must start as Pending");
+                panic_with_error!(&env, EscrowErrorExt::NewMilestonesMustStartAsPending);
             }
             total_amount += m.amount;
         }
@@ -2347,11 +2620,11 @@ impl AhjoorEscrowContract {
             || escrow.status == EscrowStatus::Refunded
             || escrow.status == EscrowStatus::Resolved
         {
-            panic!("Escrow already terminal");
+            panic_with_error!(&env, EscrowErrorExt::EscrowAlreadyTerminal);
         }
 
         if caller != escrow.buyer && caller != escrow.arbiter {
-            panic!("Only buyer or arbiter can approve milestones");
+            panic_with_error!(&env, EscrowErrorExt::OnlyBuyerOrArbiterCanApproveMilestones);
         }
 
         let mut milestones: Vec<Milestone> = env
@@ -2361,12 +2634,12 @@ impl AhjoorEscrowContract {
             .expect("Escrow has no milestones");
 
         if milestone_index >= milestones.len() {
-            panic!("Milestone index out of range");
+            panic_with_error!(&env, EscrowErrorExt::MilestoneIndexOutRange);
         }
 
         let mut milestone = milestones.get(milestone_index).unwrap();
         if milestone.status != MilestoneStatus::Pending {
-            panic!("Milestone not pending");
+            panic_with_error!(&env, EscrowErrorExt::MilestoneNotPending);
         }
 
         let client = token::Client::new(&env, &escrow.token);
@@ -2447,15 +2720,15 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can dispute escrow");
+            panic_with_error!(&env, EscrowErrorExt::OnlyBuyerOrSellerCanDisputeEscrow);
         }
 
         if dispute_amount <= 0 || dispute_amount > escrow.amount {
-            panic!("dispute_amount must be > 0 and <= escrow amount");
+            panic_with_error!(&env, EscrowErrorExt::DisputeAmountOutOfRange);
         }
 
         // #150: Track buyer activity
@@ -2540,7 +2813,7 @@ impl AhjoorEscrowContract {
         arbiter.require_auth();
 
         if buyer_percent > 100 {
-            panic!("buyer_percent must be between 0 and 100");
+            panic_with_error!(&env, EscrowErrorExt::BuyerPercentMustBeBetween0And100);
         }
 
         let mut escrow: Escrow = env
@@ -2552,11 +2825,11 @@ impl AhjoorEscrowContract {
         if escrow.status != EscrowStatus::Disputed
             && escrow.status != EscrowStatus::PartiallyDisputed
         {
-            panic!("Escrow is not disputed");
+            panic_with_error!(&env, EscrowErrorExt::EscrowIsNotDisputed);
         }
 
         if arbiter != escrow.arbiter {
-            panic!("Only arbiter can resolve dispute");
+            panic_with_error!(&env, EscrowErrorExt::OnlyArbiterCanResolveDispute);
         }
 
         let cooling_off_seconds: u64 = env
@@ -2621,7 +2894,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::CoolingOff {
-            panic!("Escrow is not in cooling-off state");
+            panic_with_error!(&env, EscrowErrorExt::EscrowIsNotCoolingOffState);
         }
 
         let verdict: PendingVerdict = env
@@ -2632,7 +2905,7 @@ impl AhjoorEscrowContract {
 
         // Only buyer or seller may flag
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can flag a resolution error");
+            panic_with_error!(&env, EscrowErrorExt::OnlyBuyerOrSellerCanFlagResolutionError);
         }
 
         // Enforce cooling-off window has not expired
@@ -2643,12 +2916,12 @@ impl AhjoorEscrowContract {
             .unwrap_or(0);
         let now = env.ledger().timestamp();
         if now > verdict.recorded_at + cooling_off_seconds {
-            panic!("Cooling-off window has expired");
+            panic_with_error!(&env, EscrowErrorExt::CoolingOffWindowHasExpired);
         }
 
         // Prevent duplicate flags
         if env.storage().persistent().has(&DataKey2::ResolutionFlag(escrow_id)) {
-            panic!("Resolution already flagged");
+            panic_with_error!(&env, EscrowErrorExt::ResolutionAlreadyFlagged);
         }
 
         env.storage()
@@ -2679,7 +2952,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::CoolingOff {
-            panic!("Escrow is not in cooling-off state");
+            panic_with_error!(&env, EscrowErrorExt::EscrowIsNotCoolingOffState);
         }
 
         let verdict: PendingVerdict = env
@@ -2696,12 +2969,12 @@ impl AhjoorEscrowContract {
 
         let now = env.ledger().timestamp();
         if now <= verdict.recorded_at + cooling_off_seconds {
-            panic!("Cooling-off window has not elapsed");
+            panic_with_error!(&env, EscrowErrorExt::CoolingOffWindowHasNotElapsed);
         }
 
         // Ensure no unresolved flag is blocking release
         if env.storage().persistent().has(&DataKey2::ResolutionFlag(escrow_id)) {
-            panic!("Resolution is flagged; admin must review before finalization");
+            panic_with_error!(&env, EscrowErrorExt::ResolutionIsFlaggedAdminMustReviewBeforeFinalization);
         }
 
         let buyer_percent = verdict.buyer_percent;
@@ -2727,11 +3000,11 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can clear resolution flags");
+            panic_with_error!(&env, EscrowErrorExt::OnlyAdminCanClearResolutionFlags);
         }
 
         if !env.storage().persistent().has(&DataKey2::ResolutionFlag(escrow_id)) {
-            panic!("No flag to clear");
+            panic_with_error!(&env, EscrowErrorExt::NoFlagToClear);
         }
 
         env.storage().persistent().remove(&DataKey2::ResolutionFlag(escrow_id));
@@ -2751,7 +3024,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can configure cooling-off period");
+            panic_with_error!(&env, EscrowErrorExt::OnlyAdminCanConfigureCoolingOffPeriod);
         }
 
         env.storage()
@@ -2800,7 +3073,7 @@ impl AhjoorEscrowContract {
         let distributable = escrow.amount - protocol_fee - arbiter_fee;
 
         if distributable < 0 {
-            panic!("Fee configuration exceeds escrow amount");
+            panic_with_error!(&env, EscrowErrorExt::FeeConfigurationExceedsEscrowAmount);
         }
 
         let seller_percent = 100 - buyer_percent;
@@ -2942,7 +3215,7 @@ impl AhjoorEscrowContract {
     pub fn update_default_dispute_timeout(env: Env, admin: Address, timeout_seconds: u64) {
         Self::require_admin(&env, &admin);
         if timeout_seconds == 0 {
-            panic!("Timeout must be positive");
+            panic_with_error!(&env, EscrowErrorExt::TimeoutMustBePositive);
         }
 
         env.storage()
@@ -2982,7 +3255,7 @@ impl AhjoorEscrowContract {
     pub fn update_max_topup_multiplier(env: Env, admin: Address, multiplier: u32) {
         Self::require_admin(&env, &admin);
         if multiplier == 0 {
-            panic!("Multiplier must be positive");
+            panic_with_error!(&env, EscrowErrorExt::MultiplierMustBePositive);
         }
 
         env.storage()
@@ -3004,7 +3277,7 @@ impl AhjoorEscrowContract {
     pub fn set_partial_release_deadline(env: Env, admin: Address, deadline: u64) {
         Self::require_admin(&env, &admin);
         if deadline == 0 {
-            panic!("Deadline must be positive");
+            panic_with_error!(&env, EscrowErrorExt::DeadlineMustBePositive);
         }
 
         env.storage()
@@ -3041,17 +3314,17 @@ impl AhjoorEscrowContract {
 
         let dispute = match dispute {
             Some(d) => d,
-            None => panic!("Escrow is not disputed"),
+            None => panic_with_error!(&env, EscrowErrorExt::EscrowIsNotDisputed),
         };
 
         if dispute.resolved {
-            panic!("Dispute already resolved");
+            panic_with_error!(&env, EscrowErrorExt::DisputeAlreadyResolved);
         }
 
         if escrow.status != EscrowStatus::Disputed
             && escrow.status != EscrowStatus::PartiallyDisputed
         {
-            panic!("Escrow is not disputed");
+            panic_with_error!(&env, EscrowErrorExt::EscrowIsNotDisputed);
         }
 
         // Get dispute deadline start timestamp
@@ -3073,7 +3346,7 @@ impl AhjoorEscrowContract {
         let now = env.ledger().timestamp();
         let elapsed = now.saturating_sub(deadline_start);
         if elapsed < effective_timeout {
-            panic!("Dispute timeout deadline has not passed yet");
+            panic_with_error!(&env, EscrowErrorExt::DisputeTimeoutDeadlineHasNotPassedYet);
         }
 
         // Determine default winner
@@ -3177,7 +3450,7 @@ impl AhjoorEscrowContract {
     pub fn set_default_arbiter_fee_bps(env: Env, admin: Address, fee_bps: u32) {
         Self::require_admin(&env, &admin);
         if fee_bps > MAX_ARBITER_FEE_BPS {
-            panic!("Arbiter fee exceeds maximum of 1000 bps");
+            panic_with_error!(&env, EscrowError::ArbiterFeeExceedsMaximum1000Bps);
         }
 
         env.storage()
@@ -3199,7 +3472,7 @@ impl AhjoorEscrowContract {
     pub fn set_oracle(env: Env, admin: Address, oracle: Address, max_oracle_age: u64) {
         Self::require_admin(&env, &admin);
         if max_oracle_age == 0 {
-            panic!("max_oracle_age must be positive");
+            panic_with_error!(&env, EscrowErrorExt::MaxOracleAgeMustBePositive);
         }
 
         env.storage().instance().set(&DataKey::OracleAddress, &oracle);
@@ -3229,7 +3502,7 @@ impl AhjoorEscrowContract {
     pub fn set_insurance_config(env: Env, admin: Address, token: Address, trigger_days: u64) {
         Self::require_admin(&env, &admin);
         if trigger_days == 0 {
-            panic!("insurance_trigger_days must be positive");
+            panic_with_error!(&env, EscrowErrorExt::InsuranceTriggerDaysMustBePositive);
         }
 
         // Token whitelist validation
@@ -3257,7 +3530,7 @@ impl AhjoorEscrowContract {
         contributor.require_auth();
 
         if amount <= 0 {
-            panic!("Insurance contribution must be positive");
+            panic_with_error!(&env, EscrowErrorExt::InsuranceContributionMustBePositive);
         }
 
         let token: Address = env
@@ -3313,13 +3586,13 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if claimant != escrow.buyer && claimant != escrow.seller {
-            panic!("Only buyer or seller can claim insurance");
+            panic_with_error!(&env, EscrowErrorExt::OnlyBuyerOrSellerCanClaimInsurance);
         }
 
         if escrow.status != EscrowStatus::Disputed
             && escrow.status != EscrowStatus::PartiallyDisputed
         {
-            panic!("Escrow is not disputed");
+            panic_with_error!(&env, EscrowErrorExt::EscrowIsNotDisputed);
         }
 
         let dispute: Dispute = env
@@ -3328,7 +3601,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Dispute(escrow_id))
             .expect("Dispute not found");
         if dispute.resolved {
-            panic!("Dispute already resolved");
+            panic_with_error!(&env, EscrowErrorExt::DisputeAlreadyResolved);
         }
 
         if env
@@ -3337,7 +3610,7 @@ impl AhjoorEscrowContract {
             .get::<DataKey, bool>(&DataKey::InsuranceClaimed(escrow_id))
             .unwrap_or(false)
         {
-            panic!("Insurance already claimed");
+            panic_with_error!(&env, EscrowErrorExt::InsuranceAlreadyClaimed);
         }
 
         let confirmed: bool = env
@@ -3346,7 +3619,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::InsuranceAdminConfirmed(escrow_id))
             .unwrap_or(false);
         if !confirmed {
-            panic!("Admin confirmation required");
+            panic_with_error!(&env, EscrowErrorExt::AdminConfirmationRequired);
         }
 
         let trigger_days: u64 = env
@@ -3357,7 +3630,7 @@ impl AhjoorEscrowContract {
         let trigger_seconds = trigger_days.saturating_mul(24 * 60 * 60);
         let elapsed = env.ledger().timestamp().saturating_sub(dispute.created_at);
         if elapsed < trigger_seconds {
-            panic!("Insurance trigger period not reached");
+            panic_with_error!(&env, EscrowErrorExt::InsuranceTriggerPeriodNotReached);
         }
 
         let insurance_token: Address = env
@@ -3366,7 +3639,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::InsuranceToken)
             .expect("Insurance token not configured");
         if insurance_token != escrow.token {
-            panic!("Escrow token not covered by insurance pool");
+            panic_with_error!(&env, EscrowErrorExt::EscrowTokenNotCoveredByInsurancePool);
         }
 
         let max_claim = escrow.amount / 2;
@@ -3382,7 +3655,7 @@ impl AhjoorEscrowContract {
         };
 
         if claim_amount <= 0 {
-            panic!("Insurance pool has insufficient balance");
+            panic_with_error!(&env, EscrowErrorExt::InsurancePoolHasInsufficientBalance);
         }
 
         let token_client = token::Client::new(&env, &insurance_token);
@@ -3411,7 +3684,7 @@ impl AhjoorEscrowContract {
     pub fn update_protocol_fee(env: Env, admin: Address, fee_bps: u32, fee_recipient: Address) {
         Self::require_admin(&env, &admin);
         if fee_bps > MAX_PROTOCOL_FEE_BPS {
-            panic!("Fee exceeds maximum of 200 bps");
+            panic_with_error!(&env, EscrowErrorExt::FeeExceedsMaximum200Bps);
         }
         env.storage()
             .instance()
@@ -3441,7 +3714,7 @@ impl AhjoorEscrowContract {
     pub fn withdraw_fees(env: Env, admin: Address, amount: i128, token: Address, destination: Address) {
         Self::require_admin(&env, &admin);
         if amount <= 0 {
-            panic!("Withdrawal amount must be positive");
+            panic_with_error!(&env, EscrowErrorExt::WithdrawalAmountMustBePositive);
         }
         let key = DataKey2::AccruedFees(token.clone());
         let mut accrued: i128 = env
@@ -3450,7 +3723,7 @@ impl AhjoorEscrowContract {
             .get(&key)
             .unwrap_or(0);
         if amount > accrued {
-            panic!("Insufficient accrued fees");
+            panic_with_error!(&env, EscrowErrorExt::InsufficientAccruedFees);
         }
         accrued = accrued.checked_sub(amount).expect("AccruedFees underflow");
         if accrued == 0 {
@@ -3476,7 +3749,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         let base = escrow
@@ -3502,11 +3775,11 @@ impl AhjoorEscrowContract {
         let condition_met = match comparison {
             ORACLE_COMPARISON_LESS_OR_EQUAL => price_data.price <= threshold_price,
             ORACLE_COMPARISON_GREATER_OR_EQUAL => price_data.price >= threshold_price,
-            _ => panic!("Invalid release comparison"),
+            _ => panic_with_error!(&env, EscrowError::InvalidReleaseComparison),
         };
 
         if !condition_met {
-            panic!("Release condition not met");
+            panic_with_error!(&env, EscrowErrorExt::ReleaseConditionNotMet);
         }
 
         Self::transfer_to_sellers(&env, &escrow, escrow.amount, escrow_id);
@@ -3545,11 +3818,11 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         if env.ledger().timestamp() <= escrow.deadline {
-            panic!("Escrow has not expired yet");
+            panic_with_error!(&env, EscrowErrorExt::EscrowHasNotExpiredYet);
         }
 
         Self::require_unlocked(&env, &escrow);
@@ -3595,12 +3868,12 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can propose deadline extension");
+            panic_with_error!(&env, EscrowErrorExt::OnlyBuyerOrSellerCanProposeDeadlineExtension);
         }
 
         if escrow.status == EscrowStatus::Disputed || Self::is_terminal_escrow_status(escrow.status)
         {
-            panic!("Cannot extend deadline while escrow is disputed");
+            panic_with_error!(&env, EscrowErrorExt::CannotExtendDeadlineWhileEscrowIsDisputed);
         }
 
         if new_deadline <= env.ledger().timestamp() {
@@ -3608,7 +3881,7 @@ impl AhjoorEscrowContract {
         }
 
         if new_deadline <= escrow.deadline {
-            panic!("New deadline must be greater than current deadline");
+            panic_with_error!(&env, EscrowErrorExt::NewDeadlineMustBeGreaterThanCurrentDeadline);
         }
 
         let proposal = DeadlineProposal {
@@ -3650,12 +3923,12 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can accept deadline extension");
+            panic_with_error!(&env, EscrowErrorExt::OnlyBuyerOrSellerCanAcceptDeadlineExtension);
         }
 
         if escrow.status == EscrowStatus::Disputed || Self::is_terminal_escrow_status(escrow.status)
         {
-            panic!("Cannot extend deadline while escrow is disputed");
+            panic_with_error!(&env, EscrowErrorExt::CannotExtendDeadlineWhileEscrowIsDisputed);
         }
 
         let proposal: DeadlineProposal = env
@@ -3665,7 +3938,7 @@ impl AhjoorEscrowContract {
             .expect("No deadline extension proposal found");
 
         if caller == proposal.proposer {
-            panic!("Proposer cannot accept their own deadline extension");
+            panic_with_error!(&env, EscrowErrorExt::ProposerCannotAcceptTheirOwnDeadlineExtension);
         }
 
         let now = env.ledger().timestamp();
@@ -3673,7 +3946,7 @@ impl AhjoorEscrowContract {
             env.storage()
                 .persistent()
                 .remove(&DataKey::DeadlineProposal(escrow_id));
-            panic!("Deadline extension proposal has expired");
+            panic_with_error!(&env, EscrowErrorExt::DeadlineExtensionProposalHasExpired);
         }
 
         if proposal.new_deadline <= now {
@@ -3687,7 +3960,7 @@ impl AhjoorEscrowContract {
             env.storage()
                 .persistent()
                 .remove(&DataKey::DeadlineProposal(escrow_id));
-            panic!("New deadline must be greater than current deadline");
+            panic_with_error!(&env, EscrowErrorExt::NewDeadlineMustBeGreaterThanCurrentDeadline);
         }
 
         let old_deadline = escrow.deadline;
@@ -3731,10 +4004,10 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can propose amendment");
+            panic_with_error!(&env, EscrowErrorExt::OnlyBuyerOrSellerCanProposeAmendment);
         }
         if Self::is_terminal_escrow_status(escrow.status) {
-            panic!("Cannot amend terminal escrow");
+            panic_with_error!(&env, EscrowErrorExt2::CannotAmendTerminalEscrow);
         }
         if let Some(deadline) = new_deadline {
             if deadline <= env.ledger().timestamp() {
@@ -3743,7 +4016,7 @@ impl AhjoorEscrowContract {
         }
         if let Some(amount) = new_amount {
             if amount <= 0 {
-                panic!("New amount must be positive");
+                panic_with_error!(&env, EscrowErrorExt2::NewAmountMustBePositive);
             }
         }
 
@@ -3810,7 +4083,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can sign amendment");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyBuyerOrSellerCanSignAmendment);
         }
 
         let key = DataKey2::AmendmentProposal(escrow_id);
@@ -3820,11 +4093,11 @@ impl AhjoorEscrowContract {
             .get(&key)
             .expect("No amendment proposal found");
         if proposal.nonce != nonce {
-            panic!("Amendment nonce mismatch");
+            panic_with_error!(&env, EscrowErrorExt2::AmendmentNonceMismatch);
         }
         if env.ledger().timestamp() > proposal.expires_at {
             env.storage().persistent().remove(&key);
-            panic!("Amendment proposal has expired");
+            panic_with_error!(&env, EscrowErrorExt2::AmendmentProposalHasExpired);
         }
 
         if caller == escrow.buyer {
@@ -3853,15 +4126,15 @@ impl AhjoorEscrowContract {
             .get(&key)
             .expect("No amendment proposal found");
         if proposal.nonce != nonce {
-            panic!("Amendment nonce mismatch");
+            panic_with_error!(&env, EscrowErrorExt2::AmendmentNonceMismatch);
         }
         if !proposal.buyer_signed || !proposal.seller_signed {
-            panic!("Amendment requires buyer and seller signatures");
+            panic_with_error!(&env, EscrowErrorExt2::AmendmentRequiresBuyerAndSellerSignatures);
         }
         let now = env.ledger().timestamp();
         if now > proposal.expires_at {
             env.storage().persistent().remove(&key);
-            panic!("Amendment proposal has expired");
+            panic_with_error!(&env, EscrowErrorExt2::AmendmentProposalHasExpired);
         }
         if let Some(deadline) = proposal.new_deadline {
             if deadline <= now {
@@ -3875,7 +4148,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if Self::is_terminal_escrow_status(escrow.status) {
-            panic!("Cannot amend terminal escrow");
+            panic_with_error!(&env, EscrowErrorExt2::CannotAmendTerminalEscrow);
         }
 
         let old_amount = escrow.amount;
@@ -3884,7 +4157,7 @@ impl AhjoorEscrowContract {
 
         if let Some(new_amount) = proposal.new_amount {
             if new_amount <= 0 {
-                panic!("New amount must be positive");
+                panic_with_error!(&env, EscrowErrorExt2::NewAmountMustBePositive);
             }
             let token_client = token::Client::new(&env, &escrow.token);
             if new_amount > escrow.amount {
@@ -3956,16 +4229,16 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if buyer != escrow.buyer {
-            panic!("Only buyer can top up escrow");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyBuyerCanTopUpEscrow);
         }
 
         // Check status is Active or AwaitingInspection
         if escrow.status != EscrowStatus::Active && escrow.status != EscrowStatus::AwaitingInspection {
-            panic!("Escrow is not active or awaiting inspection");
+            panic_with_error!(&env, EscrowErrorExt2::EscrowIsNotActiveOrAwaitingInspection);
         }
 
         if additional_amount <= 0 {
-            panic!("Additional amount must be positive");
+            panic_with_error!(&env, EscrowErrorExt2::AdditionalAmountMustBePositive);
         }
 
         let max_topup_multiplier: u32 = env
@@ -3977,7 +4250,7 @@ impl AhjoorEscrowContract {
         let new_total = escrow.amount + additional_amount;
 
         if new_total > max_total {
-            panic!("Top-up limit exceeded");
+            panic_with_error!(&env, EscrowErrorExt2::TopUpLimitExceeded);
         }
 
         // Transfer tokens
@@ -4024,7 +4297,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if seller != escrow.seller {
-            panic!("Only seller can acknowledge top-up");
+            panic_with_error!(&env, EscrowErrorExt2::OnlySellerCanAcknowledgeTopUp);
         }
 
         escrow.top_up_acknowledged = true;
@@ -4065,24 +4338,24 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if seller != escrow.seller {
-            panic!("Only seller can request partial release");
+            panic_with_error!(&env, EscrowErrorExt2::OnlySellerCanRequestPartialRelease);
         }
 
         if escrow.status != EscrowStatus::Active {
-            panic!("Partial release only allowed on active escrow");
+            panic_with_error!(&env, EscrowErrorExt2::PartialReleaseOnlyAllowedActiveEscrow);
         }
 
         if amount <= 0 {
-            panic!("Partial release amount must be positive");
+            panic_with_error!(&env, EscrowErrorExt2::PartialReleaseAmountMustBePositive);
         }
 
         if amount > escrow.amount {
-            panic!("Partial release amount cannot exceed escrow amount");
+            panic_with_error!(&env, EscrowErrorExt2::PartialReleaseAmountCannotExceedEscrowAmount);
         }
 
         // Check if there's already a pending request
         if env.storage().persistent().has(&DataKey::PendingPartialRelease(escrow_id)) {
-            panic!("Request already pending");
+            panic_with_error!(&env, EscrowErrorExt2::RequestAlreadyPending);
         }
 
         // Get next request ID
@@ -4145,7 +4418,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if buyer != escrow.buyer {
-            panic!("Only buyer can approve partial release");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyBuyerCanApprovePartialRelease);
         }
 
         // Get pending request
@@ -4156,7 +4429,7 @@ impl AhjoorEscrowContract {
             .expect("No pending partial release request");
 
         if request.request_id != request_id {
-            panic!("Invalid request ID");
+            panic_with_error!(&env, EscrowErrorExt2::InvalidRequestID);
         }
 
         // Transfer funds
@@ -4195,7 +4468,7 @@ impl AhjoorEscrowContract {
         seller.require_auth();
 
         if seller == delegate {
-            panic!("Delegate must be different from seller");
+            panic_with_error!(&env, EscrowErrorExt2::DelegateMustBeDifferentFromSeller);
         }
 
         let escrow: Escrow = env
@@ -4213,12 +4486,12 @@ impl AhjoorEscrowContract {
             }
         }
         if !is_seller {
-            panic!("Seller is not part of this escrow");
+            panic_with_error!(&env, EscrowErrorExt2::SellerNotPartOfEscrow);
         }
 
         // Only allow delegation before release
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Can only delegate before escrow is released");
+            panic_with_error!(&env, EscrowErrorExt2::CanOnlyDelegateBeforeEscrowIsReleased);
         }
 
         env.storage()
@@ -4249,7 +4522,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if buyer != escrow.buyer {
-            panic!("Only buyer can reject partial release");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyBuyerCanRejectPartialRelease);
         }
 
         // Get pending request
@@ -4260,7 +4533,7 @@ impl AhjoorEscrowContract {
             .expect("No pending partial release request");
 
         if request.request_id != request_id {
-            panic!("Invalid request ID");
+            panic_with_error!(&env, EscrowErrorExt2::InvalidRequestID);
         }
 
         // Remove pending request
@@ -4284,7 +4557,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if seller != escrow.seller {
-            panic!("Only seller can escalate partial release");
+            panic_with_error!(&env, EscrowErrorExt2::OnlySellerCanEscalatePartialRelease);
         }
 
         // Get pending request
@@ -4297,7 +4570,7 @@ impl AhjoorEscrowContract {
         // Check if deadline passed
         let now = env.ledger().timestamp();
         if now < request.response_deadline {
-            panic!("Response deadline not yet passed");
+            panic_with_error!(&env, EscrowErrorExt2::ResponseDeadlineNotYetPassed);
         }
 
         // Remove pending request
@@ -4348,7 +4621,7 @@ impl AhjoorEscrowContract {
         current_buyer.require_auth();
 
         if current_buyer == new_buyer {
-            panic!("New buyer must be different from current buyer");
+            panic_with_error!(&env, EscrowErrorExt2::NewBuyerMustBeDifferentFromCurrentBuyer);
         }
 
         let mut escrow: Escrow = env
@@ -4358,11 +4631,11 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::Active {
-            panic!("Buyer transfer only allowed for active escrows");
+            panic_with_error!(&env, EscrowErrorExt2::BuyerTransferOnlyAllowedActiveEscrows);
         }
 
         if escrow.buyer != current_buyer {
-            panic!("Only current buyer can transfer buyer role");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyCurrentBuyerCanTransferBuyerRole);
         }
 
         let old_buyer = escrow.buyer.clone();
@@ -4400,7 +4673,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can update metadata");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyBuyerOrSellerCanUpdateMetadata);
         }
 
         // #150: Track buyer activity
@@ -4471,7 +4744,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can upgrade contract");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyAdminCanUpgradeContract);
         }
 
         let old_version = Self::get_or_init_version(&env);
@@ -4499,7 +4772,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can migrate contract");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyAdminCanMigrateContract);
         }
 
         let version = Self::get_or_init_version(&env);
@@ -4509,7 +4782,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::MigrationCompleted(version))
             .unwrap_or(false)
         {
-            panic!("Migration already completed for this version");
+            panic_with_error!(&env, EscrowErrorExt2::MigrationAlreadyCompletedVersion);
         }
 
         env.storage()
@@ -4541,7 +4814,7 @@ impl AhjoorEscrowContract {
     ) -> u32 {
         Self::require_not_paused(&env);
         buyer.require_auth();
-        if unlock_at <= env.ledger().timestamp() { panic!("unlock_at must be in the future"); }
+        if unlock_at <= env.ledger().timestamp() { panic_with_error!(&env, EscrowErrorExt2::UnlockAtMustBeFuture); }
         let request = EscrowCreateRequest {
             seller: beneficiary.clone(),
             arbiter,
@@ -4576,11 +4849,11 @@ impl AhjoorEscrowContract {
         Self::require_not_paused(&env);
         beneficiary.require_auth();
         let mut lock_data: TimeLockData = env.storage().persistent().get(&DataKey::TimeLockData(escrow_id)).expect("Not a time-locked escrow");
-        if lock_data.claimed { panic!("Already claimed"); }
-        if beneficiary != lock_data.beneficiary { panic!("Only beneficiary can claim"); }
-        if env.ledger().timestamp() < lock_data.unlock_at { panic!("Unlock time has not passed"); }
+        if lock_data.claimed { panic_with_error!(&env, EscrowErrorExt2::AlreadyClaimed); }
+        if beneficiary != lock_data.beneficiary { panic_with_error!(&env, EscrowErrorExt2::OnlyBeneficiaryCanClaim); }
+        if env.ledger().timestamp() < lock_data.unlock_at { panic_with_error!(&env, EscrowErrorExt2::UnlockTimeHasNotPassed); }
         let escrow: Escrow = env.storage().persistent().get(&DataKey::Escrow(escrow_id)).expect("Escrow not found");
-        if escrow.status != EscrowStatus::Active { panic!("Escrow not active"); }
+        if escrow.status != EscrowStatus::Active { panic_with_error!(&env, EscrowErrorExt2::EscrowNotActive); }
         let client = token::Client::new(&env, &escrow.token);
         client.transfer(&env.current_contract_address(), &beneficiary, &escrow.amount);
         let mut e = escrow.clone();
@@ -4597,12 +4870,12 @@ impl AhjoorEscrowContract {
         Self::require_not_paused(&env);
         buyer.require_auth();
         let lock_data: TimeLockData = env.storage().persistent().get(&DataKey::TimeLockData(escrow_id)).expect("Not a time-locked escrow");
-        if lock_data.claimed { panic!("Already claimed"); }
-        if env.ledger().timestamp() >= lock_data.unlock_at { panic!("Past unlock time; use claim_timelocked"); }
+        if lock_data.claimed { panic_with_error!(&env, EscrowErrorExt2::AlreadyClaimed); }
+        if env.ledger().timestamp() >= lock_data.unlock_at { panic_with_error!(&env, EscrowErrorExt2::PastUnlockTimeUseClaimTimelocked); }
         let mut escrow: Escrow = env.storage().persistent().get(&DataKey::Escrow(escrow_id)).expect("Escrow not found");
-        if escrow.buyer != buyer { panic!("Only buyer can cancel"); }
-        if escrow.status == EscrowStatus::Disputed || escrow.status == EscrowStatus::PartiallyDisputed { panic!("Dispute active"); }
-        if escrow.status != EscrowStatus::Active { panic!("Escrow not active"); }
+        if escrow.buyer != buyer { panic_with_error!(&env, EscrowErrorExt2::OnlyBuyerCanCancel); }
+        if escrow.status == EscrowStatus::Disputed || escrow.status == EscrowStatus::PartiallyDisputed { panic_with_error!(&env, EscrowErrorExt2::DisputeActive); }
+        if escrow.status != EscrowStatus::Active { panic_with_error!(&env, EscrowErrorExt2::EscrowNotActive); }
         Self::transfer_to_buyers(&env, &escrow, escrow.amount, escrow_id);
         escrow.status = EscrowStatus::Refunded;
         env.storage().persistent().set(&DataKey::Escrow(escrow_id), &escrow);
@@ -4628,7 +4901,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can set token whitelist contract");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyAdminCanSetTokenWhitelistContract);
         }
 
         env.storage()
@@ -4665,7 +4938,7 @@ impl AhjoorEscrowContract {
         Self::require_or_bootstrap_admin(&env, &admin);
 
         if Self::is_paused(env.clone()) {
-            panic!("Contract already paused");
+            panic_with_error!(&env, EscrowErrorExt2::ContractAlreadyPaused);
         }
 
         env.storage().instance().set(&DataKey::Paused, &true);
@@ -4678,7 +4951,7 @@ impl AhjoorEscrowContract {
         Self::require_admin(&env, &admin);
 
         if !Self::is_paused(env.clone()) {
-            panic!("Contract is not paused");
+            panic_with_error!(&env, EscrowErrorExt2::ContractIsNotPaused);
         }
 
         env.storage().instance().set(&DataKey::Paused, &false);
@@ -4742,10 +5015,10 @@ impl AhjoorEscrowContract {
             .get(&DataKey::AllowedToken(config.token.clone()))
             .unwrap_or(false);
         if !is_allowed {
-            panic!("TokenNotAllowed");
+            panic_with_error!(&env, EscrowErrorExt2::TokenNotAllowed);
         }
         if config.deadline_duration == 0 {
-            panic!("deadline_duration must be positive");
+            panic_with_error!(&env, EscrowErrorExt2::DeadlineDurationMustBePositive);
         }
 
         let mut counter: u32 = env
@@ -4801,10 +5074,10 @@ impl AhjoorEscrowContract {
             .expect("Template not found");
 
         if !template.active {
-            panic!("Template is deactivated");
+            panic_with_error!(&env, EscrowErrorExt2::TemplateIsDeactivated);
         }
         if amount <= 0 {
-            panic!("Escrow amount must be positive");
+            panic_with_error!(&env, EscrowError::EscrowAmountMustBePositive);
         }
 
         let deadline = env.ledger().timestamp() + template.config.deadline_duration;
@@ -4893,7 +5166,7 @@ impl AhjoorEscrowContract {
             .unwrap_or(Vec::new(&env));
         for i in 0..pool.len() {
             if pool.get(i).unwrap() == arbiter {
-                panic!("Arbiter already in pool");
+                panic_with_error!(&env, EscrowErrorExt2::ArbiterAlreadyPool);
             }
         }
         pool.push_back(arbiter.clone());
@@ -4926,7 +5199,7 @@ impl AhjoorEscrowContract {
             }
         }
         if !found {
-            panic!("Arbiter not in pool");
+            panic_with_error!(&env, EscrowErrorExt2::ArbiterNotPool);
         }
         // Reset index if it would go out of bounds
         let next_idx: u32 = env
@@ -4976,10 +5249,10 @@ impl AhjoorEscrowContract {
         buyer.require_auth();
 
         if amount <= 0 {
-            panic!("Escrow amount must be positive");
+            panic_with_error!(&env, EscrowError::EscrowAmountMustBePositive);
         }
         if deadline <= env.ledger().timestamp() {
-            panic!("Deadline must be in the future");
+            panic_with_error!(&env, EscrowError::DeadlineMustBeFuture);
         }
         let is_allowed = env
             .storage()
@@ -4987,7 +5260,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::AllowedToken(token.clone()))
             .unwrap_or(false);
         if !is_allowed {
-            panic!("TokenNotAllowed");
+            panic_with_error!(&env, EscrowErrorExt2::TokenNotAllowed);
         }
 
         let pool: Vec<Address> = env
@@ -4996,7 +5269,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::ArbiterPool)
             .unwrap_or(Vec::new(&env));
         if pool.is_empty() {
-            panic!("Arbiter pool is empty");
+            panic_with_error!(&env, EscrowErrorExt2::ArbiterPoolIsEmpty);
         }
 
         let idx: u32 = env
@@ -5094,10 +5367,10 @@ impl AhjoorEscrowContract {
             .expect("Template not found");
 
         if template.creator != creator {
-            panic!("Only template creator can update");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyTemplateCreatorCanUpdate);
         }
         if !template.active {
-            panic!("Template is deactivated");
+            panic_with_error!(&env, EscrowErrorExt2::TemplateIsDeactivated);
         }
 
         let is_allowed = env
@@ -5106,10 +5379,10 @@ impl AhjoorEscrowContract {
             .get(&DataKey::AllowedToken(new_config.token.clone()))
             .unwrap_or(false);
         if !is_allowed {
-            panic!("TokenNotAllowed");
+            panic_with_error!(&env, EscrowErrorExt2::TokenNotAllowed);
         }
         if new_config.deadline_duration == 0 {
-            panic!("deadline_duration must be positive");
+            panic_with_error!(&env, EscrowErrorExt2::DeadlineDurationMustBePositive);
         }
 
         template.config = new_config;
@@ -5140,10 +5413,10 @@ impl AhjoorEscrowContract {
             .expect("Template not found");
 
         if template.creator != creator {
-            panic!("Only template creator can deactivate");
+            panic_with_error!(&env, EscrowErrorExt2::OnlyTemplateCreatorCanDeactivate);
         }
         if !template.active {
-            panic!("Template already deactivated");
+            panic_with_error!(&env, EscrowErrorExt3::TemplateAlreadyDeactivated);
         }
 
         template.active = false;
@@ -5184,15 +5457,15 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.extensions.buyer_inactivity_secs == 0 {
-            panic!("Inactivity release is not enabled for this escrow");
+            panic_with_error!(&env, EscrowErrorExt3::InactivityReleaseIsNotEnabledEscrow);
         }
 
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         if seller != escrow.seller {
-            panic!("Only the escrow seller can claim inactivity release");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyEscrowSellerCanClaimInactivityRelease);
         }
 
         let last_action: u64 = env
@@ -5205,7 +5478,7 @@ impl AhjoorEscrowContract {
         let inactivity_seconds = now.saturating_sub(last_action);
 
         if inactivity_seconds < escrow.extensions.buyer_inactivity_secs {
-            panic!("Buyer inactivity window has not elapsed");
+            panic_with_error!(&env, EscrowErrorExt3::BuyerInactivityWindowHasNotElapsed);
         }
 
         let client = token::Client::new(&env, &escrow.token);
@@ -5242,7 +5515,7 @@ impl AhjoorEscrowContract {
         Self::require_not_paused(&env);
         Self::require_or_bootstrap_admin(&env, &admin);
         if penalty_bps > 10_000 {
-            panic!("Penalty cannot exceed 10000 bps");
+            panic_with_error!(&env, EscrowErrorExt3::PenaltyCannotExceed10000Bps);
         }
         env.storage()
             .instance()
@@ -5257,7 +5530,7 @@ impl AhjoorEscrowContract {
         Self::require_not_paused(&env);
         Self::require_or_bootstrap_admin(&env, &admin);
         if window_seconds == 0 {
-            panic!("Response window must be positive");
+            panic_with_error!(&env, EscrowErrorExt3::ResponseWindowMustBePositive);
         }
         env.storage()
             .instance()
@@ -5279,11 +5552,11 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can request cancellation");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyBuyerOrSellerCanRequestCancellation);
         }
 
         let window: u64 = env
@@ -5342,7 +5615,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::CancellationPending {
-            panic!("No pending cancellation for this escrow");
+            panic_with_error!(&env, EscrowErrorExt3::NoPendingCancellationEscrow);
         }
 
         let request: CancellationRequest = env
@@ -5373,10 +5646,10 @@ impl AhjoorEscrowContract {
 
         // Caller must be the counterparty (not the initiator)
         if caller == request.initiator {
-            panic!("Initiator cannot accept their own cancellation request");
+            panic_with_error!(&env, EscrowErrorExt3::InitiatorCannotAcceptTheirOwnCancellationRequest);
         }
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can accept cancellation");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyBuyerOrSellerCanAcceptCancellation);
         }
 
         let penalty_bps: u32 = env
@@ -5452,7 +5725,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::CancellationPending {
-            panic!("No pending cancellation for this escrow");
+            panic_with_error!(&env, EscrowErrorExt3::NoPendingCancellationEscrow);
         }
 
         let request: CancellationRequest = env
@@ -5462,10 +5735,10 @@ impl AhjoorEscrowContract {
             .expect("Cancellation request not found");
 
         if caller == request.initiator {
-            panic!("Initiator cannot reject their own cancellation request");
+            panic_with_error!(&env, EscrowErrorExt3::InitiatorCannotRejectTheirOwnCancellationRequest);
         }
         if caller != escrow.buyer && caller != escrow.seller {
-            panic!("Only buyer or seller can reject cancellation");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyBuyerOrSellerCanRejectCancellation);
         }
 
         escrow.status = EscrowStatus::Active;
@@ -5498,7 +5771,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::CancellationPending {
-            panic!("No pending cancellation for this escrow");
+            panic_with_error!(&env, EscrowErrorExt3::NoPendingCancellationEscrow);
         }
 
         let request: CancellationRequest = env
@@ -5508,7 +5781,7 @@ impl AhjoorEscrowContract {
             .expect("Cancellation request not found");
 
         if env.ledger().timestamp() <= request.expires_at {
-            panic!("Response window has not elapsed");
+            panic_with_error!(&env, EscrowErrorExt3::ResponseWindowHasNotElapsed);
         }
 
         escrow.status = EscrowStatus::Active;
@@ -5548,15 +5821,15 @@ impl AhjoorEscrowContract {
         buyer.require_auth();
 
         if amount <= 0 {
-            panic!("Bounty amount must be positive");
+            panic_with_error!(&env, EscrowErrorExt3::BountyAmountMustBePositive);
         }
 
         let current_time = env.ledger().timestamp();
         if claim_deadline_ledger <= current_time {
-            panic!("Claim deadline must be in the future");
+            panic_with_error!(&env, EscrowErrorExt3::ClaimDeadlineMustBeFuture);
         }
         if submission_deadline_ledger <= claim_deadline_ledger {
-            panic!("Submission deadline must be after claim deadline");
+            panic_with_error!(&env, EscrowErrorExt3::SubmissionDeadlineMustBeAfterClaimDeadline);
         }
 
         // Check token whitelist if configured
@@ -5567,7 +5840,7 @@ impl AhjoorEscrowContract {
         {
             let whitelist_client = TokenWhitelistClient::new(&env, &whitelist_addr);
             if !whitelist_client.is_whitelisted(&token) {
-                panic!("Token not whitelisted");
+                panic_with_error!(&env, EscrowErrorExt3::TokenNotWhitelisted);
             }
         }
 
@@ -5685,7 +5958,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::BountyUnclaimed {
-            panic!("Bounty is not available for claiming");
+            panic_with_error!(&env, EscrowErrorExt3::BountyIsNotAvailableClaiming);
         }
 
         let mut bounty_data: BountyData = env
@@ -5696,7 +5969,7 @@ impl AhjoorEscrowContract {
 
         let current_time = env.ledger().timestamp();
         if current_time > bounty_data.claim_deadline_ledger {
-            panic!("Claim deadline has passed");
+            panic_with_error!(&env, EscrowErrorExt3::ClaimDeadlineHasPassed);
         }
 
         // Update escrow with solver as seller
@@ -5746,11 +6019,11 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::BountyClaimed {
-            panic!("Bounty is not in claimed status");
+            panic_with_error!(&env, EscrowErrorExt3::BountyIsNotClaimedStatus);
         }
 
         if escrow.seller != solver {
-            panic!("Only the assigned solver can submit work");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyAssignedSolverCanSubmitWork);
         }
 
         let mut bounty_data: BountyData = env
@@ -5761,7 +6034,7 @@ impl AhjoorEscrowContract {
 
         let current_time = env.ledger().timestamp();
         if current_time > bounty_data.submission_deadline_ledger {
-            panic!("Submission deadline has passed");
+            panic_with_error!(&env, EscrowErrorExt3::SubmissionDeadlineHasPassed);
         }
 
         // Store submission hash
@@ -5794,11 +6067,11 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.buyer != buyer {
-            panic!("Only buyer can approve submission");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyBuyerCanApproveSubmission);
         }
 
         if escrow.status != EscrowStatus::BountyClaimed {
-            panic!("Bounty is not in claimed status");
+            panic_with_error!(&env, EscrowErrorExt3::BountyIsNotClaimedStatus);
         }
 
         let bounty_data: BountyData = env
@@ -5808,7 +6081,7 @@ impl AhjoorEscrowContract {
             .expect("Bounty data not found");
 
         if bounty_data.submission_hash.is_none() {
-            panic!("No submission has been made");
+            panic_with_error!(&env, EscrowErrorExt3::NoSubmissionHasBeenMade);
         }
 
         let solver = escrow.seller.clone();
@@ -5848,11 +6121,11 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.buyer != buyer {
-            panic!("Only buyer can reject submission");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyBuyerCanRejectSubmission);
         }
 
         if escrow.status != EscrowStatus::BountyClaimed {
-            panic!("Bounty is not in claimed status");
+            panic_with_error!(&env, EscrowErrorExt3::BountyIsNotClaimedStatus);
         }
 
         let mut bounty_data: BountyData = env
@@ -5868,7 +6141,7 @@ impl AhjoorEscrowContract {
             .unwrap_or(DEFAULT_MAX_BOUNTY_REJECTION_ROUNDS);
 
         if bounty_data.rejection_count >= max_rejections {
-            panic!("Maximum rejection rounds reached");
+            panic_with_error!(&env, EscrowErrorExt3::MaximumRejectionRoundsReached);
         }
 
         let rejected_solver = escrow.seller.clone();
@@ -5917,7 +6190,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.buyer != buyer {
-            panic!("Only buyer can cancel bounty");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyBuyerCanCancelBounty);
         }
 
         let bounty_data: BountyData = env
@@ -5936,7 +6209,7 @@ impl AhjoorEscrowContract {
         {
             // Allow cancellation if claim deadline passed (edge case)
         } else {
-            panic!("Cannot cancel bounty in current state");
+            panic_with_error!(&env, EscrowErrorExt3::CannotCancelBountyCurrentState);
         }
 
         let refund_amount = escrow
@@ -5977,7 +6250,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can set max bounty rejection rounds");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyAdminCanSetMaxBountyRejectionRounds);
         }
 
         env.storage()
@@ -6015,22 +6288,22 @@ impl AhjoorEscrowContract {
         buyer.require_auth();
 
         if milestones.is_empty() {
-            panic!("Bounty must have at least one milestone");
+            panic_with_error!(&env, EscrowErrorExt3::BountyMustHaveAtLeastOneMilestone);
         }
 
         let current_time = env.ledger().timestamp();
         if claim_deadline_ledger <= current_time {
-            panic!("Claim deadline must be in the future");
+            panic_with_error!(&env, EscrowErrorExt3::ClaimDeadlineMustBeFuture);
         }
         if submission_deadline_ledger <= claim_deadline_ledger {
-            panic!("Submission deadline must be after claim deadline");
+            panic_with_error!(&env, EscrowErrorExt3::SubmissionDeadlineMustBeAfterClaimDeadline);
         }
 
         // Validate milestone amounts and compute the total escrow amount.
         let mut total_amount: i128 = 0;
         for m in milestones.iter() {
             if m.amount <= 0 {
-                panic!("Milestone amount must be positive");
+                panic_with_error!(&env, EscrowErrorExt::MilestoneAmountMustBePositive);
             }
             total_amount += m.amount;
         }
@@ -6043,7 +6316,7 @@ impl AhjoorEscrowContract {
         {
             let whitelist_client = TokenWhitelistClient::new(&env, &whitelist_addr);
             if !whitelist_client.is_whitelisted(&token) {
-                panic!("Token not whitelisted");
+                panic_with_error!(&env, EscrowErrorExt3::TokenNotWhitelisted);
             }
         }
 
@@ -6184,15 +6457,15 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::BountyClaimed {
-            panic!("Bounty must be claimed before submitting milestones");
+            panic_with_error!(&env, EscrowErrorExt3::BountyMustBeClaimedBeforeSubmittingMilestones);
         }
         if escrow.seller != solver {
-            panic!("Only the solver can submit milestones");
+            panic_with_error!(&env, EscrowErrorExt3::OnlySolverCanSubmitMilestones);
         }
 
         let current_time = env.ledger().timestamp();
         if current_time > escrow.deadline {
-            panic!("Submission deadline has passed");
+            panic_with_error!(&env, EscrowErrorExt3::SubmissionDeadlineHasPassed);
         }
 
         let mut states: Vec<BountyMilestone> = env
@@ -6202,21 +6475,21 @@ impl AhjoorEscrowContract {
             .expect("No milestones for this bounty");
 
         if index >= states.len() {
-            panic!("Milestone index out of bounds");
+            panic_with_error!(&env, EscrowErrorExt3::MilestoneIndexOutBounds);
         }
 
         // Enforce strict ordering: all earlier milestones must already be paid.
         let mut i: u32 = 0;
         while i < index {
             if states.get(i).unwrap().status != BountyMilestoneStatus::Paid {
-                panic!("Previous milestone not yet verified");
+                panic_with_error!(&env, EscrowErrorExt3::PreviousMilestoneNotYetVerified);
             }
             i += 1;
         }
 
         let mut milestone = states.get(index).unwrap();
         if milestone.status != BountyMilestoneStatus::Pending {
-            panic!("Milestone is not awaiting submission");
+            panic_with_error!(&env, EscrowErrorExt3::MilestoneIsNotAwaitingSubmission);
         }
 
         milestone.status = BountyMilestoneStatus::Submitted;
@@ -6253,7 +6526,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.status != EscrowStatus::BountyClaimed {
-            panic!("Bounty is not in claimed status");
+            panic_with_error!(&env, EscrowErrorExt3::BountyIsNotClaimedStatus);
         }
 
         let mut states: Vec<BountyMilestone> = env
@@ -6263,7 +6536,7 @@ impl AhjoorEscrowContract {
             .expect("No milestones for this bounty");
 
         if index >= states.len() {
-            panic!("Milestone index out of range");
+            panic_with_error!(&env, EscrowErrorExt::MilestoneIndexOutRange);
         }
 
         let mut milestone = states.get(index).unwrap();
@@ -6272,7 +6545,7 @@ impl AhjoorEscrowContract {
         milestone.verifier.require_auth();
 
         if milestone.status != BountyMilestoneStatus::Submitted {
-            panic!("Milestone is not awaiting verification");
+            panic_with_error!(&env, EscrowErrorExt3::MilestoneIsNotAwaitingVerification);
         }
 
         // Mark verified, then release the tranche to the solver.
@@ -6346,7 +6619,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.buyer != buyer {
-            panic!("Only the bounty creator can replace a verifier");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyBountyCreatorCanReplaceVerifier);
         }
 
         let mut states: Vec<BountyMilestone> = env
@@ -6356,12 +6629,12 @@ impl AhjoorEscrowContract {
             .expect("No milestones for this bounty");
 
         if index >= states.len() {
-            panic!("Milestone index out of range");
+            panic_with_error!(&env, EscrowErrorExt::MilestoneIndexOutRange);
         }
 
         let mut milestone = states.get(index).unwrap();
         if milestone.status != BountyMilestoneStatus::Pending {
-            panic!("Verifier can only be replaced before the milestone is submitted");
+            panic_with_error!(&env, EscrowErrorExt3::VerifierCanOnlyBeReplacedBeforeMilestoneIsSubmitted);
         }
 
         let old_verifier = milestone.verifier.clone();
@@ -6419,13 +6692,13 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.buyer != buyer {
-            panic!("Only buyer can configure collateral health");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyBuyerCanConfigureCollateralHealth);
         }
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
         if min_collateral_ratio_bps == 0 || min_collateral_ratio_bps > 10_000 {
-            panic!("min_collateral_ratio_bps must be 1-10000");
+            panic_with_error!(&env, EscrowErrorExt3::MinCollateralRatioBpsOutOfRange);
         }
         env.storage().persistent().set(&DataKey2::CollateralMinRatioBps(escrow_id), &min_collateral_ratio_bps);
         env.storage().persistent().extend_ttl(&DataKey2::CollateralMinRatioBps(escrow_id), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
@@ -6507,7 +6780,7 @@ impl AhjoorEscrowContract {
         provider.require_auth();
 
         if amount <= 0 {
-            panic!("Top-up amount must be positive");
+            panic_with_error!(&env, EscrowErrorExt3::TopUpAmountMustBePositive);
         }
 
         let mut escrow: Escrow = env
@@ -6519,7 +6792,7 @@ impl AhjoorEscrowContract {
         if escrow.status != EscrowStatus::UnderCollateralized
             && !Self::is_open_escrow_status(escrow.status)
         {
-            panic!("Escrow is not active or under-collateralized");
+            panic_with_error!(&env, EscrowErrorExt3::EscrowIsNotActiveOrUnderCollateralized);
         }
 
         let client = token::Client::new(&env, &escrow.token);
@@ -6580,20 +6853,20 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.buyer != buyer {
-            panic!("Only buyer can configure multi-party approval");
+            panic_with_error!(&env, EscrowErrorExt3::OnlyBuyerCanConfigureMultiPartyApproval);
         }
 
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         let count = approvers.len();
         if count < 2 || count > 10 {
-            panic!("Approvers count must be between 2 and 10");
+            panic_with_error!(&env, EscrowErrorExt3::ApproversCountMustBeBetween2And10);
         }
 
         if threshold == 0 || threshold > count {
-            panic!("Threshold must be between 1 and approvers count");
+            panic_with_error!(&env, EscrowErrorExt3::ThresholdMustBeBetween1AndApproversCount);
         }
 
         let in_progress: Vec<Address> = env
@@ -6602,7 +6875,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey2::ReleaseApprovals(escrow_id))
             .unwrap_or(Vec::new(&env));
         if !in_progress.is_empty() {
-            panic!("Cannot reconfigure: approvals already in progress");
+            panic_with_error!(&env, EscrowErrorExt3::CannotReconfigureApprovalsAlreadyProgress);
         }
 
         env.storage()
@@ -6652,7 +6925,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         let approvers: Vec<Address> = env
@@ -6669,7 +6942,7 @@ impl AhjoorEscrowContract {
             }
         }
         if !is_authorized {
-            panic!("Caller is not an authorized approver for this escrow");
+            panic_with_error!(&env, EscrowErrorExt3::CallerIsNotAuthorizedApproverEscrow);
         }
 
         let mut approvals: Vec<Address> = env
@@ -6680,7 +6953,7 @@ impl AhjoorEscrowContract {
 
         for a in approvals.iter() {
             if a == approver {
-                panic!("Approver has already approved this escrow");
+                panic_with_error!(&env, EscrowErrorExt3::ApproverHasAlreadyApprovedEscrow);
             }
         }
 
@@ -6777,7 +7050,7 @@ impl AhjoorEscrowContract {
         buyer.require_auth();
 
         if schedule.is_empty() {
-            panic!("Release schedule must contain at least one tranche");
+            panic_with_error!(&env, EscrowErrorExt3::ReleaseScheduleMustContainAtLeastOneTranche);
         }
 
         let now = env.ledger().timestamp();
@@ -6786,10 +7059,10 @@ impl AhjoorEscrowContract {
         for i in 0..schedule.len() {
             let tranche = schedule.get(i).unwrap();
             if tranche.amount <= 0 {
-                panic!("Each tranche amount must be positive");
+                panic_with_error!(&env, EscrowErrorExt3::EachTrancheAmountMustBePositive);
             }
             if tranche.unlock_at <= now {
-                panic!("Each tranche unlock_at must be in the future");
+                panic_with_error!(&env, EscrowErrorExt4::EachTrancheUnlockAtMustBeFuture);
             }
             total += tranche.amount;
             stored_schedule.push_back(ReleaseTranche {
@@ -6865,11 +7138,11 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.seller != beneficiary {
-            panic!("Only the beneficiary (seller) can claim scheduled releases");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyBeneficiarySellerCanClaimScheduledReleases);
         }
 
         if !Self::is_open_escrow_status(escrow.status) && escrow.status != EscrowStatus::PartiallyReleased {
-            panic!("Escrow is not in a claimable state");
+            panic_with_error!(&env, EscrowErrorExt4::EscrowIsNotClaimableState);
         }
 
         let mut schedule: Vec<ReleaseTranche> = env
@@ -6924,7 +7197,7 @@ impl AhjoorEscrowContract {
         }
 
         if !claimed_any {
-            panic!("No tranches are currently claimable");
+            panic_with_error!(&env, EscrowErrorExt4::NoTranchesAreCurrentlyClaimable);
         }
 
         env.storage()
@@ -6987,10 +7260,10 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.seller != beneficiary {
-            panic!("Only the beneficiary (seller) can claim scheduled releases");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyBeneficiarySellerCanClaimScheduledReleases);
         }
         if !Self::is_open_escrow_status(escrow.status) && escrow.status != EscrowStatus::PartiallyReleased {
-            panic!("Escrow is not in a claimable state");
+            panic_with_error!(&env, EscrowErrorExt4::EscrowIsNotClaimableState);
         }
 
         let mut schedule: Vec<ReleaseTranche> = env
@@ -7008,7 +7281,7 @@ impl AhjoorEscrowContract {
             panic_with_error!(&env, EscrowError::TrancheAlreadyClaimed);
         }
         if tranche.unlock_at > env.ledger().timestamp() {
-            panic!("No tranches are currently claimable");
+            panic_with_error!(&env, EscrowErrorExt4::NoTranchesAreCurrentlyClaimable);
         }
 
         let token_client = token::Client::new(&env, &escrow.token);
@@ -7093,7 +7366,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Paused)
             .unwrap_or(false)
         {
-            panic!("Contract is paused");
+            panic_with_error!(&env, EscrowErrorExt4::ContractIsPaused);
         }
     }
 
@@ -7105,7 +7378,7 @@ impl AhjoorEscrowContract {
             .get::<DataKey, Address>(&DataKey::Admin)
         {
             if stored_admin != *admin {
-                panic!("Only admin can pause contract");
+                panic_with_error!(&env, EscrowErrorExt4::OnlyAdminCanPauseContract);
             }
         } else {
             env.storage().instance().set(&DataKey::Admin, admin);
@@ -7120,7 +7393,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Admin not set");
         if stored_admin != *admin {
-            panic!("Only admin can resume contract");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyAdminCanResumeContract);
         }
     }
 
@@ -7133,7 +7406,7 @@ impl AhjoorEscrowContract {
         {
             let client = TokenWhitelistClient::new(env, &whitelist_contract);
             if !client.is_token_allowed_for_contract(&env.current_contract_address(), token) {
-                panic!("TokenNotAllowed");
+                panic_with_error!(&env, EscrowErrorExt2::TokenNotAllowed);
             }
         } else {
             // Fall back to internal allowlist if it has been activated
@@ -7149,7 +7422,7 @@ impl AhjoorEscrowContract {
                     .get(&DataKey::AllowedToken(token.clone()))
                     .unwrap_or(false);
                 if !is_allowed {
-                    panic!("TokenNotAllowed");
+                    panic_with_error!(&env, EscrowErrorExt2::TokenNotAllowed);
                 }
             }
             // If allowlist not activated → allow all tokens (backward compatibility)
@@ -7159,7 +7432,7 @@ impl AhjoorEscrowContract {
     fn require_unlocked(env: &Env, escrow: &Escrow) {
         if let Some(lock_until) = escrow.extensions.min_lock_until {
             if env.ledger().timestamp() < lock_until {
-                panic!("EscrowStillLocked");
+                panic_with_error!(&env, EscrowErrorExt4::EscrowStillLocked);
             }
         }
     }
@@ -7281,10 +7554,10 @@ impl AhjoorEscrowContract {
 
         let age = env.ledger().timestamp().saturating_sub(price_data.timestamp);
         if age > max_oracle_age {
-            panic!("Oracle price is stale");
+            panic_with_error!(&env, EscrowErrorExt4::OraclePriceIsStale);
         }
         if price_data.price <= 0 {
-            panic!("Invalid oracle price");
+            panic_with_error!(&env, EscrowErrorExt4::InvalidOraclePrice);
         }
 
         price_data
@@ -7529,12 +7802,12 @@ impl AhjoorEscrowContract {
             .get(&DataKey::RenewalAllowance(old_escrow_id))
             .unwrap_or(0);
         if allowance == 0 {
-            panic!("Insufficient renewal allowance");
+            panic_with_error!(&env, EscrowErrorExt4::InsufficientRenewalAllowance);
         }
 
         let duration = source.deadline.saturating_sub(source.created_at);
         if duration == 0 {
-            panic!("Escrow renewal duration must be positive");
+            panic_with_error!(&env, EscrowErrorExt4::EscrowRenewalDurationMustBePositive);
         }
 
         let client = token::Client::new(env, &source.token);
@@ -7674,7 +7947,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can set max top-up bps");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyAdminCanSetMaxTopUpBps);
         }
         env.storage().instance().set(&DataKey::MaxTopUpBps, &max_top_up_bps);
         env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
@@ -7703,10 +7976,10 @@ impl AhjoorEscrowContract {
         Self::require_not_paused(&env);
         buyer.require_auth();
         if collateral_forfeit_bps > 10_000 {
-            panic!("collateral_forfeit_bps cannot exceed 10000");
+            panic_with_error!(&env, EscrowErrorExt4::CollateralForfeitBpsCannotExceed10000);
         }
         if sellers.is_empty() {
-            panic!("At least one seller required");
+            panic_with_error!(&env, EscrowErrorExt4::AtLeastOneSellerRequired);
         }
         let primary_seller = sellers.get(0).unwrap().0;
         let escrow_id = Self::create_escrow_core(
@@ -7773,14 +8046,14 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.seller != seller {
-            panic!("Only seller can deposit collateral");
+            panic_with_error!(&env, EscrowErrorExt4::OnlySellerCanDepositCollateral);
         }
         if escrow.status != EscrowStatus::AwaitingCollateral {
-            panic!("Escrow is not awaiting collateral");
+            panic_with_error!(&env, EscrowErrorExt4::EscrowIsNotAwaitingCollateral);
         }
         let now = env.ledger().timestamp();
         if now > escrow.extensions.collateral_deposit_deadline {
-            panic!("Collateral deposit window has expired");
+            panic_with_error!(&env, EscrowErrorExt4::CollateralDepositWindowHasExpired);
         }
         let collateral = escrow.extensions.collateral_amount;
         let client = token::Client::new(&env, &escrow.token);
@@ -7822,7 +8095,7 @@ impl AhjoorEscrowContract {
     ) {
         rater.require_auth();
         if rating < 1 || rating > 5 {
-            panic!("Rating must be between 1 and 5");
+            panic_with_error!(&env, EscrowErrorExt4::RatingMustBeBetween1And5);
         }
         let escrow: Escrow = env
             .storage()
@@ -7830,18 +8103,18 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.status != EscrowStatus::Released && escrow.status != EscrowStatus::Resolved {
-            panic!("Rating only allowed after escrow is Released or Resolved");
+            panic_with_error!(&env, EscrowErrorExt4::RatingOnlyAllowedAfterEscrowIsReleasedOrResolved);
         }
         let ratee = if rater == escrow.buyer {
             escrow.seller.clone()
         } else if rater == escrow.seller {
             escrow.buyer.clone()
         } else {
-            panic!("Only buyer or seller can submit a rating");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyBuyerOrSellerCanSubmitRating);
         };
         let rating_key = DataKey2::RatingSubmitted(escrow_id, rater.clone());
         if env.storage().persistent().has(&rating_key) {
-            panic!("Rating already submitted for this escrow");
+            panic_with_error!(&env, EscrowErrorExt4::RatingAlreadySubmittedEscrow);
         }
         env.storage().persistent().set(&rating_key, &true);
         env.storage().persistent().extend_ttl(
@@ -7882,13 +8155,13 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.seller != seller {
-            panic!("Only seller can submit delivery proof");
+            panic_with_error!(&env, EscrowErrorExt4::OnlySellerCanSubmitDeliveryProof);
         }
         if escrow.status == EscrowStatus::Disputed {
-            panic!("Proof submission locked: escrow is under dispute");
+            panic_with_error!(&env, EscrowErrorExt4::ProofSubmissionLockedEscrowIsUnderDispute);
         }
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
         let expected_hash = escrow
             .extensions
@@ -7898,7 +8171,7 @@ impl AhjoorEscrowContract {
         let proof_bytes = soroban_sdk::Bytes::from(proof.clone());
         let computed: BytesN<32> = env.crypto().sha256(&proof_bytes).into();
         if computed != expected_hash {
-            panic!("InvalidDeliveryProof");
+            panic_with_error!(&env, EscrowErrorExt4::InvalidDeliveryProof);
         }
         let total = escrow.amount;
         Self::transfer_to_sellers(&env, &escrow, total, escrow_id);
@@ -7931,10 +8204,10 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
 
         if escrow.seller != seller {
-            panic!("Only the escrow seller can raise a veto");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyEscrowSellerCanRaiseVeto);
         }
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         // Enforce cooldown: reject if a prior veto was raised within the window.
@@ -7950,7 +8223,7 @@ impl AhjoorEscrowContract {
             .get::<DataKey2, u64>(&DataKey2::SellerVetoLastTimestamp(escrow_id))
         {
             if env.ledger().timestamp() < last_ts + cooldown {
-                panic!("VetoCooldownActive: seller must wait for cooldown before raising another veto");
+                panic_with_error!(&env, EscrowErrorExt4::VetoCooldownActive);
             }
         }
 
@@ -7983,7 +8256,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if !Self::is_open_escrow_status(escrow.status) {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         // Overriding resets the timestamp to now, starting a fresh cooldown window.
@@ -8033,10 +8306,10 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.buyer != buyer {
-            panic!("Only the buyer can approve");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyBuyerCanApprove);
         }
         if escrow.status != EscrowStatus::AwaitingBuyerVetoDecision {
-            panic!("No pending seller transfer");
+            panic_with_error!(&env, EscrowErrorExt4::NoPendingSellerTransfer);
         }
         let proposal: SellerTransferProposal = env
             .storage()
@@ -8071,10 +8344,10 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can set veto override window");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyAdminCanSetVetoOverrideWindow);
         }
         if window_seconds == 0 {
-            panic!("window_seconds must be positive");
+            panic_with_error!(&env, EscrowErrorExt4::WindowSecondsMustBePositive);
         }
         env.storage()
             .persistent()
@@ -8096,7 +8369,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.seller != seller {
-            panic!("Only the escrow seller can cancel a veto");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyEscrowSellerCanCancelVeto);
         }
         let veto_ts: u64 = env
             .storage()
@@ -8110,7 +8383,7 @@ impl AhjoorEscrowContract {
             .unwrap_or(DEFAULT_VETO_OVERRIDE_WINDOW_SECONDS);
         let now = env.ledger().timestamp();
         if now > veto_ts.saturating_add(window) {
-            panic!("VetoWindowElapsed: override window has passed; only admin can act now");
+            panic_with_error!(&env, EscrowErrorExt4::VetoWindowElapsed);
         }
         env.storage()
             .persistent()
@@ -8132,7 +8405,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can override a seller veto");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyAdminCanOverrideSellerVeto);
         }
         let mut escrow: Escrow = env
             .storage()
@@ -8141,7 +8414,7 @@ impl AhjoorEscrowContract {
             .expect("Escrow not found");
         // Block if an active dispute exists
         if escrow.status == EscrowStatus::Disputed || escrow.status == EscrowStatus::PartiallyDisputed {
-            panic!("ActiveDisputeExists: resolve the dispute before overriding veto");
+            panic_with_error!(&env, EscrowErrorExt4::ActiveDisputeExists);
         }
         let veto_ts: u64 = env
             .storage()
@@ -8155,7 +8428,7 @@ impl AhjoorEscrowContract {
             .unwrap_or(DEFAULT_VETO_OVERRIDE_WINDOW_SECONDS);
         let now = env.ledger().timestamp();
         if now <= veto_ts.saturating_add(window) {
-            panic!("VetoWindowNotElapsed: override window has not yet passed");
+            panic_with_error!(&env, EscrowErrorExt4::VetoWindowNotElapsed);
         }
         let elapsed = now.saturating_sub(veto_ts);
         // Store reason hash immutably
@@ -8197,7 +8470,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.status != EscrowStatus::AwaitingBuyerVetoDecision {
-            panic!("No pending seller transfer");
+            panic_with_error!(&env, EscrowErrorExt4::NoPendingSellerTransfer);
         }
         let proposal: SellerTransferProposal = env
             .storage()
@@ -8205,7 +8478,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey2::SellerTransferProposal(escrow_id))
             .expect("Proposal not found");
         if env.ledger().sequence() <= proposal.veto_deadline {
-            panic!("Veto window has not expired yet");
+            panic_with_error!(&env, EscrowErrorExt4::VetoWindowHasNotExpiredYet);
         }
         escrow.seller = proposal.new_seller.clone();
         escrow.status = EscrowStatus::Active;
@@ -8234,10 +8507,10 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.seller != seller {
-            panic!("Only the current seller can initiate a transfer");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyCurrentSellerCanInitiateTransfer);
         }
         if escrow.status != EscrowStatus::Active {
-            panic!("Escrow must be active to transfer seller role");
+            panic_with_error!(&env, EscrowErrorExt4::EscrowMustBeActiveToTransferSellerRole);
         }
         let veto_window: u32 = env
             .storage()
@@ -8283,10 +8556,10 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.buyer != buyer {
-            panic!("Only the buyer can veto");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyBuyerCanVeto);
         }
         if escrow.status != EscrowStatus::AwaitingBuyerVetoDecision {
-            panic!("No pending seller transfer");
+            panic_with_error!(&env, EscrowErrorExt4::NoPendingSellerTransfer);
         }
         let amount = escrow.amount;
         Self::transfer_to_buyers(&env, &escrow, amount, escrow_id);
@@ -8315,7 +8588,7 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         if admin != stored_admin {
-            panic!("Only admin can set the veto window");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyAdminCanSetVetoWindow);
         }
         env.storage()
             .instance()
@@ -8364,10 +8637,10 @@ impl AhjoorEscrowContract {
         buyer.require_auth();
 
         if milestones.is_empty() {
-            panic!("At least one milestone required");
+            panic_with_error!(&env, EscrowErrorExt::AtLeastOneMilestoneRequired);
         }
         if milestones.len() > MAX_MILESTONES {
-            panic!("Too many milestones");
+            panic_with_error!(&env, EscrowErrorExt::TooManyMilestones);
         }
 
         // Validate release_bps sum == 10 000
@@ -8375,15 +8648,15 @@ impl AhjoorEscrowContract {
         for i in 0..milestones.len() {
             let m = milestones.get(i).unwrap();
             if m.release_bps == 0 {
-                panic!("release_bps must be positive for each milestone");
+                panic_with_error!(&env, EscrowErrorExt4::ReleaseBpsMustBePositiveEachMilestone);
             }
             total_bps = total_bps.saturating_add(m.release_bps);
         }
         if total_bps != 10_000 {
-            panic!("Milestone release_bps must sum to 10 000");
+            panic_with_error!(&env, EscrowErrorExt4::MilestoneReleaseBpsMustSumTo10000);
         }
         if amount <= 0 {
-            panic!("Escrow amount must be positive");
+            panic_with_error!(&env, EscrowError::EscrowAmountMustBePositive);
         }
 
         let request = EscrowCreateRequest {
@@ -8456,10 +8729,10 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.seller != seller {
-            panic!("Only the escrow seller may submit milestones");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyEscrowSellerMaySubmitMilestones);
         }
         if escrow.status != EscrowStatus::Active {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         let mut states: Vec<MilestoneState> = env
@@ -8469,13 +8742,13 @@ impl AhjoorEscrowContract {
             .expect("No BPS milestones for this escrow");
 
         if milestone_index >= states.len() {
-            panic!("Milestone index out of range");
+            panic_with_error!(&env, EscrowErrorExt::MilestoneIndexOutRange);
         }
         let mut state = states.get(milestone_index).unwrap();
         if state.status != MilestoneStateStatus::Pending
             && state.status != MilestoneStateStatus::Rejected
         {
-            panic!("Milestone must be Pending or Rejected to submit");
+            panic_with_error!(&env, EscrowErrorExt4::MilestoneMustBePendingOrRejectedToSubmit);
         }
 
         state.status = MilestoneStateStatus::Submitted;
@@ -8515,10 +8788,10 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if caller != escrow.buyer && caller != escrow.arbiter {
-            panic!("Only buyer or arbiter can approve milestones");
+            panic_with_error!(&env, EscrowErrorExt::OnlyBuyerOrArbiterCanApproveMilestones);
         }
         if escrow.status != EscrowStatus::Active {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         let mut states: Vec<MilestoneState> = env
@@ -8528,11 +8801,11 @@ impl AhjoorEscrowContract {
             .expect("No BPS milestones for this escrow");
 
         if milestone_index >= states.len() {
-            panic!("Milestone index out of range");
+            panic_with_error!(&env, EscrowErrorExt::MilestoneIndexOutRange);
         }
         let mut state = states.get(milestone_index).unwrap();
         if state.status != MilestoneStateStatus::Submitted {
-            panic!("Milestone must be Submitted before approval");
+            panic_with_error!(&env, EscrowErrorExt4::MilestoneMustBeSubmittedBeforeApproval);
         }
 
         // Calculate release amount using bps; final milestone gets remainder
@@ -8616,10 +8889,10 @@ impl AhjoorEscrowContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("Escrow not found");
         if escrow.buyer != buyer {
-            panic!("Only the escrow buyer may reject milestones");
+            panic_with_error!(&env, EscrowErrorExt4::OnlyEscrowBuyerMayRejectMilestones);
         }
         if escrow.status != EscrowStatus::Active {
-            panic!("Escrow is not active");
+            panic_with_error!(&env, EscrowError::EscrowIsNotActive);
         }
 
         let mut states: Vec<MilestoneState> = env
@@ -8629,11 +8902,11 @@ impl AhjoorEscrowContract {
             .expect("No BPS milestones for this escrow");
 
         if milestone_index >= states.len() {
-            panic!("Milestone index out of range");
+            panic_with_error!(&env, EscrowErrorExt::MilestoneIndexOutRange);
         }
         let mut state = states.get(milestone_index).unwrap();
         if state.status != MilestoneStateStatus::Submitted {
-            panic!("Only a Submitted milestone can be rejected");
+            panic_with_error!(&env, EscrowErrorExt4::OnlySubmittedMilestoneCanBeRejected);
         }
 
         state.status = MilestoneStateStatus::Rejected;

--- a/contracts/ahjoor-escrow/src/test.rs
+++ b/contracts/ahjoor-escrow/src/test.rs
@@ -106,7 +106,6 @@ fn test_receipt_transfer_and_release_to_new_holder() {
 }
 
 #[test]
-#[should_panic(expected = "Only current holder can transfer receipt")]
 fn test_non_holder_transfer_rejected() {
     let s = setup();
 
@@ -122,11 +121,11 @@ fn test_non_holder_transfer_rejected() {
     let receipt_id = receipt.receipt_id;
 
     // Arbiter is not the holder — should panic
-    s.client.transfer_escrow_receipt(&arbiter, &receipt_id, &Address::generate(&s.env));
+    let __typed_err_result = s.client.try_transfer_escrow_receipt(&arbiter, &receipt_id, &Address::generate(&s.env));
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::OnlyCurrentHolderCanTransferReceipt.into());
 }
 
 #[test]
-#[should_panic(expected = "ActiveMilestoneInProgress")]
 fn test_mid_milestone_transfer_rejection() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -141,7 +140,8 @@ fn test_mid_milestone_transfer_rejection() {
     let receipt_id = receipt.receipt_id;
 
     // Seller cannot transfer while milestones present
-    s.client.transfer_escrow_receipt(&seller, &receipt_id, &Address::generate(&s.env));
+    let __typed_err_result = s.client.try_transfer_escrow_receipt(&seller, &receipt_id, &Address::generate(&s.env));
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::ActiveMilestoneInProgress.into());
 }
 
 #[test]
@@ -162,7 +162,6 @@ fn test_burn_on_cancel() {
 }
 
 #[test]
-#[should_panic(expected = "Escrow amount must be positive")]
 fn test_create_escrow_zero_amount_panics() {
     let s = setup();
 
@@ -172,12 +171,12 @@ fn test_create_escrow_zero_amount_panics() {
     s.token_admin_client.mint(&buyer, &1000);
 
     let deadline = s.env.ledger().timestamp() + 1000;
-    s.client
-        .create_escrow(&buyer, &seller, &arbiter, &0, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+    let __typed_err_result = s.client
+        .try_create_escrow(&buyer, &seller, &arbiter, &0, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::EscrowAmountMustBePositive.into());
 }
 
 #[test]
-#[should_panic(expected = "Deadline must be in the future")]
 fn test_create_escrow_past_deadline_panics() {
     let s = setup();
 
@@ -187,8 +186,9 @@ fn test_create_escrow_past_deadline_panics() {
     s.token_admin_client.mint(&buyer, &1000);
 
     let deadline = s.env.ledger().timestamp();
-    s.client
-        .create_escrow(&buyer, &seller, &arbiter, &250, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+    let __typed_err_result = s.client
+        .try_create_escrow(&buyer, &seller, &arbiter, &250, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::DeadlineMustBeFuture.into());
 }
 
 // ===========================================================================
@@ -392,7 +392,6 @@ fn test_partial_release_over_release_attempt_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "Only buyer or arbiter can release escrow")]
 fn test_release_escrow_by_seller_panics() {
     let s = setup();
 
@@ -405,12 +404,11 @@ fn test_release_escrow_by_seller_panics() {
     let escrow_id =
         s.client
             .create_escrow(&buyer, &seller, &arbiter, &250, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
-
-    s.client.release_escrow(&seller, &escrow_id);
+    let __typed_err_result = s.client.try_release_escrow(&seller, &escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::OnlyBuyerOrArbiterCanReleaseEscrow.into());
 }
 
 #[test]
-#[should_panic(expected = "Escrow is not active")]
 fn test_release_escrow_already_released_panics() {
     let s = setup();
 
@@ -425,7 +423,8 @@ fn test_release_escrow_already_released_panics() {
             .create_escrow(&buyer, &seller, &arbiter, &250, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
 
     s.client.release_escrow(&buyer, &escrow_id);
-    s.client.release_escrow(&buyer, &escrow_id); // Should panic
+    let __typed_err_result = s.client.try_release_escrow(&buyer, &escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::EscrowIsNotActive.into());
 }
 
 // ===========================================================================
@@ -486,7 +485,6 @@ fn test_dispute_escrow_by_seller() {
 }
 
 #[test]
-#[should_panic(expected = "Only buyer or seller can dispute escrow")]
 fn test_dispute_escrow_by_arbiter_panics() {
     let s = setup();
 
@@ -499,13 +497,13 @@ fn test_dispute_escrow_by_arbiter_panics() {
     let escrow_id =
         s.client
             .create_escrow(&buyer, &seller, &arbiter, &250, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
-
-    s.client.dispute_escrow(
+    let __typed_err_result = s.client.try_dispute_escrow(
         &arbiter,
         &escrow_id,
         &String::from_str(&s.env, "Invalid"),
         &250,
     );
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::OnlyBuyerOrSellerCanDisputeEscrow.into());
 }
 
 #[test]
@@ -635,7 +633,6 @@ fn test_escalation_emits_event_with_effective_timeout() {
 }
 
 #[test]
-#[should_panic(expected = "dispute_timeout_seconds must be positive")]
 fn test_create_escrow_with_zero_dispute_timeout_panics() {
     let s = setup();
 
@@ -645,7 +642,7 @@ fn test_create_escrow_with_zero_dispute_timeout_panics() {
     s.token_admin_client.mint(&buyer, &1000);
 
     let deadline = s.env.ledger().timestamp() + 1000;
-    s.client.create_escrow_w_timeout(
+    let __typed_err_result = s.client.try_create_escrow_w_timeout(
         &buyer,
         &seller,
         &arbiter,
@@ -657,14 +654,15 @@ fn test_create_escrow_with_zero_dispute_timeout_panics() {
         &0u32,
         &0u64,
     );
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::DisputeTimeoutSecondsMustBePositive.into());
 }
 
 #[test]
-#[should_panic(expected = "Timeout must be positive")]
 fn test_update_default_dispute_timeout_zero_panics() {
     let s = setup();
-    s.client
-        .update_default_dispute_timeout(&s.admin, &0u64);
+    let __typed_err_result = s.client
+        .try_update_default_dispute_timeout(&s.admin, &0u64);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::TimeoutMustBePositive.into());
 }
 
 // ===========================================================================
@@ -896,7 +894,6 @@ fn test_resolve_dispute_to_buyer() {
 }
 
 #[test]
-#[should_panic(expected = "Only arbiter can resolve dispute")]
 fn test_resolve_dispute_by_buyer_panics() {
     let s = setup();
 
@@ -916,7 +913,8 @@ fn test_resolve_dispute_by_buyer_panics() {
         &String::from_str(&s.env, "Item not received"),
         &250,
     );
-    s.client.resolve_dispute(&buyer, &escrow_id, &0u32);
+    let __typed_err_result = s.client.try_resolve_dispute(&buyer, &escrow_id, &0u32);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::OnlyArbiterCanResolveDispute.into());
 }
 
 // ===========================================================================
@@ -1030,7 +1028,6 @@ fn test_resolve_dispute_0_100_is_full_seller_win() {
 }
 
 #[test]
-#[should_panic(expected = "buyer_percent must be between 0 and 100")]
 fn test_resolve_dispute_invalid_percent_panics() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -1044,7 +1041,8 @@ fn test_resolve_dispute_invalid_percent_panics() {
             .create_escrow(&buyer, &seller, &arbiter, &500, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
 
     s.client.dispute_escrow(&buyer, &escrow_id, &String::from_str(&s.env, "d"), &500);
-    s.client.resolve_dispute(&arbiter, &escrow_id, &101u32);
+    let __typed_err_result = s.client.try_resolve_dispute(&arbiter, &escrow_id, &101u32);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::BuyerPercentMustBeBetween0And100.into());
 }
 
 // ===========================================================================
@@ -1240,7 +1238,6 @@ fn test_auto_release_expired() {
 }
 
 #[test]
-#[should_panic(expected = "Escrow has not expired yet")]
 fn test_auto_release_not_expired_panics() {
     let s = setup();
 
@@ -1253,12 +1250,11 @@ fn test_auto_release_not_expired_panics() {
     let escrow_id =
         s.client
             .create_escrow(&buyer, &seller, &arbiter, &250, &s.token_addr, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
-
-    s.client.auto_release_expired(&escrow_id);
+    let __typed_err_result = s.client.try_auto_release_expired(&escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::EscrowHasNotExpiredYet.into());
 }
 
 #[test]
-#[should_panic(expected = "Escrow is not active")]
 fn test_auto_release_disputed_panics() {
     let s = setup();
 
@@ -1281,8 +1277,8 @@ fn test_auto_release_disputed_panics() {
 
     // Advance time past deadline
     s.env.ledger().set_timestamp(deadline + 1);
-
-    s.client.auto_release_expired(&escrow_id);
+    let __typed_err_result = s.client.try_auto_release_expired(&escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::EscrowIsNotActive.into());
 }
 
 // ===========================================================================
@@ -1883,7 +1879,6 @@ fn test_non_admin_cannot_add_or_remove_allowed_token() {
 }
 
 #[test]
-#[should_panic(expected = "TokenNotAllowed")]
 fn test_create_escrow_with_disallowed_token_panics_token_not_allowed() {
     let s = setup();
     let unallowed_token = Address::generate(&s.env);
@@ -1894,8 +1889,9 @@ fn test_create_escrow_with_disallowed_token_panics_token_not_allowed() {
     s.token_admin_client.mint(&buyer, &1000);
 
     let deadline = s.env.ledger().timestamp() + 1000;
-    s.client
-        .create_escrow(&buyer, &seller, &arbiter, &250, &unallowed_token, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+    let __typed_err_result = s.client
+        .try_create_escrow(&buyer, &seller, &arbiter, &250, &unallowed_token, &deadline, &None, &Vec::new(&s.env), &false, &0u32);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt2::TokenNotAllowed.into());
 }
 
 // ===========================================================================
@@ -2045,7 +2041,6 @@ fn test_update_metadata_multiple_times_only_latest_stored() {
 }
 
 #[test]
-#[should_panic(expected = "Only buyer or seller can update metadata")]
 fn test_update_metadata_unauthorized_panics() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -2069,7 +2064,8 @@ fn test_update_metadata_unauthorized_panics() {
     );
 
     let hash = BytesN::from_array(&s.env, &[6u8; 32]);
-    s.client.update_metadata(&outsider, &escrow_id, &hash);
+    let __typed_err_result = s.client.try_update_metadata(&outsider, &escrow_id, &hash);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt2::OnlyBuyerOrSellerCanUpdateMetadata.into());
 }
 
 // ===========================================================================
@@ -2220,7 +2216,6 @@ fn test_release_multi_party_dust_goes_to_first_seller() {
 }
 
 #[test]
-#[should_panic(expected = "Seller allocations must sum to 10000 bps")]
 fn test_create_multi_party_escrow_invalid_bps_panics() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -2234,7 +2229,7 @@ fn test_create_multi_party_escrow_invalid_bps_panics() {
     sellers.push_back((seller2.clone(), 3000u32)); // only 8000 bps total
 
     let deadline = s.env.ledger().timestamp() + 1000;
-    s.client.create_escrow(
+    let __typed_err_result = s.client.try_create_escrow(
         &buyer,
         &seller1,
         &arbiter,
@@ -2246,10 +2241,10 @@ fn test_create_multi_party_escrow_invalid_bps_panics() {
         &false,
         &0u32,
     );
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::SellerAllocationsMustSumTo10000Bps.into());
 }
 
 #[test]
-#[should_panic(expected = "Maximum 5 sellers allowed")]
 fn test_create_multi_party_escrow_too_many_sellers_panics() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -2266,7 +2261,7 @@ fn test_create_multi_party_escrow_too_many_sellers_panics() {
     sellers.push_back((Address::generate(&s.env), 1000u32)); // 6th seller
 
     let deadline = s.env.ledger().timestamp() + 1000;
-    s.client.create_escrow(
+    let __typed_err_result = s.client.try_create_escrow(
         &buyer,
         &Address::generate(&s.env),
         &arbiter,
@@ -2278,6 +2273,7 @@ fn test_create_multi_party_escrow_too_many_sellers_panics() {
         &false,
         &0u32,
     );
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::Maximum5SellersAllowed.into());
 }
 
 // ===========================================================================
@@ -4087,7 +4083,6 @@ fn test_milestone_full_release_transitions_to_released() {
 }
 
 #[test]
-#[should_panic(expected = "Milestone not pending")]
 fn test_double_approve_milestone_panics() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -4106,11 +4101,11 @@ fn test_double_approve_milestone_panics() {
     );
 
     s.client.approve_milestone(&buyer, &escrow_id, &0);
-    s.client.approve_milestone(&buyer, &escrow_id, &0);
+    let __typed_err_result = s.client.try_approve_milestone(&buyer, &escrow_id, &0);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::MilestoneNotPending.into());
 }
 
 #[test]
-#[should_panic(expected = "Only buyer or arbiter can approve milestones")]
 fn test_seller_cannot_approve_own_milestone() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -4127,12 +4122,11 @@ fn test_seller_cannot_approve_own_milestone() {
         &deadline,
         &make_milestones(&s.env, &[100, 200, 300]),
     );
-
-    s.client.approve_milestone(&seller, &escrow_id, &0);
+    let __typed_err_result = s.client.try_approve_milestone(&seller, &escrow_id, &0);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::OnlyBuyerOrArbiterCanApproveMilestones.into());
 }
 
 #[test]
-#[should_panic(expected = "Milestone amount must be positive")]
 fn test_zero_milestone_amount_rejected() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -4141,7 +4135,7 @@ fn test_zero_milestone_amount_rejected() {
     s.token_admin_client.mint(&buyer, &1000);
 
     let deadline = s.env.ledger().timestamp() + 1000;
-    s.client.create_milestone_escrow(
+    let __typed_err_result = s.client.try_create_milestone_escrow(
         &buyer,
         &seller,
         &arbiter,
@@ -4149,10 +4143,10 @@ fn test_zero_milestone_amount_rejected() {
         &deadline,
         &make_milestones(&s.env, &[0, 100]),
     );
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::MilestoneAmountMustBePositive.into());
 }
 
 #[test]
-#[should_panic(expected = "At least one milestone required")]
 fn test_empty_milestones_rejected() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -4161,7 +4155,7 @@ fn test_empty_milestones_rejected() {
     s.token_admin_client.mint(&buyer, &1000);
 
     let deadline = s.env.ledger().timestamp() + 1000;
-    s.client.create_milestone_escrow(
+    let __typed_err_result = s.client.try_create_milestone_escrow(
         &buyer,
         &seller,
         &arbiter,
@@ -4169,10 +4163,10 @@ fn test_empty_milestones_rejected() {
         &deadline,
         &make_milestones(&s.env, &[]),
     );
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::AtLeastOneMilestoneRequired.into());
 }
 
 #[test]
-#[should_panic(expected = "Milestone index out of range")]
 fn test_milestone_out_of_range_rejected() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -4189,8 +4183,8 @@ fn test_milestone_out_of_range_rejected() {
         &deadline,
         &make_milestones(&s.env, &[100, 200]),
     );
-
-    s.client.approve_milestone(&buyer, &escrow_id, &5);
+    let __typed_err_result = s.client.try_approve_milestone(&buyer, &escrow_id, &5);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::MilestoneIndexOutRange.into());
 }
 
 // ------------------------------
@@ -4278,7 +4272,6 @@ fn test_multiple_top_ups() {
 }
 
 #[test]
-#[should_panic(expected = "Top-up limit exceeded")]
 fn test_top_up_limit_exceeded() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -4301,11 +4294,11 @@ fn test_top_up_limit_exceeded() {
     );
 
     // Max top-up is 3x original (200*3=600, so 400 extra allowed)
-    s.client.top_up_escrow(&buyer, &escrow_id, &450); // Will panic
+    let __typed_err_result = s.client.try_top_up_escrow(&buyer, &escrow_id, &450);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt2::TopUpLimitExceeded.into());
 }
 
 #[test]
-#[should_panic(expected = "Escrow is not active or awaiting inspection")]
 fn test_top_up_after_release_rejected() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -4331,7 +4324,8 @@ fn test_top_up_after_release_rejected() {
     s.client.release_escrow(&buyer, &escrow_id);
 
     // Try to top up
-    s.client.top_up_escrow(&buyer, &escrow_id, &100);
+    let __typed_err_result = s.client.try_top_up_escrow(&buyer, &escrow_id, &100);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt2::EscrowIsNotActiveOrAwaitingInspection.into());
 }
 
 #[test]
@@ -4473,7 +4467,6 @@ fn test_partial_release_reject() {
 }
 
 #[test]
-#[should_panic(expected = "Request already pending")]
 fn test_duplicate_partial_release() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -4500,7 +4493,8 @@ fn test_duplicate_partial_release() {
     s.client.request_partial_release(&seller, &escrow_id, &100, &justification_hash);
 
     // Second request (should panic)
-    s.client.request_partial_release(&seller, &escrow_id, &100, &justification_hash);
+    let __typed_err_result = s.client.try_request_partial_release(&seller, &escrow_id, &100, &justification_hash);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt2::RequestAlreadyPending.into());
 }
 
 #[test]
@@ -4541,7 +4535,6 @@ fn test_partial_release_escalate() {
 }
 
 #[test]
-#[should_panic(expected = "Partial release only allowed on active escrow")]
 fn test_partial_release_non_active() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -4568,7 +4561,8 @@ fn test_partial_release_non_active() {
 
     // Try to request partial release (should panic)
     let justification_hash = BytesN::from_array(&s.env, &[1u8; 32]);
-    s.client.request_partial_release(&seller, &escrow_id, &100, &justification_hash);
+    let __typed_err_result = s.client.try_request_partial_release(&seller, &escrow_id, &100, &justification_hash);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt2::PartialReleaseOnlyAllowedActiveEscrow.into());
 }
 
 // ===========================================================================

--- a/contracts/ahjoor-escrow/src/test_auto_renewal.rs
+++ b/contracts/ahjoor-escrow/src/test_auto_renewal.rs
@@ -349,7 +349,6 @@ fn test_get_renewal_history_ordered() {
 
 /// cancel_auto_renewal panics if caller is not the buyer.
 #[test]
-#[should_panic(expected = "Only buyer can cancel auto-renewal")]
 fn test_cancel_auto_renewal_non_buyer_panics() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -370,12 +369,12 @@ fn test_cancel_auto_renewal_non_buyer_panics() {
     );
 
     // Seller tries to cancel — should panic
-    s.client.cancel_auto_renewal(&seller, &escrow_id);
+    let __typed_err_result = s.client.try_cancel_auto_renewal(&seller, &escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::OnlyBuyerCanCancelAutoRenewal.into());
 }
 
 /// cancel_auto_renewal panics if no AutoRenewConfig is set.
 #[test]
-#[should_panic(expected = "No AutoRenewConfig set on this escrow")]
 fn test_cancel_auto_renewal_no_config_panics() {
     let s = setup();
     let buyer = Address::generate(&s.env);
@@ -388,8 +387,8 @@ fn test_cancel_auto_renewal_no_config_panics() {
         &buyer, &seller, &arbiter, &200, &s.token_addr, &deadline, &None,
         &Vec::new(&s.env), &false, &0u32,
     );
-
-    s.client.cancel_auto_renewal(&buyer, &escrow_id);
+    let __typed_err_result = s.client.try_cancel_auto_renewal(&buyer, &escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowError::NoAutoRenewConfigSetEscrow.into());
 }
 
 /// Max renewals cap: renewals_completed == max_renewals means no further renewal.

--- a/contracts/ahjoor-escrow/src/test_bounty_board.rs
+++ b/contracts/ahjoor-escrow/src/test_bounty_board.rs
@@ -16,7 +16,8 @@
 //! - Cancellation after partial milestone payout refunds only remaining funds.
 
 use crate::{
-    AhjoorEscrowContract, AhjoorEscrowContractClient, BountyMilestoneInput, EscrowStatus,
+    AhjoorEscrowContract, AhjoorEscrowContractClient, BountyMilestoneInput, EscrowErrorExt3,
+    EscrowStatus,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
@@ -87,7 +88,6 @@ fn test_create_bounty_success() {
 }
 
 #[test]
-#[should_panic(expected = "Bounty amount must be positive")]
 fn test_create_bounty_zero_amount() {
     let env = Env::default();
     env.mock_all_auths();
@@ -105,8 +105,7 @@ fn test_create_bounty_zero_amount() {
 
     let description_hash = BytesN::from_array(&env, &[1u8; 32]);
     let current_time = env.ledger().timestamp();
-
-    client.create_bounty(
+    let __typed_err_result = client.try_create_bounty(
         &buyer,
         &token.address,
         &0,
@@ -114,10 +113,10 @@ fn test_create_bounty_zero_amount() {
         &(current_time + 86400),
         &(current_time + 172800),
     );
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::BountyAmountMustBePositive.into());
 }
 
 #[test]
-#[should_panic(expected = "Claim deadline must be in the future")]
 fn test_create_bounty_past_claim_deadline() {
     let env = Env::default();
     env.mock_all_auths();
@@ -137,8 +136,7 @@ fn test_create_bounty_past_claim_deadline() {
     let description_hash = BytesN::from_array(&env, &[1u8; 32]);
     advance_ledger(&env, 1000); // ensure timestamp > 100 so subtraction doesn't overflow
     let current_time = env.ledger().timestamp();
-
-    client.create_bounty(
+    let __typed_err_result = client.try_create_bounty(
         &buyer,
         &token.address,
         &500,
@@ -146,10 +144,10 @@ fn test_create_bounty_past_claim_deadline() {
         &(current_time - 100),
         &(current_time + 172800),
     );
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::ClaimDeadlineMustBeFuture.into());
 }
 
 #[test]
-#[should_panic(expected = "Submission deadline must be after claim deadline")]
 fn test_create_bounty_invalid_deadlines() {
     let env = Env::default();
     env.mock_all_auths();
@@ -168,8 +166,7 @@ fn test_create_bounty_invalid_deadlines() {
 
     let description_hash = BytesN::from_array(&env, &[1u8; 32]);
     let current_time = env.ledger().timestamp();
-
-    client.create_bounty(
+    let __typed_err_result = client.try_create_bounty(
         &buyer,
         &token.address,
         &500,
@@ -177,6 +174,7 @@ fn test_create_bounty_invalid_deadlines() {
         &(current_time + 172800),
         &(current_time + 86400),
     );
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::SubmissionDeadlineMustBeAfterClaimDeadline.into());
 }
 
 #[test]
@@ -220,7 +218,6 @@ fn test_claim_bounty_success() {
 }
 
 #[test]
-#[should_panic(expected = "Bounty is not available for claiming")]
 fn test_claim_bounty_duplicate() {
     let env = Env::default();
     env.mock_all_auths();
@@ -252,11 +249,11 @@ fn test_claim_bounty_duplicate() {
     );
 
     client.claim_bounty(&solver1, &escrow_id);
-    client.claim_bounty(&solver2, &escrow_id); // Should panic
+    let __typed_err_result = client.try_claim_bounty(&solver2, &escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::BountyIsNotAvailableClaiming.into());
 }
 
 #[test]
-#[should_panic(expected = "Claim deadline has passed")]
 fn test_claim_bounty_after_deadline() {
     let env = Env::default();
     env.mock_all_auths();
@@ -288,7 +285,8 @@ fn test_claim_bounty_after_deadline() {
 
     advance_ledger(&env, 86401); // Past claim deadline
 
-    client.claim_bounty(&solver, &escrow_id);
+    let __typed_err_result = client.try_claim_bounty(&solver, &escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::ClaimDeadlineHasPassed.into());
 }
 
 #[test]
@@ -331,7 +329,6 @@ fn test_submit_bounty_work_success() {
 }
 
 #[test]
-#[should_panic(expected = "Only the assigned solver can submit work")]
 fn test_submit_bounty_work_wrong_solver() {
     let env = Env::default();
     env.mock_all_auths();
@@ -365,11 +362,11 @@ fn test_submit_bounty_work_wrong_solver() {
     client.claim_bounty(&solver, &escrow_id);
 
     let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
-    client.submit_bounty_work(&wrong_solver, &escrow_id, &submission_hash);
+    let __typed_err_result = client.try_submit_bounty_work(&wrong_solver, &escrow_id, &submission_hash);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::OnlyAssignedSolverCanSubmitWork.into());
 }
 
 #[test]
-#[should_panic(expected = "Submission deadline has passed")]
 fn test_submit_bounty_work_after_deadline() {
     let env = Env::default();
     env.mock_all_auths();
@@ -404,7 +401,8 @@ fn test_submit_bounty_work_after_deadline() {
     advance_ledger(&env, 172801); // Past submission deadline
 
     let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
-    client.submit_bounty_work(&solver, &escrow_id, &submission_hash);
+    let __typed_err_result = client.try_submit_bounty_work(&solver, &escrow_id, &submission_hash);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::SubmissionDeadlineHasPassed.into());
 }
 
 #[test]
@@ -453,7 +451,6 @@ fn test_approve_bounty_submission_success() {
 }
 
 #[test]
-#[should_panic(expected = "No submission has been made")]
 fn test_approve_bounty_without_submission() {
     let env = Env::default();
     env.mock_all_auths();
@@ -484,7 +481,8 @@ fn test_approve_bounty_without_submission() {
     );
 
     client.claim_bounty(&solver, &escrow_id);
-    client.approve_bounty_submission(&buyer, &escrow_id);
+    let __typed_err_result = client.try_approve_bounty_submission(&buyer, &escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::NoSubmissionHasBeenMade.into());
 }
 
 #[test]
@@ -542,7 +540,6 @@ fn test_reject_bounty_submission_and_reclaim() {
 }
 
 #[test]
-#[should_panic(expected = "Maximum rejection rounds reached")]
 fn test_reject_bounty_max_rejections() {
     let env = Env::default();
     env.mock_all_auths();
@@ -584,7 +581,8 @@ fn test_reject_bounty_max_rejections() {
     client.claim_bounty(&solver, &escrow_id);
     let submission_hash = BytesN::from_array(&env, &[2u8; 32]);
     client.submit_bounty_work(&solver, &escrow_id, &submission_hash);
-    client.reject_bounty_submission(&buyer, &escrow_id);
+    let __typed_err_result = client.try_reject_bounty_submission(&buyer, &escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::MaximumRejectionRoundsReached.into());
 }
 
 #[test]
@@ -700,7 +698,6 @@ fn test_cancel_bounty_after_inspection_fee() {
 }
 
 #[test]
-#[should_panic(expected = "Cannot cancel bounty in current state")]
 fn test_cancel_bounty_claimed() {
     let env = Env::default();
     env.mock_all_auths();
@@ -731,7 +728,8 @@ fn test_cancel_bounty_claimed() {
     );
 
     client.claim_bounty(&solver, &escrow_id);
-    client.cancel_bounty(&buyer, &escrow_id); // Should panic
+    let __typed_err_result = client.try_cancel_bounty(&buyer, &escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::CannotCancelBountyCurrentState.into());
 }
 
 #[test]

--- a/contracts/ahjoor-escrow/src/test_bounty_milestone.rs
+++ b/contracts/ahjoor-escrow/src/test_bounty_milestone.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     AhjoorEscrowContract, AhjoorEscrowContractClient, BountyMilestoneInput,
-    BountyMilestoneStatus, EscrowStatus,
+    BountyMilestoneStatus, EscrowErrorExt3, EscrowStatus,
 };
 use soroban_sdk::{testutils::Address as _, token, vec, Address, BytesN, Env, Vec};
 
@@ -155,25 +155,25 @@ fn test_sequential_verification_releases_tranches_then_settles() {
 }
 
 #[test]
-#[should_panic(expected = "Previous milestone not yet verified")]
 fn test_out_of_order_submission_is_rejected() {
     let hx = setup();
     let id = create_two_milestone_bounty(&hx);
     hx.client.claim_bounty(&hx.solver, &id);
 
     // Attempt to submit milestone 1 before milestone 0 is verified.
-    hx.client.submit_bounty_milestone(&hx.solver, &id, &1, &h(&hx.env, 12));
+    let __typed_err_result = hx.client.try_submit_bounty_milestone(&hx.solver, &id, &1, &h(&hx.env, 12));
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::PreviousMilestoneNotYetVerified.into());
 }
 
 #[test]
-#[should_panic(expected = "Milestone is not awaiting verification")]
 fn test_verify_before_submit_is_rejected() {
     let hx = setup();
     let id = create_two_milestone_bounty(&hx);
     hx.client.claim_bounty(&hx.solver, &id);
 
     // Milestone 0 has not been submitted yet.
-    hx.client.verify_bounty_milestone(&id, &0);
+    let __typed_err_result = hx.client.try_verify_bounty_milestone(&id, &0);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::MilestoneIsNotAwaitingVerification.into());
 }
 
 #[test]
@@ -203,7 +203,6 @@ fn test_replace_verifier_before_submission_then_flow_works() {
 }
 
 #[test]
-#[should_panic(expected = "Verifier can only be replaced before the milestone is submitted")]
 fn test_replace_verifier_after_submission_is_rejected() {
     let hx = setup();
     let id = create_two_milestone_bounty(&hx);
@@ -212,12 +211,12 @@ fn test_replace_verifier_after_submission_is_rejected() {
 
     let new_verifier = Address::generate(&hx.env);
     // Too late — milestone 0 is already Submitted.
-    hx.client
-        .replace_bounty_verifier(&hx.buyer, &id, &0, &new_verifier);
+    let __typed_err_result = hx.client
+        .try_replace_bounty_verifier(&hx.buyer, &id, &0, &new_verifier);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::VerifierCanOnlyBeReplacedBeforeMilestoneIsSubmitted.into());
 }
 
 #[test]
-#[should_panic(expected = "Only the bounty creator can replace a verifier")]
 fn test_non_buyer_cannot_replace_verifier() {
     let hx = setup();
     let id = create_two_milestone_bounty(&hx);
@@ -226,12 +225,12 @@ fn test_non_buyer_cannot_replace_verifier() {
     let unauthorized = Address::generate(&hx.env);
     
     // Unauthorized address tries to replace verifier
-    hx.client
-        .replace_bounty_verifier(&unauthorized, &id, &0, &new_verifier);
+    let __typed_err_result = hx.client
+        .try_replace_bounty_verifier(&unauthorized, &id, &0, &new_verifier);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::OnlyBountyCreatorCanReplaceVerifier.into());
 }
 
 #[test]
-#[should_panic(expected = "Only the solver can submit milestones")]
 fn test_non_solver_cannot_submit_milestone() {
     let hx = setup();
     let id = create_two_milestone_bounty(&hx);
@@ -240,17 +239,18 @@ fn test_non_solver_cannot_submit_milestone() {
     let unauthorized = Address::generate(&hx.env);
     
     // Unauthorized address tries to submit milestone
-    hx.client.submit_bounty_milestone(&unauthorized, &id, &0, &h(&hx.env, 11));
+    let __typed_err_result = hx.client.try_submit_bounty_milestone(&unauthorized, &id, &0, &h(&hx.env, 11));
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::OnlySolverCanSubmitMilestones.into());
 }
 
 #[test]
-#[should_panic(expected = "Bounty must be claimed before submitting milestones")]
 fn test_submit_milestone_before_claim_is_rejected() {
     let hx = setup();
     let id = create_two_milestone_bounty(&hx);
 
     // Try to submit milestone without claiming the bounty first
-    hx.client.submit_bounty_milestone(&hx.solver, &id, &0, &h(&hx.env, 11));
+    let __typed_err_result = hx.client.try_submit_bounty_milestone(&hx.solver, &id, &0, &h(&hx.env, 11));
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::BountyMustBeClaimedBeforeSubmittingMilestones.into());
 }
 
 #[test]
@@ -338,23 +338,23 @@ fn test_all_milestones_can_be_verified_independently_by_different_verifiers() {
 
 /// #419: Out-of-order submission must be rejected before any prior milestone is verified.
 #[test]
-#[should_panic(expected = "Previous milestone not yet verified")]
 fn test_out_of_order_submission_rejected() {
     let hx = setup();
     let id = create_two_milestone_bounty(&hx);
     hx.client.claim_bounty(&hx.solver, &id);
 
     // Milestone 0 is Pending (not yet verified). Submitting milestone 1 must fail.
-    hx.client.submit_bounty_milestone(&hx.solver, &id, &1, &h(&hx.env, 12));
+    let __typed_err_result = hx.client.try_submit_bounty_milestone(&hx.solver, &id, &1, &h(&hx.env, 12));
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::PreviousMilestoneNotYetVerified.into());
 }
 
 #[test]
-#[should_panic(expected = "Milestone index out of bounds")]
 fn test_submit_invalid_milestone_index() {
     let hx = setup();
     let id = create_two_milestone_bounty(&hx);
     hx.client.claim_bounty(&hx.solver, &id);
 
     // Try to submit milestone with index 2 (only 0 and 1 exist)
-    hx.client.submit_bounty_milestone(&hx.solver, &id, &2, &h(&hx.env, 13));
+    let __typed_err_result = hx.client.try_submit_bounty_milestone(&hx.solver, &id, &2, &h(&hx.env, 13));
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt3::MilestoneIndexOutBounds.into());
 }

--- a/contracts/ahjoor-escrow/src/test_cooling_off.rs
+++ b/contracts/ahjoor-escrow/src/test_cooling_off.rs
@@ -103,7 +103,6 @@ fn test_flagged_then_reviewed() {
 // Test: flag after window expires is rejected
 // ---------------------------------------------------------------------------
 #[test]
-#[should_panic(expected = "Cooling-off window has expired")]
 fn test_flag_after_window_expired() {
     let (env, client, admin, buyer, _seller, arbiter, _token_addr, _token_client, _) = setup_cooling_off();
     let escrow_id = 0u32;
@@ -116,14 +115,14 @@ fn test_flag_after_window_expired() {
     env.ledger().with_mut(|l| l.timestamp += cooling_off + 1);
 
     // Attempt to flag after window — should panic
-    client.flag_resolution_error(&buyer, &escrow_id, &make_reason_hash(&env));
+    let __typed_err_result = client.try_flag_resolution_error(&buyer, &escrow_id, &make_reason_hash(&env));
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::CoolingOffWindowHasExpired.into());
 }
 
 // ---------------------------------------------------------------------------
 // Test: finalize before window expires is rejected
 // ---------------------------------------------------------------------------
 #[test]
-#[should_panic(expected = "Cooling-off window has not elapsed")]
 fn test_finalize_before_window_elapsed() {
     let (env, client, admin, _buyer, _seller, arbiter, _token_addr, _token_client, _) = setup_cooling_off();
     let escrow_id = 0u32;
@@ -133,7 +132,8 @@ fn test_finalize_before_window_elapsed() {
     client.resolve_dispute(&arbiter, &escrow_id, &50u32);
 
     // Try to finalize immediately — should panic
-    client.finalize_resolution(&escrow_id);
+    let __typed_err_result = client.try_finalize_resolution(&escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::CoolingOffWindowHasNotElapsed.into());
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/ahjoor-escrow/src/test_dispute_timeout.rs
+++ b/contracts/ahjoor-escrow/src/test_dispute_timeout.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{AhjoorEscrowContract, AhjoorEscrowContractClient, DisputeDefaultWinner};
+use crate::{AhjoorEscrowContract, AhjoorEscrowContractClient, DisputeDefaultWinner, EscrowErrorExt};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::Client as TokenClient,
@@ -165,7 +165,6 @@ fn test_enforce_dispute_timeout_seller_default() {
 }
 
 #[test]
-#[should_panic(expected = "Dispute timeout deadline has not passed yet")]
 fn test_enforce_timeout_before_deadline() {
     let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
 
@@ -190,12 +189,11 @@ fn test_enforce_timeout_before_deadline() {
     env.ledger().with_mut(|li| {
         li.timestamp += 3 * 24 * 60 * 60; // 3 days
     });
-
-    client.enforce_dispute_timeout(&escrow_id);
+    let __typed_err_result = client.try_enforce_dispute_timeout(&escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::DisputeTimeoutDeadlineHasNotPassedYet.into());
 }
 
 #[test]
-#[should_panic(expected = "Escrow is not disputed")]
 fn test_enforce_timeout_on_non_disputed_escrow() {
     let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
 
@@ -214,11 +212,11 @@ fn test_enforce_timeout_on_non_disputed_escrow() {
     );
 
     // Try to enforce timeout without dispute
-    client.enforce_dispute_timeout(&escrow_id);
+    let __typed_err_result = client.try_enforce_dispute_timeout(&escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::EscrowIsNotDisputed.into());
 }
 
 #[test]
-#[should_panic(expected = "Dispute already resolved")]
 fn test_enforce_timeout_on_resolved_dispute() {
     let (env, _admin, buyer, seller, arbiter, token, client) = setup_test_env();
 
@@ -246,7 +244,8 @@ fn test_enforce_timeout_on_resolved_dispute() {
     });
 
     // Try to enforce timeout on already resolved dispute
-    client.enforce_dispute_timeout(&escrow_id);
+    let __typed_err_result = client.try_enforce_dispute_timeout(&escrow_id);
+    assert_eq!(__typed_err_result.unwrap_err().unwrap(), EscrowErrorExt::DisputeAlreadyResolved.into());
 }
 
 #[test]

--- a/contracts/ahjoor-escrow/src/test_inspector.rs
+++ b/contracts/ahjoor-escrow/src/test_inspector.rs
@@ -371,13 +371,13 @@ fn test_inspector_replacement_requires_both_parties() {
     client.replace_inspector(&buyer, &escrow_id, &new_inspector);
     
     let escrow = client.get_escrow(&escrow_id);
-    assert_eq!(escrow.inspector, Some(old_inspector.clone()));
+    assert_eq!(escrow.extensions.inspector, Some(old_inspector.clone()));
 
     // Now seller also approves - inspector should change
     client.replace_inspector(&seller, &escrow_id, &new_inspector);
-    
+
     let escrow = client.get_escrow(&escrow_id);
-    assert_eq!(escrow.inspector, Some(new_inspector));
+    assert_eq!(escrow.extensions.inspector, Some(new_inspector));
 }
 
 #[test]

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -169,7 +169,7 @@ savings-goal tracking feature of the ROSCA contract.
 
 ## ahjoor-escrow
 
-### `EscrowError` (codes 1-3)
+### `EscrowError` (codes 1-50)
 
 Defined in `contracts/ahjoor-escrow/src/lib.rs`.
 
@@ -178,6 +178,283 @@ Defined in `contracts/ahjoor-escrow/src/lib.rs`.
 | 1 | InvalidDeadline | ahjoor-escrow | The supplied deadline is invalid (e.g. in the past or out of range). |
 | 2 | InvalidTrancheIndex | ahjoor-escrow | Tranche index is out of range for the escrow. |
 | 3 | TrancheAlreadyClaimed | ahjoor-escrow | Tranche has already been claimed by the beneficiary. |
+| 4 | AlreadyInitialized | ahjoor-escrow | Already initialized. |
+| 5 | AtLeastOneBuyerIsRequired | ahjoor-escrow | At least one buyer is required. |
+| 6 | DeadlineMustBeFuture | ahjoor-escrow | Deadline must be in the future. |
+| 7 | BuyerContributionMustBePositive | ahjoor-escrow | Buyer contribution must be positive. |
+| 8 | DuplicateBuyerInList | ahjoor-escrow | Duplicate buyer in buyer list. |
+| 9 | BatchMustContainAtLeastOneEscrowConfig | ahjoor-escrow | Batch must contain at least one escrow config. |
+| 10 | BatchSizeExceedsMaximum10Escrows | ahjoor-escrow | Batch size exceeds maximum of 10 escrows. |
+| 11 | OnlySellerCanMarkComplete | ahjoor-escrow | Only seller can mark complete. |
+| 12 | EscrowIsNotActive | ahjoor-escrow | Escrow is not active. |
+| 13 | NoInspectorSetUseReleaseEscrowDirectly | ahjoor-escrow | No inspector set; use release_escrow directly. |
+| 14 | EscrowIsNotAwaitingInspection | ahjoor-escrow | Escrow is not awaiting inspection. |
+| 15 | OnlyAssignedInspectorCanSubmitReport | ahjoor-escrow | Only the assigned inspector can submit a report. |
+| 16 | OnlyBuyerOrSellerCanProposeInspectorReplacement | ahjoor-escrow | Only buyer or seller can propose inspector replacement. |
+| 17 | NoInspectorSetEscrow | ahjoor-escrow | No inspector set on this escrow. |
+| 18 | OnlyAdminCanSetInspectorScoreThreshold | ahjoor-escrow | Only admin can set inspector score threshold. |
+| 19 | MinScoreBpsExceedsMaximum | ahjoor-escrow | Min_score_bps must be <= 10000. |
+| 20 | OnlyAdminCanAppealInspectorRuling | ahjoor-escrow | Only admin can appeal inspector ruling. |
+| 21 | InspectorRulingAlreadyAppealedEscrow | ahjoor-escrow | Inspector ruling already appealed for this escrow. |
+| 22 | InspectorScoreBelowMinimumThresholdHighValueEscrow | ahjoor-escrow | Inspector score below minimum threshold for high-value escrow. |
+| 23 | EscrowAmountMustBePositive | ahjoor-escrow | Escrow amount must be positive. |
+| 24 | DeadlineMustBeAfterMinLockUntil | ahjoor-escrow | Deadline must be after min_lock_until. |
+| 25 | ArbiterFeeExceedsMaximum1000Bps | ahjoor-escrow | Arbiter fee exceeds maximum of 1000 bps. |
+| 26 | IncompleteReleaseCondition | ahjoor-escrow | Incomplete release condition. |
+| 27 | ReleaseConditionThresholdMustBePositive | ahjoor-escrow | Release condition threshold must be positive. |
+| 28 | InvalidReleaseComparison | ahjoor-escrow | Invalid release comparison. |
+| 29 | Maximum5SellersAllowed | ahjoor-escrow | Maximum 5 sellers allowed. |
+| 30 | SellerAllocationsMustSumTo10000Bps | ahjoor-escrow | Seller allocations must sum to 10000 bps. |
+| 31 | DisputeTimeoutSecondsMustBePositive | ahjoor-escrow | Dispute_timeout_seconds must be positive. |
+| 32 | OnlyCurrentHolderCanTransferReceipt | ahjoor-escrow | Only current holder can transfer receipt. |
+| 33 | ActiveMilestoneInProgress | ahjoor-escrow | Active milestone in progress. |
+| 34 | InspectionPending | ahjoor-escrow | InspectionPending: inspector must submit report before release. |
+| 35 | OnlyListedBuyerCanApproveMultiBuyerRelease | ahjoor-escrow | Only a listed buyer can approve multi-buyer release. |
+| 36 | BuyerHasAlreadyApprovedRelease | ahjoor-escrow | Buyer has already approved release. |
+| 37 | OnlyBuyerOrArbiterCanReleaseEscrow | ahjoor-escrow | Only buyer or arbiter can release escrow. |
+| 38 | SellerVetoActive | ahjoor-escrow | SellerVetoActive: admin must override_seller_veto before release. |
+| 39 | SellerVetoActive2 | ahjoor-escrow | SellerVetoActive: seller has blocked fund release. |
+| 40 | ConditionNotMet | ahjoor-escrow | Condition not met. |
+| 41 | OnlyBuyerOrSellerCanWaiveCondition | ahjoor-escrow | Only buyer or seller can waive condition. |
+| 42 | NoConditionalReleaseSetEscrow | ahjoor-escrow | No conditional release set for this escrow. |
+| 43 | OnlyBuyerOrSellerCanSubmitEvidence | ahjoor-escrow | Only buyer or seller can submit evidence. |
+| 44 | MaximumEvidenceEntriesReachedParty | ahjoor-escrow | Maximum evidence entries reached for this party. |
+| 45 | OnlyBuyerCanSetRenewalAllowance | ahjoor-escrow | Only buyer can set renewal allowance. |
+| 46 | AutoRenewIsNotEnabledEscrow | ahjoor-escrow | Auto-renew is not enabled for this escrow. |
+| 47 | OnlyBuyerCanCancelAutoRenew | ahjoor-escrow | Only buyer can cancel auto-renew. |
+| 48 | OnlyBuyerCanCancelAutoRenewal | ahjoor-escrow | Only buyer can cancel auto-renewal. |
+| 49 | NoAutoRenewConfigSetEscrow | ahjoor-escrow | No AutoRenewConfig set on this escrow. |
+| 50 | ReleaseAmountMustBePositive | ahjoor-escrow | Release amount must be positive. |
+
+### `EscrowErrorExt` (codes 1-50)
+
+Defined in `contracts/ahjoor-escrow/src/lib.rs`. Split from `EscrowError` because
+`#[contracterror]` is bounded by the Soroban XDR 50-case limit.
+
+| Code | Name | Contract | Description |
+| ---- | ---- | -------- | ----------- |
+| 1 | ReleaseAmountExceedsEscrowBalance | ahjoor-escrow | Release amount exceeds escrow balance. |
+| 2 | AtLeastOneMilestoneRequired | ahjoor-escrow | At least one milestone required. |
+| 3 | TooManyMilestones | ahjoor-escrow | Too many milestones. |
+| 4 | MilestoneAmountMustBePositive | ahjoor-escrow | Milestone amount must be positive. |
+| 5 | NewMilestonesMustStartAsPending | ahjoor-escrow | New milestones must start as Pending. |
+| 6 | EscrowAlreadyTerminal | ahjoor-escrow | Escrow already terminal. |
+| 7 | OnlyBuyerOrArbiterCanApproveMilestones | ahjoor-escrow | Only buyer or arbiter can approve milestones. |
+| 8 | MilestoneIndexOutRange | ahjoor-escrow | Milestone index out of range. |
+| 9 | MilestoneNotPending | ahjoor-escrow | Milestone not pending. |
+| 10 | OnlyBuyerOrSellerCanDisputeEscrow | ahjoor-escrow | Only buyer or seller can dispute escrow. |
+| 11 | DisputeAmountOutOfRange | ahjoor-escrow | Dispute_amount must be > 0 and <= escrow amount. |
+| 12 | BuyerPercentMustBeBetween0And100 | ahjoor-escrow | Buyer_percent must be between 0 and 100. |
+| 13 | EscrowIsNotDisputed | ahjoor-escrow | Escrow is not disputed. |
+| 14 | OnlyArbiterCanResolveDispute | ahjoor-escrow | Only arbiter can resolve dispute. |
+| 15 | EscrowIsNotCoolingOffState | ahjoor-escrow | Escrow is not in cooling-off state. |
+| 16 | OnlyBuyerOrSellerCanFlagResolutionError | ahjoor-escrow | Only buyer or seller can flag a resolution error. |
+| 17 | CoolingOffWindowHasExpired | ahjoor-escrow | Cooling-off window has expired. |
+| 18 | ResolutionAlreadyFlagged | ahjoor-escrow | Resolution already flagged. |
+| 19 | CoolingOffWindowHasNotElapsed | ahjoor-escrow | Cooling-off window has not elapsed. |
+| 20 | ResolutionIsFlaggedAdminMustReviewBeforeFinalization | ahjoor-escrow | Resolution is flagged; admin must review before finalization. |
+| 21 | OnlyAdminCanClearResolutionFlags | ahjoor-escrow | Only admin can clear resolution flags. |
+| 22 | NoFlagToClear | ahjoor-escrow | No flag to clear. |
+| 23 | OnlyAdminCanConfigureCoolingOffPeriod | ahjoor-escrow | Only admin can configure cooling-off period. |
+| 24 | FeeConfigurationExceedsEscrowAmount | ahjoor-escrow | Fee configuration exceeds escrow amount. |
+| 25 | TimeoutMustBePositive | ahjoor-escrow | Timeout must be positive. |
+| 26 | MultiplierMustBePositive | ahjoor-escrow | Multiplier must be positive. |
+| 27 | DeadlineMustBePositive | ahjoor-escrow | Deadline must be positive. |
+| 28 | DisputeAlreadyResolved | ahjoor-escrow | Dispute already resolved. |
+| 29 | DisputeTimeoutDeadlineHasNotPassedYet | ahjoor-escrow | Dispute timeout deadline has not passed yet. |
+| 30 | MaxOracleAgeMustBePositive | ahjoor-escrow | Max_oracle_age must be positive. |
+| 31 | InsuranceTriggerDaysMustBePositive | ahjoor-escrow | Insurance_trigger_days must be positive. |
+| 32 | InsuranceContributionMustBePositive | ahjoor-escrow | Insurance contribution must be positive. |
+| 33 | OnlyBuyerOrSellerCanClaimInsurance | ahjoor-escrow | Only buyer or seller can claim insurance. |
+| 34 | InsuranceAlreadyClaimed | ahjoor-escrow | Insurance already claimed. |
+| 35 | AdminConfirmationRequired | ahjoor-escrow | Admin confirmation required. |
+| 36 | InsuranceTriggerPeriodNotReached | ahjoor-escrow | Insurance trigger period not reached. |
+| 37 | EscrowTokenNotCoveredByInsurancePool | ahjoor-escrow | Escrow token not covered by insurance pool. |
+| 38 | InsurancePoolHasInsufficientBalance | ahjoor-escrow | Insurance pool has insufficient balance. |
+| 39 | FeeExceedsMaximum200Bps | ahjoor-escrow | Fee exceeds maximum of 200 bps. |
+| 40 | WithdrawalAmountMustBePositive | ahjoor-escrow | Withdrawal amount must be positive. |
+| 41 | InsufficientAccruedFees | ahjoor-escrow | Insufficient accrued fees. |
+| 42 | ReleaseConditionNotMet | ahjoor-escrow | Release condition not met. |
+| 43 | EscrowHasNotExpiredYet | ahjoor-escrow | Escrow has not expired yet. |
+| 44 | OnlyBuyerOrSellerCanProposeDeadlineExtension | ahjoor-escrow | Only buyer or seller can propose deadline extension. |
+| 45 | CannotExtendDeadlineWhileEscrowIsDisputed | ahjoor-escrow | Cannot extend deadline while escrow is disputed. |
+| 46 | NewDeadlineMustBeGreaterThanCurrentDeadline | ahjoor-escrow | New deadline must be greater than current deadline. |
+| 47 | OnlyBuyerOrSellerCanAcceptDeadlineExtension | ahjoor-escrow | Only buyer or seller can accept deadline extension. |
+| 48 | ProposerCannotAcceptTheirOwnDeadlineExtension | ahjoor-escrow | Proposer cannot accept their own deadline extension. |
+| 49 | DeadlineExtensionProposalHasExpired | ahjoor-escrow | Deadline extension proposal has expired. |
+| 50 | OnlyBuyerOrSellerCanProposeAmendment | ahjoor-escrow | Only buyer or seller can propose amendment. |
+
+### `EscrowErrorExt2` (codes 1-50)
+
+Defined in `contracts/ahjoor-escrow/src/lib.rs`. Split from `EscrowError` because
+`#[contracterror]` is bounded by the Soroban XDR 50-case limit.
+
+| Code | Name | Contract | Description |
+| ---- | ---- | -------- | ----------- |
+| 1 | CannotAmendTerminalEscrow | ahjoor-escrow | Cannot amend terminal escrow. |
+| 2 | NewAmountMustBePositive | ahjoor-escrow | New amount must be positive. |
+| 3 | OnlyBuyerOrSellerCanSignAmendment | ahjoor-escrow | Only buyer or seller can sign amendment. |
+| 4 | AmendmentNonceMismatch | ahjoor-escrow | Amendment nonce mismatch. |
+| 5 | AmendmentProposalHasExpired | ahjoor-escrow | Amendment proposal has expired. |
+| 6 | AmendmentRequiresBuyerAndSellerSignatures | ahjoor-escrow | Amendment requires buyer and seller signatures. |
+| 7 | OnlyBuyerCanTopUpEscrow | ahjoor-escrow | Only buyer can top up escrow. |
+| 8 | EscrowIsNotActiveOrAwaitingInspection | ahjoor-escrow | Escrow is not active or awaiting inspection. |
+| 9 | AdditionalAmountMustBePositive | ahjoor-escrow | Additional amount must be positive. |
+| 10 | TopUpLimitExceeded | ahjoor-escrow | Top-up limit exceeded. |
+| 11 | OnlySellerCanAcknowledgeTopUp | ahjoor-escrow | Only seller can acknowledge top-up. |
+| 12 | OnlySellerCanRequestPartialRelease | ahjoor-escrow | Only seller can request partial release. |
+| 13 | PartialReleaseOnlyAllowedActiveEscrow | ahjoor-escrow | Partial release only allowed on active escrow. |
+| 14 | PartialReleaseAmountMustBePositive | ahjoor-escrow | Partial release amount must be positive. |
+| 15 | PartialReleaseAmountCannotExceedEscrowAmount | ahjoor-escrow | Partial release amount cannot exceed escrow amount. |
+| 16 | RequestAlreadyPending | ahjoor-escrow | Request already pending. |
+| 17 | OnlyBuyerCanApprovePartialRelease | ahjoor-escrow | Only buyer can approve partial release. |
+| 18 | InvalidRequestID | ahjoor-escrow | Invalid request ID. |
+| 19 | DelegateMustBeDifferentFromSeller | ahjoor-escrow | Delegate must be different from seller. |
+| 20 | SellerNotPartOfEscrow | ahjoor-escrow | Seller is not part of this escrow. |
+| 21 | CanOnlyDelegateBeforeEscrowIsReleased | ahjoor-escrow | Can only delegate before escrow is released. |
+| 22 | OnlyBuyerCanRejectPartialRelease | ahjoor-escrow | Only buyer can reject partial release. |
+| 23 | OnlySellerCanEscalatePartialRelease | ahjoor-escrow | Only seller can escalate partial release. |
+| 24 | ResponseDeadlineNotYetPassed | ahjoor-escrow | Response deadline not yet passed. |
+| 25 | NewBuyerMustBeDifferentFromCurrentBuyer | ahjoor-escrow | New buyer must be different from current buyer. |
+| 26 | BuyerTransferOnlyAllowedActiveEscrows | ahjoor-escrow | Buyer transfer only allowed for active escrows. |
+| 27 | OnlyCurrentBuyerCanTransferBuyerRole | ahjoor-escrow | Only current buyer can transfer buyer role. |
+| 28 | OnlyBuyerOrSellerCanUpdateMetadata | ahjoor-escrow | Only buyer or seller can update metadata. |
+| 29 | OnlyAdminCanUpgradeContract | ahjoor-escrow | Only admin can upgrade contract. |
+| 30 | OnlyAdminCanMigrateContract | ahjoor-escrow | Only admin can migrate contract. |
+| 31 | MigrationAlreadyCompletedVersion | ahjoor-escrow | Migration already completed for this version. |
+| 32 | UnlockAtMustBeFuture | ahjoor-escrow | Unlock_at must be in the future. |
+| 33 | AlreadyClaimed | ahjoor-escrow | Already claimed. |
+| 34 | OnlyBeneficiaryCanClaim | ahjoor-escrow | Only beneficiary can claim. |
+| 35 | UnlockTimeHasNotPassed | ahjoor-escrow | Unlock time has not passed. |
+| 36 | EscrowNotActive | ahjoor-escrow | Escrow not active. |
+| 37 | PastUnlockTimeUseClaimTimelocked | ahjoor-escrow | Past unlock time; use claim_timelocked. |
+| 38 | OnlyBuyerCanCancel | ahjoor-escrow | Only buyer can cancel. |
+| 39 | DisputeActive | ahjoor-escrow | Dispute active. |
+| 40 | OnlyAdminCanSetTokenWhitelistContract | ahjoor-escrow | Only admin can set token whitelist contract. |
+| 41 | ContractAlreadyPaused | ahjoor-escrow | Contract already paused. |
+| 42 | ContractIsNotPaused | ahjoor-escrow | Contract is not paused. |
+| 43 | TokenNotAllowed | ahjoor-escrow | Token not allowed. |
+| 44 | DeadlineDurationMustBePositive | ahjoor-escrow | Deadline_duration must be positive. |
+| 45 | TemplateIsDeactivated | ahjoor-escrow | Template is deactivated. |
+| 46 | ArbiterAlreadyPool | ahjoor-escrow | Arbiter already in pool. |
+| 47 | ArbiterNotPool | ahjoor-escrow | Arbiter not in pool. |
+| 48 | ArbiterPoolIsEmpty | ahjoor-escrow | Arbiter pool is empty. |
+| 49 | OnlyTemplateCreatorCanUpdate | ahjoor-escrow | Only template creator can update. |
+| 50 | OnlyTemplateCreatorCanDeactivate | ahjoor-escrow | Only template creator can deactivate. |
+
+### `EscrowErrorExt3` (codes 1-50)
+
+Defined in `contracts/ahjoor-escrow/src/lib.rs`. Split from `EscrowError` because
+`#[contracterror]` is bounded by the Soroban XDR 50-case limit.
+
+| Code | Name | Contract | Description |
+| ---- | ---- | -------- | ----------- |
+| 1 | TemplateAlreadyDeactivated | ahjoor-escrow | Template already deactivated. |
+| 2 | InactivityReleaseIsNotEnabledEscrow | ahjoor-escrow | Inactivity release is not enabled for this escrow. |
+| 3 | OnlyEscrowSellerCanClaimInactivityRelease | ahjoor-escrow | Only the escrow seller can claim inactivity release. |
+| 4 | BuyerInactivityWindowHasNotElapsed | ahjoor-escrow | Buyer inactivity window has not elapsed. |
+| 5 | PenaltyCannotExceed10000Bps | ahjoor-escrow | Penalty cannot exceed 10000 bps. |
+| 6 | ResponseWindowMustBePositive | ahjoor-escrow | Response window must be positive. |
+| 7 | OnlyBuyerOrSellerCanRequestCancellation | ahjoor-escrow | Only buyer or seller can request cancellation. |
+| 8 | NoPendingCancellationEscrow | ahjoor-escrow | No pending cancellation for this escrow. |
+| 9 | InitiatorCannotAcceptTheirOwnCancellationRequest | ahjoor-escrow | Initiator cannot accept their own cancellation request. |
+| 10 | OnlyBuyerOrSellerCanAcceptCancellation | ahjoor-escrow | Only buyer or seller can accept cancellation. |
+| 11 | InitiatorCannotRejectTheirOwnCancellationRequest | ahjoor-escrow | Initiator cannot reject their own cancellation request. |
+| 12 | OnlyBuyerOrSellerCanRejectCancellation | ahjoor-escrow | Only buyer or seller can reject cancellation. |
+| 13 | ResponseWindowHasNotElapsed | ahjoor-escrow | Response window has not elapsed. |
+| 14 | BountyAmountMustBePositive | ahjoor-escrow | Bounty amount must be positive. |
+| 15 | ClaimDeadlineMustBeFuture | ahjoor-escrow | Claim deadline must be in the future. |
+| 16 | SubmissionDeadlineMustBeAfterClaimDeadline | ahjoor-escrow | Submission deadline must be after claim deadline. |
+| 17 | TokenNotWhitelisted | ahjoor-escrow | Token not whitelisted. |
+| 18 | BountyIsNotAvailableClaiming | ahjoor-escrow | Bounty is not available for claiming. |
+| 19 | ClaimDeadlineHasPassed | ahjoor-escrow | Claim deadline has passed. |
+| 20 | BountyIsNotClaimedStatus | ahjoor-escrow | Bounty is not in claimed status. |
+| 21 | OnlyAssignedSolverCanSubmitWork | ahjoor-escrow | Only the assigned solver can submit work. |
+| 22 | SubmissionDeadlineHasPassed | ahjoor-escrow | Submission deadline has passed. |
+| 23 | OnlyBuyerCanApproveSubmission | ahjoor-escrow | Only buyer can approve submission. |
+| 24 | NoSubmissionHasBeenMade | ahjoor-escrow | No submission has been made. |
+| 25 | OnlyBuyerCanRejectSubmission | ahjoor-escrow | Only buyer can reject submission. |
+| 26 | MaximumRejectionRoundsReached | ahjoor-escrow | Maximum rejection rounds reached. |
+| 27 | OnlyBuyerCanCancelBounty | ahjoor-escrow | Only buyer can cancel bounty. |
+| 28 | CannotCancelBountyCurrentState | ahjoor-escrow | Cannot cancel bounty in current state. |
+| 29 | OnlyAdminCanSetMaxBountyRejectionRounds | ahjoor-escrow | Only admin can set max bounty rejection rounds. |
+| 30 | BountyMustHaveAtLeastOneMilestone | ahjoor-escrow | Bounty must have at least one milestone. |
+| 31 | BountyMustBeClaimedBeforeSubmittingMilestones | ahjoor-escrow | Bounty must be claimed before submitting milestones. |
+| 32 | OnlySolverCanSubmitMilestones | ahjoor-escrow | Only the solver can submit milestones. |
+| 33 | MilestoneIndexOutBounds | ahjoor-escrow | Milestone index out of bounds. |
+| 34 | PreviousMilestoneNotYetVerified | ahjoor-escrow | Previous milestone not yet verified. |
+| 35 | MilestoneIsNotAwaitingSubmission | ahjoor-escrow | Milestone is not awaiting submission. |
+| 36 | MilestoneIsNotAwaitingVerification | ahjoor-escrow | Milestone is not awaiting verification. |
+| 37 | OnlyBountyCreatorCanReplaceVerifier | ahjoor-escrow | Only the bounty creator can replace a verifier. |
+| 38 | VerifierCanOnlyBeReplacedBeforeMilestoneIsSubmitted | ahjoor-escrow | Verifier can only be replaced before the milestone is submitted. |
+| 39 | OnlyBuyerCanConfigureCollateralHealth | ahjoor-escrow | Only buyer can configure collateral health. |
+| 40 | MinCollateralRatioBpsOutOfRange | ahjoor-escrow | Min_collateral_ratio_bps must be 1-10000. |
+| 41 | TopUpAmountMustBePositive | ahjoor-escrow | Top-up amount must be positive. |
+| 42 | EscrowIsNotActiveOrUnderCollateralized | ahjoor-escrow | Escrow is not active or under-collateralized. |
+| 43 | OnlyBuyerCanConfigureMultiPartyApproval | ahjoor-escrow | Only buyer can configure multi-party approval. |
+| 44 | ApproversCountMustBeBetween2And10 | ahjoor-escrow | Approvers count must be between 2 and 10. |
+| 45 | ThresholdMustBeBetween1AndApproversCount | ahjoor-escrow | Threshold must be between 1 and approvers count. |
+| 46 | CannotReconfigureApprovalsAlreadyProgress | ahjoor-escrow | Cannot reconfigure: approvals already in progress. |
+| 47 | CallerIsNotAuthorizedApproverEscrow | ahjoor-escrow | Caller is not an authorized approver for this escrow. |
+| 48 | ApproverHasAlreadyApprovedEscrow | ahjoor-escrow | Approver has already approved this escrow. |
+| 49 | ReleaseScheduleMustContainAtLeastOneTranche | ahjoor-escrow | Release schedule must contain at least one tranche. |
+| 50 | EachTrancheAmountMustBePositive | ahjoor-escrow | Each tranche amount must be positive. |
+
+### `EscrowErrorExt4` (codes 1-48)
+
+Defined in `contracts/ahjoor-escrow/src/lib.rs`. Split from `EscrowError` because
+`#[contracterror]` is bounded by the Soroban XDR 50-case limit.
+
+| Code | Name | Contract | Description |
+| ---- | ---- | -------- | ----------- |
+| 1 | EachTrancheUnlockAtMustBeFuture | ahjoor-escrow | Each tranche unlock_at must be in the future. |
+| 2 | OnlyBeneficiarySellerCanClaimScheduledReleases | ahjoor-escrow | Only the beneficiary (seller) can claim scheduled releases. |
+| 3 | EscrowIsNotClaimableState | ahjoor-escrow | Escrow is not in a claimable state. |
+| 4 | NoTranchesAreCurrentlyClaimable | ahjoor-escrow | No tranches are currently claimable. |
+| 5 | ContractIsPaused | ahjoor-escrow | Contract is paused. |
+| 6 | OnlyAdminCanPauseContract | ahjoor-escrow | Only admin can pause contract. |
+| 7 | OnlyAdminCanResumeContract | ahjoor-escrow | Only admin can resume contract. |
+| 8 | EscrowStillLocked | ahjoor-escrow | Escrow still locked. |
+| 9 | OraclePriceIsStale | ahjoor-escrow | Oracle price is stale. |
+| 10 | InvalidOraclePrice | ahjoor-escrow | Invalid oracle price. |
+| 11 | InsufficientRenewalAllowance | ahjoor-escrow | Insufficient renewal allowance. |
+| 12 | EscrowRenewalDurationMustBePositive | ahjoor-escrow | Escrow renewal duration must be positive. |
+| 13 | OnlyAdminCanSetMaxTopUpBps | ahjoor-escrow | Only admin can set max top-up bps. |
+| 14 | CollateralForfeitBpsCannotExceed10000 | ahjoor-escrow | Collateral_forfeit_bps cannot exceed 10000. |
+| 15 | AtLeastOneSellerRequired | ahjoor-escrow | At least one seller required. |
+| 16 | OnlySellerCanDepositCollateral | ahjoor-escrow | Only seller can deposit collateral. |
+| 17 | EscrowIsNotAwaitingCollateral | ahjoor-escrow | Escrow is not awaiting collateral. |
+| 18 | CollateralDepositWindowHasExpired | ahjoor-escrow | Collateral deposit window has expired. |
+| 19 | RatingMustBeBetween1And5 | ahjoor-escrow | Rating must be between 1 and 5. |
+| 20 | RatingOnlyAllowedAfterEscrowIsReleasedOrResolved | ahjoor-escrow | Rating only allowed after escrow is Released or Resolved. |
+| 21 | OnlyBuyerOrSellerCanSubmitRating | ahjoor-escrow | Only buyer or seller can submit a rating. |
+| 22 | RatingAlreadySubmittedEscrow | ahjoor-escrow | Rating already submitted for this escrow. |
+| 23 | OnlySellerCanSubmitDeliveryProof | ahjoor-escrow | Only seller can submit delivery proof. |
+| 24 | ProofSubmissionLockedEscrowIsUnderDispute | ahjoor-escrow | Proof submission locked: escrow is under dispute. |
+| 25 | InvalidDeliveryProof | ahjoor-escrow | Invalid delivery proof. |
+| 26 | OnlyEscrowSellerCanRaiseVeto | ahjoor-escrow | Only the escrow seller can raise a veto. |
+| 27 | VetoCooldownActive | ahjoor-escrow | VetoCooldownActive: seller must wait for cooldown before raising another veto. |
+| 28 | OnlyBuyerCanApprove | ahjoor-escrow | Only the buyer can approve. |
+| 29 | NoPendingSellerTransfer | ahjoor-escrow | No pending seller transfer. |
+| 30 | OnlyAdminCanSetVetoOverrideWindow | ahjoor-escrow | Only admin can set veto override window. |
+| 31 | WindowSecondsMustBePositive | ahjoor-escrow | Window_seconds must be positive. |
+| 32 | OnlyEscrowSellerCanCancelVeto | ahjoor-escrow | Only the escrow seller can cancel a veto. |
+| 33 | VetoWindowElapsed | ahjoor-escrow | VetoWindowElapsed: override window has passed; only admin can act now. |
+| 34 | OnlyAdminCanOverrideSellerVeto | ahjoor-escrow | Only admin can override a seller veto. |
+| 35 | ActiveDisputeExists | ahjoor-escrow | ActiveDisputeExists: resolve the dispute before overriding veto. |
+| 36 | VetoWindowNotElapsed | ahjoor-escrow | VetoWindowNotElapsed: override window has not yet passed. |
+| 37 | VetoWindowHasNotExpiredYet | ahjoor-escrow | Veto window has not expired yet. |
+| 38 | OnlyCurrentSellerCanInitiateTransfer | ahjoor-escrow | Only the current seller can initiate a transfer. |
+| 39 | EscrowMustBeActiveToTransferSellerRole | ahjoor-escrow | Escrow must be active to transfer seller role. |
+| 40 | OnlyBuyerCanVeto | ahjoor-escrow | Only the buyer can veto. |
+| 41 | OnlyAdminCanSetVetoWindow | ahjoor-escrow | Only admin can set the veto window. |
+| 42 | ReleaseBpsMustBePositiveEachMilestone | ahjoor-escrow | Release_bps must be positive for each milestone. |
+| 43 | MilestoneReleaseBpsMustSumTo10000 | ahjoor-escrow | Milestone release_bps must sum to 10 000. |
+| 44 | OnlyEscrowSellerMaySubmitMilestones | ahjoor-escrow | Only the escrow seller may submit milestones. |
+| 45 | MilestoneMustBePendingOrRejectedToSubmit | ahjoor-escrow | Milestone must be Pending or Rejected to submit. |
+| 46 | MilestoneMustBeSubmittedBeforeApproval | ahjoor-escrow | Milestone must be Submitted before approval. |
+| 47 | OnlyEscrowBuyerMayRejectMilestones | ahjoor-escrow | Only the escrow buyer may reject milestones. |
+| 48 | OnlySubmittedMilestoneCanBeRejected | ahjoor-escrow | Only a Submitted milestone can be rejected. |
 
 ---
 


### PR DESCRIPTION
Closes #552

## Summary
- `ahjoor-escrow` used plain `panic!("...")` string messages instead of a `#[contracterror]` enum, unlike `ahjoor-rosca`, `ahjoor-payments`, and `ahjoor-token-whitelist`. This meant off-chain code had no way to decode most escrow failures by code.
- Extended the existing 3-variant `EscrowError` enum to 50 variants and added four more 50-variant overflow enums (`EscrowErrorExt`..`EscrowErrorExt4`, mirroring the pattern already used by `ahjoor-rosca`/`ahjoor-payments` for Soroban's `#[contracterror]` 50-case limit), covering all 245 distinct failure conditions that were previously bare `panic!()` strings.
- Every one of the 313 `panic!()` call sites in `ahjoor-escrow/src/lib.rs` now panics via `panic_with_error!(&env, ...)` instead.
- Populated `ahjoor-errors::escrow` with the matching 248 namespaced codes (3001–3248, within the contract's allocated 3000–3299 range) and bumped `COUNT`; `ALL_ERRORS` stays in sync (enforced by that crate's own tests).
- Updated escrow tests that previously asserted on `#[should_panic(expected = "...")]` strings to call the `try_*` client method and assert on the typed `Error` variant instead.
- Regenerated the `ahjoor-escrow` section of `docs/errors.md`.

`.expect("...")` panics on storage lookups (e.g. `"Escrow not found"`) are left as-is — this matches the existing convention in `ahjoor-rosca` and `ahjoor-payments`, which still use `.expect()` for storage gets even after their own typed-error migrations.

## Acceptance criteria
- [x] `ahjoor-escrow` exposes a typed `Error` enum used by its public functions
- [x] `ahjoor-errors::escrow` module's code count matches the new enum's variant count
- [x] Existing escrow tests updated to assert on typed errors where they previously matched panic strings

## Test plan
- [x] `cargo test -p ahjoor-escrow` — 247/251 pass. The 4 failures (`test_inspector::*`) are pre-existing on `main`, unrelated to this change (verified via a clean worktree of `main`) — a stale field reference (`escrow.inspector` vs `escrow.extensions.inspector`) that predates this PR; fixed the one compile-blocking instance of it so the rest of the suite could run, left the two still-failing assertions in that file alone since they're out of scope for #552.
- [x] `cargo test -p ahjoor-errors` — all pass, including the code-count/no-duplicate/range checks against `ALL_ERRORS`.
- [x] `cargo test --workspace` — all other crates pass.
- [x] `cargo clippy -p ahjoor-escrow --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)