### PR TITLE
feat(rosca): add paginated get_round_history query

### DIFF
--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -5938,11 +5938,36 @@ impl AhjoorContract {
         (contributed, remaining)
     }
 
-    pub fn get_round_history(env: Env) -> Vec<PayoutRecord> {
-        env.storage()
+    /// Paginated round-by-round payout history for a group (#555).
+    ///
+    /// `group_id` is accepted for API/event-payload consistency with other
+    /// group-scoped functions (see `freeze_group`); this contract manages a
+    /// single group per instance, so it is not used to key storage.
+    ///
+    /// Returns the slice `[offset, offset + limit)` of `RoundHistory`. An
+    /// out-of-range `offset` (>= total number of rounds) returns an empty
+    /// vec rather than panicking.
+    pub fn get_round_history(
+        env: Env,
+        _group_id: u32,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<PayoutRecord> {
+        let history: Vec<PayoutRecord> = env
+            .storage()
             .persistent()
             .get(&PersistentKey::RoundHistory)
-            .unwrap_or(Vec::new(&env))
+            .unwrap_or(Vec::new(&env));
+
+        let total = history.len();
+        let start = offset.min(total);
+        let end = start.saturating_add(limit).min(total);
+
+        let mut page = Vec::new(&env);
+        for i in start..end {
+            page.push_back(history.get(i).unwrap());
+        }
+        page
     }
 
     pub fn get_state(env: Env) -> (u32, Vec<Address>, u64, PayoutStrategy, Address) {

--- a/contracts/ahjoor-rosca/src/test.rs
+++ b/contracts/ahjoor-rosca/src/test.rs
@@ -1149,7 +1149,7 @@ fn test_read_interface_lifecycle() {
     assert_eq!(info.members.len(), 2);
     assert_eq!(info.current_round, 0);
     assert_eq!(info.next_recipient, u1); // Round 0 recipient
-    assert_eq!(client.get_round_history().len(), 0);
+    assert_eq!(client.get_round_history(&0u32, &0u32, &100u32).len(), 0);
 
     // 2. STAGE: Mid-Round Contribution
     client.contribute(&u1, &token_admin, &100);
@@ -1167,7 +1167,7 @@ fn test_read_interface_lifecycle() {
     client.contribute(&u2, &token_admin, &100); // This triggers complete_round_payout
 
     // Verify History
-    let history = client.get_round_history();
+    let history = client.get_round_history(&0u32, &0u32, &100u32);
     assert_eq!(history.len(), 1);
     let record = history.get(0).unwrap();
     assert_eq!(record.recipient, u1);
@@ -4319,7 +4319,7 @@ fn test_round_history_persistent_ttl() {
         .set_sequence_number(setup.env.ledger().sequence() + 110_000);
 
     // RoundHistory must still be accessible (persistent storage, individual TTL)
-    let history = setup.client.get_round_history();
+    let history = setup.client.get_round_history(&0u32, &0u32, &100u32);
     assert_eq!(history.len(), 1);
     assert_eq!(history.get(0).unwrap().amount, 200);
 }
@@ -4345,8 +4345,86 @@ fn test_round_history_ttl_extended_each_round() {
         .ledger()
         .set_sequence_number(setup.env.ledger().sequence() + 110_000);
 
-    let history = setup.client.get_round_history();
+    let history = setup.client.get_round_history(&0u32, &0u32, &100u32);
     assert_eq!(history.len(), 2);
+}
+
+// ===========================================================================
+//  #555: get_round_history pagination
+// ===========================================================================
+
+/// get_round_history(group_id, offset, limit) returns the correct page of
+/// RoundHistory for a group with more rounds than fit on one page.
+#[test]
+fn test_get_round_history_pagination_returns_correct_slice() {
+    let setup = setup_with_members(2, 5_000);
+    default_init(&setup);
+
+    let u1 = setup.members.get(0).unwrap();
+    let u2 = setup.members.get(1).unwrap();
+
+    // Complete 5 rounds (round-robin: u1, u2, u1, u2, u1).
+    for _ in 0..5 {
+        setup.client.contribute(&u1, &setup.token_admin, &100);
+        setup.client.contribute(&u2, &setup.token_admin, &100);
+    }
+
+    let full = setup.client.get_round_history(&0u32, &0u32, &100u32);
+    assert_eq!(full.len(), 5);
+
+    // First page: 2 records, matching the start of the full history.
+    let page1 = setup.client.get_round_history(&0u32, &0u32, &2u32);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1.get(0).unwrap().recipient, full.get(0).unwrap().recipient);
+    assert_eq!(page1.get(1).unwrap().recipient, full.get(1).unwrap().recipient);
+
+    // Second page: next 2 records.
+    let page2 = setup.client.get_round_history(&0u32, &2u32, &2u32);
+    assert_eq!(page2.len(), 2);
+    assert_eq!(page2.get(0).unwrap().recipient, full.get(2).unwrap().recipient);
+    assert_eq!(page2.get(1).unwrap().recipient, full.get(3).unwrap().recipient);
+
+    // Final (partial) page: only 1 record remains.
+    let page3 = setup.client.get_round_history(&0u32, &4u32, &2u32);
+    assert_eq!(page3.len(), 1);
+    assert_eq!(page3.get(0).unwrap().recipient, full.get(4).unwrap().recipient);
+}
+
+/// An out-of-range offset returns an empty vec rather than panicking.
+#[test]
+fn test_get_round_history_out_of_range_offset_returns_empty() {
+    let setup = setup_with_members(2, 1_000);
+    default_init(&setup);
+
+    let u1 = setup.members.get(0).unwrap();
+    let u2 = setup.members.get(1).unwrap();
+
+    setup.client.contribute(&u1, &setup.token_admin, &100);
+    setup.client.contribute(&u2, &setup.token_admin, &100);
+
+    // Only 1 round exists; offset way past the end must not panic.
+    let page = setup.client.get_round_history(&0u32, &50u32, &10u32);
+    assert_eq!(page.len(), 0);
+
+    // Offset exactly at the total count is also "out of range".
+    let page_at_boundary = setup.client.get_round_history(&0u32, &1u32, &10u32);
+    assert_eq!(page_at_boundary.len(), 0);
+}
+
+/// A zero limit returns an empty vec regardless of a valid offset.
+#[test]
+fn test_get_round_history_zero_limit_returns_empty() {
+    let setup = setup_with_members(2, 1_000);
+    default_init(&setup);
+
+    let u1 = setup.members.get(0).unwrap();
+    let u2 = setup.members.get(1).unwrap();
+
+    setup.client.contribute(&u1, &setup.token_admin, &100);
+    setup.client.contribute(&u2, &setup.token_admin, &100);
+
+    let page = setup.client.get_round_history(&0u32, &0u32, &0u32);
+    assert_eq!(page.len(), 0);
 }
 
 /// ExitRequests in temporary storage: a request is stored, accessible, and

--- a/contracts/integration-tests/src/rosca_payout_flow.rs
+++ b/contracts/integration-tests/src/rosca_payout_flow.rs
@@ -161,7 +161,7 @@ fn test_rosca_round_completes_payout_on_full_contribution() {
     );
 
     // Round history should record exactly one payout for round 0.
-    let history = t.rosca.get_round_history();
+    let history = t.rosca.get_round_history(&0u32, &0u32, &100u32);
     assert_eq!(history.len(), 1);
     let record = history.get(0).unwrap();
     assert_eq!(record.recipient, expected_recipient);
@@ -199,7 +199,7 @@ fn test_rosca_finalize_round_flags_defaulter_and_pays_partial_pot() {
     // finalize_round pays out before applying new suspensions, so round
     // history should still show a completed payout for round 0 even though
     // contributions were partial.
-    let history = t.rosca.get_round_history();
+    let history = t.rosca.get_round_history(&0u32, &0u32, &100u32);
     assert_eq!(history.len(), 1);
 
     let (round_after, _, _, _, _) = t.rosca.get_state();


### PR DESCRIPTION
Closes #555

## Summary
There was no way to fetch a group's round-by-round `PayoutRecord`/`RoundHistory` in a paginated view; integrators had to reconstruct history from raw events.

`get_round_history` now takes `(group_id, offset, limit)` and returns the `[offset, offset + limit)` slice of the existing `RoundHistory` persistent storage appended in `internals::complete_round_payout`.

`group_id` is accepted for API/event-payload consistency with other group-scoped functions (see `freeze_group`) — this contract manages a single group per instance, so it isn't used to key storage.

Note: this changes `get_round_history`'s signature (previously no-arg, unbounded, unlimited growth risk for long-lived groups). Updated the existing `ahjoor-rosca` test callers and the `integration-tests` callers accordingly.

## Acceptance criteria
- [x] Returns the correct slice of round history for a given offset/limit
- [x] Out-of-range offset returns an empty vec, not an error
- [x] Test covering a group with more rounds than one page's limit

## Test plan
- [x] `test_get_round_history_pagination_returns_correct_slice` — 5 rounds, verifies page 1 (offset 0, limit 2), page 2 (offset 2, limit 2), and the final partial page (offset 4, limit 2 → 1 record)
- [x] `test_get_round_history_out_of_range_offset_returns_empty` — offset past the end, and offset exactly at the total count, both return an empty vec without panicking
- [x] `test_get_round_history_zero_limit_returns_empty`
- [x] `cargo test -p ahjoor-rosca -p integration-tests` — 243/243 and 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)