### PR TITLE
feat(rosca): add get_pending_penalties admin view function

### DIFF
--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -5945,6 +5945,57 @@ impl AhjoorContract {
             .unwrap_or(Vec::new(&env))
     }
 
+    /// Admin view of the current pending-penalty queue (#556).
+    ///
+    /// Penalties move through `request_penalty_grace` (deferred into the
+    /// queue when requested within the grace window) →
+    /// `process_pending_penalties` (applied once the grace period elapses
+    /// or the round advances) → `apply_penalty`. This surfaces which
+    /// members currently have an unprocessed pending penalty, without
+    /// mutating state or triggering processing.
+    ///
+    /// `group_id` is accepted for API consistency with other group-scoped
+    /// functions (see `freeze_group`); this contract manages a single group
+    /// per instance, so it is not used to key storage.
+    pub fn get_pending_penalties(env: Env, _group_id: u32) -> Vec<(Address, PendingPenaltyInfo)> {
+        let pending_penalties: Map<Address, u32> = env
+            .storage()
+            .instance()
+            .get(&DataKey4::PendingPenalties)
+            .unwrap_or(Map::new(&env));
+
+        let penalty_amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PenaltyAmount)
+            .unwrap_or(0);
+        let grace_period_ledgers: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey4::GracePeriodLedgers)
+            .unwrap_or(0);
+        let round_deadline: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey4::LastRoundDeadline)
+            .or(env.storage().instance().get(&DataKey::RoundDeadline))
+            .unwrap_or(0);
+        let grace_expires_at = round_deadline.saturating_add(grace_period_ledgers as u64);
+
+        let mut result = Vec::new(&env);
+        for (member, round) in pending_penalties.iter() {
+            result.push_back((
+                member,
+                PendingPenaltyInfo {
+                    round,
+                    penalty_amount,
+                    grace_expires_at,
+                },
+            ));
+        }
+        result
+    }
+
     pub fn get_state(env: Env) -> (u32, Vec<Address>, u64, PayoutStrategy, Address) {
         let current_round: u32 = env
             .storage()

--- a/contracts/ahjoor-rosca/src/test.rs
+++ b/contracts/ahjoor-rosca/src/test.rs
@@ -4972,6 +4972,95 @@ fn test_grace_period_ledger_vs_timestamp() {
     assert!(info.current_round >= 1, "should have progressed past round 0");
 }
 
+// ===========================================================================
+//  #556: get_pending_penalties admin view
+// ===========================================================================
+
+/// Empty vec when no penalties are pending.
+#[test]
+fn test_get_pending_penalties_empty_when_none_pending() {
+    let (_env, client, _admin, _token_addr, _members, _token_admin_client) =
+        setup_grace_env(false, 600, 0);
+
+    let pending = client.get_pending_penalties(&0u32);
+    assert_eq!(pending.len(), 0);
+}
+
+/// A group with a mix of an already-processed (auto-flushed on round
+/// advance) and a still-pending penalty: get_pending_penalties must surface
+/// only the member whose penalty is genuinely still awaiting processing.
+#[test]
+fn test_get_pending_penalties_mix_of_processed_and_pending() {
+    let (env, client, _admin, token_addr, members, _token_admin_client) =
+        setup_grace_env(false, 600, 0);
+    let token_client = TokenClient::new(&env, &token_addr);
+
+    let member0 = members.get(0).unwrap();
+    let member1 = members.get(1).unwrap();
+    let member2 = members.get(2).unwrap();
+
+    // Round 0 (deadline = 3600): member2 defaults.
+    env.ledger().with_mut(|l| l.timestamp = 100);
+    client.contribute(&member0, &token_addr, &100);
+    client.contribute(&member1, &token_addr, &100);
+
+    env.ledger().with_mut(|l| l.timestamp = 3800);
+    client.finalize_round();
+
+    // Still within round 0's grace window (deadline 3600 + grace 600 = 4200):
+    // member2's penalty is deferred, not charged yet.
+    env.ledger().with_mut(|l| l.timestamp = 3850);
+    let member2_balance_before = token_client.balance(&member2);
+    client.request_penalty_grace(&member2);
+
+    let pending_after_round0 = client.get_pending_penalties(&0u32);
+    assert_eq!(pending_after_round0.len(), 1);
+    assert_eq!(pending_after_round0.get(0).unwrap().0, member2);
+    // Deferred, not yet charged: balance unchanged.
+    assert_eq!(token_client.balance(&member2), member2_balance_before);
+
+    // Round 1: member1 defaults this time.
+    let round1_deadline = client.get_group_info().round_deadline;
+    client.contribute(&member0, &token_addr, &100);
+    client.contribute(&member2, &token_addr, &100);
+
+    env.ledger().with_mut(|l| l.timestamp = round1_deadline + 100);
+    client.finalize_round();
+    let member1_balance_before_request = token_client.balance(&member1);
+
+    // Still within round 1's own grace window (round1_deadline + 600).
+    // Requesting grace for member1 first runs process_pending_penalties,
+    // which flushes member2's stale round-0 entry (the round has advanced
+    // past it) before deferring member1's brand-new one.
+    let round1_grace_expires_at = round1_deadline + 600;
+    env.ledger()
+        .with_mut(|l| l.timestamp = round1_deadline + 150);
+    client.request_penalty_grace(&member1);
+
+    // member2 was auto-processed: the penalty was actually charged, on top
+    // of member2's normal round-1 contribution of 100.
+    assert_eq!(
+        token_client.balance(&member2),
+        member2_balance_before - 100 - 10
+    );
+
+    // member1 is the only one still awaiting processing.
+    let pending = client.get_pending_penalties(&0u32);
+    assert_eq!(pending.len(), 1);
+    let (pending_member, info) = pending.get(0).unwrap();
+    assert_eq!(pending_member, member1);
+    assert_eq!(info.round, 2);
+    assert_eq!(info.penalty_amount, 10);
+    assert_eq!(info.grace_expires_at, round1_grace_expires_at);
+
+    // member1's penalty hasn't been charged yet — deferred, not applied —
+    // so requesting grace left member1's balance unchanged.
+    assert_eq!(
+        token_client.balance(&member1),
+        member1_balance_before_request
+    );
+}
+
 /// #390 — set_use_timestamp_schedule must reject calls after round 1 starts.
 #[test]
 fn test_cannot_change_timestamp_schedule_mid_round() {

--- a/contracts/ahjoor-rosca/src/types.rs
+++ b/contracts/ahjoor-rosca/src/types.rs
@@ -87,6 +87,21 @@ pub struct PayoutRecord {
     pub amount: i128,
 }
 
+/// A defaulter's penalty that has been deferred via `request_penalty_grace`
+/// and is awaiting processing by `process_pending_penalties`/`apply_penalty` (#556).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingPenaltyInfo {
+    /// Round in which the penalty deferral was requested.
+    pub round: u32,
+    /// Penalty amount (in the group's contribution token) that will be
+    /// charged once the penalty is processed.
+    pub penalty_amount: i128,
+    /// Ledger timestamp after which the grace period has elapsed and the
+    /// penalty becomes eligible for processing.
+    pub grace_expires_at: u64,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExitRequest {


### PR DESCRIPTION
Closes #556

## Summary
Penalties move through `request_penalty_grace` → `process_pending_penalties` → `apply_penalty`, but there was no read-only function for an admin to see which members currently have a pending penalty awaiting processing.

Added `get_pending_penalties(group_id) -> Vec<(Address, PendingPenaltyInfo)>`, surfacing the current pending-penalty queue. `PendingPenaltyInfo` includes the round the deferral was requested in, the configured penalty amount, and the ledger timestamp after which the grace period elapses. `group_id` is accepted for API consistency with other group-scoped functions (see `freeze_group`); this contract manages a single group per instance, so it isn't used to key storage. The function is read-only — it does not mutate `PendingPenalties` or trigger processing.

## Acceptance criteria
- [x] Returns members with an unprocessed pending penalty for the group
- [x] Empty vec when no penalties are pending
- [x] Test covering a group with a mix of processed and pending penalties

## Test plan
- [x] `test_get_pending_penalties_empty_when_none_pending`
- [x] `test_get_pending_penalties_mix_of_processed_and_pending` — one member's penalty is deferred within the grace window, then a second member defaults in the next round; requesting grace for the second member's `process_pending_penalties` pass auto-flushes the first member's stale entry (round advanced past it) while deferring the second. Asserts via token balances that the first member was actually charged and the second was not, and that `get_pending_penalties` surfaces only the second.
- [x] `cargo test -p ahjoor-rosca` — 242/242 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)