### PR TITLE
Docs/527 emergency reserve v2

### DIFF
--- a/docs/bounty-board.md
+++ b/docs/bounty-board.md
@@ -1,0 +1,42 @@
+# Bounty Board (ahjoor-escrow)
+
+This document describes the bounty-board flows in `contracts/ahjoor-escrow`, with emphasis on milestone-based payout behavior.
+
+## Milestone Payouts
+
+Milestone payouts let a bounty release funds in smaller tranches instead of paying the full amount at the end.
+
+### How milestones are defined and ordered
+
+Each milestone is defined when the bounty is created. A milestone includes:
+
+- a description hash for the sub-deliverable
+- the verifier address responsible for sign-off
+- the token amount or release share tied to that milestone
+
+Milestones are stored on-chain in the same order they are provided at creation time, and the contract enforces that order during submission and verification.
+
+For verifier-based bounty milestones, milestone `N + 1` cannot be submitted until milestone `N` has already been verified and paid. That prevents the solver from skipping ahead or claiming later work before earlier work is accepted.
+
+### How the basis-point split determines each payout
+
+For proportional milestone escrows, each milestone defines a `release_bps` value. The contract requires all milestone basis-point values to sum to exactly `10,000`, which represents 100% of the escrow amount.
+
+- `3,000 bps` pays 30% of the escrow amount
+- `5,000 bps` pays 50% of the escrow amount
+- `2,000 bps` pays the remaining 20%
+
+When a submitted milestone is approved, the contract releases that milestone's proportional share to the seller. The final milestone releases any rounding remainder so the full escrow balance is settled exactly.
+
+### What happens if a milestone is disputed or skipped
+
+The bounty milestone payout flow does not introduce a separate on-chain dispute state for milestones. Instead, a verifier-gated milestone can be rejected before verification and returned to `Pending`, which lets the solver revise and resubmit the work.
+
+Skipped milestones are not allowed. The contract requires strict ordering, so later milestones cannot be submitted until all earlier milestones have reached the paid state. That means a solver cannot bypass an unfinished milestone to unlock later payouts.
+
+For verifier-gated bounty milestones, each milestone remains independently verifiable by its designated verifier, and any unresolved earlier milestone blocks progress to later payouts.
+
+## References
+
+- `contracts/ahjoor-escrow/src/test_bounty_milestone.rs`
+- `contracts/ahjoor-escrow/src/test_milestone_bps.rs`

--- a/docs/emergency-reserve.md
+++ b/docs/emergency-reserve.md
@@ -1,0 +1,45 @@
+# Emergency Reserve (ahjoor-rosca)
+
+This document describes the ROSCA emergency reserve feature implemented in `contracts/ahjoor-rosca`.
+
+## How the reserve is funded
+
+The reserve is optional and is enabled through the ROSCA configuration (`RoscaConfig`) with:
+
+- `reserve_enabled: true`
+- `reserve_contribution_bps`: a surcharge applied to each contribution routed into the reserve
+
+When the reserve is enabled, a portion of each contribution is diverted into the group reserve instead of being treated as ordinary round funds. The reserve balance is tracked on-chain in `EmergencyReserveBalance`.
+
+## When members can draw from the reserve
+
+A member may request an emergency loan from the reserve by calling `request_emergency_loan(amount, repayment_window_ledgers)`.
+
+The draw is allowed only when all of the following are true:
+
+- the reserve feature is enabled for the group
+- the member does not already have an outstanding reserve loan
+- the requested amount is positive
+- the requested amount does not exceed the maximum allowed fraction of the reserve balance (currently capped at 50% of the reserve)
+- the reserve balance is large enough to cover the loan amount
+
+If the reserve balance is insufficient, the loan request fails.
+
+## Who authorizes a draw and how it is repaid
+
+A draw is authorized by the member who requests the emergency loan. The contract does not require an admin or group vote for the initial loan request; the borrower receives the funds directly from the reserve once the request is accepted.
+
+Repayment is also member-driven. The borrower can repay the loan by calling `repay_emergency_loan(loan_id, amount)`. Repayments are transferred back to the contract and increase the reserve balance. The loan record tracks:
+
+- the original loan amount
+- the amount already repaid
+- the repayment deadline ledger
+- whether the loan has defaulted
+
+A partial or full repayment is allowed until the loan balance is fully settled. Once fully repaid, the member’s outstanding-loan marker is cleared.
+
+## Operational notes
+
+- The reserve is intended as a liquidity buffer for members facing short-term cash-flow needs.
+- Loans are limited to a capped fraction of the reserve balance to avoid draining the reserve too aggressively.
+- The reserve balance is replenished as members repay emergency loans.


### PR DESCRIPTION
# docs: document emergency reserve fund for ROSCA groups

This PR adds documentation for the ROSCA emergency reserve fund feature in emergency-reserve.md.

It covers:
- How the reserve is funded through the ROSCA configuration and contribution surcharge
- What conditions allow a member to draw from the reserve
- Who authorizes the draw and how repayment works
- Operational notes on how the reserve balance is replenished

## Validation
- Documentation-only change
- Reviewed the emergency reserve flow against the ROSCA contract implementation

Closes #527