### PR TITLE
Add refund policy export, merchant stats alias, reserve migration, dispute window floor

### DIFF
--- a/contracts/ahjoor-refund/src/events.rs
+++ b/contracts/ahjoor-refund/src/events.rs
@@ -899,6 +899,29 @@ pub fn emit_refund_policy_updated(e: &Env, merchant: Address) {
     RefundPolicyUpdated { merchant }.publish(e);
 }
 
+/// Event: legacy (#274) reserve balance migrated into canonical (#334) reserve (#585)
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MerchantReserveMigrated {
+    pub merchant: Address,
+    pub migrated_amount: i128,
+    pub new_canonical_balance: i128,
+}
+
+pub fn emit_merchant_reserve_migrated(
+    e: &Env,
+    merchant: Address,
+    migrated_amount: i128,
+    new_canonical_balance: i128,
+) {
+    MerchantReserveMigrated {
+        merchant,
+        migrated_amount,
+        new_canonical_balance,
+    }
+    .publish(e);
+}
+
 pub fn emit_store_credit_redeemed(
     e: &Env,
     payment_id: u32,

--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -11,6 +11,11 @@ const INSTANCE_BUMP_AMOUNT: u32 = 120_000;
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 100_000;
 const PERSISTENT_BUMP_AMOUNT: u32 = 120_000;
 
+/// #582: Minimum allowed `dispute_window`, in seconds (1 hour), below which
+/// `auto_approve_refund` would become callable immediately or near-immediately
+/// after a refund request, defeating the intended merchant review window.
+const MIN_DISPUTE_WINDOW_SECONDS: u64 = 3_600;
+
 // ---------------------------------------------------------------------------
 // Minimal payment contract client — only the fields we need from get_payment.
 // ---------------------------------------------------------------------------
@@ -478,6 +483,12 @@ impl AhjoorRefundContract {
         // Validate fee cap (max 200 bps = 2%)
         if refund_fee_bps > 200 {
             panic!("Refund fee cannot exceed 200 basis points (2%)");
+        }
+
+        // #582: Enforce a minimum dispute window so auto_approve_refund cannot
+        // become immediately callable.
+        if dispute_window < MIN_DISPUTE_WINDOW_SECONDS {
+            panic!("DisputeWindowBelowMinimum");
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -2688,6 +2699,13 @@ impl AhjoorRefundContract {
             })
     }
 
+    /// Get refund statistics scoped to a single merchant (#584). Alias of
+    /// `get_merchant_refund_stats` under the name used by merchant dashboards
+    /// and buyer-trust-tier/abuse-scoring consumers.
+    pub fn get_refund_stats_by_merchant(env: &Env, merchant: Address) -> RefundStats {
+        Self::get_merchant_refund_stats(env, merchant)
+    }
+
     /// Update the refund fee in basis points. Admin only. Max 200 bps (2%).
     pub fn update_refund_fee(env: Env, admin: Address, new_fee_bps: u32) {
         Self::require_admin(&env, &admin);
@@ -2724,6 +2742,22 @@ impl AhjoorRefundContract {
             .instance()
             .get(&DataKey::DisputeWindow)
             .expect("Dispute window not configured")
+    }
+
+    /// Admin sets the dispute window in seconds. Rejects values below
+    /// `MIN_DISPUTE_WINDOW_SECONDS` (#582), which would otherwise let
+    /// `auto_approve_refund` bypass the intended merchant review period.
+    pub fn set_dispute_window(env: Env, admin: Address, dispute_window: u64) {
+        Self::require_admin(&env, &admin);
+        if dispute_window < MIN_DISPUTE_WINDOW_SECONDS {
+            panic!("DisputeWindowBelowMinimum");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::DisputeWindow, &dispute_window);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 
     /// Get refund details
@@ -5380,6 +5414,49 @@ impl AhjoorRefundContract {
             .set(&DataKey2::ReserveAlertThresholdBps, &alert_bps);
     }
 
+    /// #585: Admin-triggered one-time migration of a merchant's legacy (#274)
+    /// reserve balance into the canonical (#334) reserve balance. Moves the
+    /// full legacy balance, zeroes the legacy entry, and returns the amount
+    /// migrated (0 if the merchant had no legacy balance). Total merchant
+    /// reserve balance is preserved exactly — no funds are created or lost,
+    /// only relocated between the two storage keys the two subsystems track.
+    pub fn migrate_merchant_reserve(env: Env, admin: Address, merchant: Address) -> i128 {
+        Self::require_not_paused(&env);
+        Self::require_admin(&env, &admin);
+
+        let legacy_key = DataKey::MerchantReserve(merchant.clone());
+        let legacy_balance: i128 = env.storage().persistent().get(&legacy_key).unwrap_or(0);
+        if legacy_balance == 0 {
+            return 0;
+        }
+
+        env.storage().persistent().set(&legacy_key, &0i128);
+
+        let canonical_key = DataKey2::MerchantReserveBalance(merchant.clone());
+        let canonical_balance: i128 = env.storage().persistent().get(&canonical_key).unwrap_or(0);
+        let new_canonical_balance = canonical_balance + legacy_balance;
+        env.storage()
+            .persistent()
+            .set(&canonical_key, &new_canonical_balance);
+        env.storage().persistent().extend_ttl(
+            &canonical_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        events::emit_merchant_reserve_migrated(
+            &env,
+            merchant,
+            legacy_balance,
+            new_canonical_balance,
+        );
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        legacy_balance
+    }
+
     pub fn set_merchant_response_deadline(
         env: Env,
         admin: Address,
@@ -5630,6 +5707,13 @@ impl AhjoorRefundContract {
                 max_refund_bps: 10_000,
                 excluded_tags: Vec::new(env),
             })
+    }
+
+    /// Returns the full currently active `RefundPolicy` for a merchant (#583):
+    /// the merchant's own published policy if set, else the admin global default,
+    /// else the hardcoded fallback — the same resolution used to enforce refunds.
+    pub fn export_refund_policy(env: Env, merchant: Address) -> RefundPolicy {
+        Self::refund_policy_for(&env, &merchant)
     }
 
     fn enforce_refund_policy(

--- a/contracts/ahjoor-refund/src/test.rs
+++ b/contracts/ahjoor-refund/src/test.rs
@@ -1290,6 +1290,34 @@ fn test_get_dispute_window_returns_configured_value() {
     assert_eq!(s.refund_client.get_dispute_window(), 3600);
 }
 
+// --- #582: dispute_window minimum floor ---
+
+#[test]
+#[should_panic(expected = "DisputeWindowBelowMinimum")]
+fn test_initialize_rejects_zero_dispute_window() {
+    setup_with_dispute_window(0);
+}
+
+#[test]
+#[should_panic(expected = "DisputeWindowBelowMinimum")]
+fn test_initialize_rejects_dispute_window_below_floor() {
+    setup_with_dispute_window(3599);
+}
+
+#[test]
+fn test_set_dispute_window_updates_value_above_floor() {
+    let s = setup_with_dispute_window(86_400);
+    s.refund_client.set_dispute_window(&s.admin, &7_200u64);
+    assert_eq!(s.refund_client.get_dispute_window(), 7_200);
+}
+
+#[test]
+#[should_panic(expected = "DisputeWindowBelowMinimum")]
+fn test_set_dispute_window_rejects_zero() {
+    let s = setup_with_dispute_window(86_400);
+    s.refund_client.set_dispute_window(&s.admin, &0u64);
+}
+
 #[test]
 #[should_panic(expected = "Dispute window has not elapsed")]
 fn test_auto_approve_early_panics() {
@@ -1603,4 +1631,137 @@ fn test_bulk_process_refunds_oversized_batch_rejected() {
 
     let res = s.refund_client.try_bulk_process_refunds(&s.admin, &ids);
     assert!(res.is_err());
+}
+
+// ===========================================================================
+//  #583: export_refund_policy
+// ===========================================================================
+
+#[test]
+fn test_export_refund_policy_returns_default_when_unset() {
+    let s = setup();
+    let merchant = Address::generate(&s.env);
+
+    let policy = s.refund_client.export_refund_policy(&merchant);
+    assert_eq!(policy.eligible_window_ledgers, u32::MAX);
+    assert_eq!(policy.max_refund_bps, 10_000);
+    assert_eq!(policy.excluded_tags.len(), 0);
+}
+
+// Seeds the global refund policy directly in storage. `set_global_refund_policy`
+// itself calls `admin.require_auth()` and then `require_admin` (which calls
+// `require_auth()` again), which soroban-sdk's `mock_all_auths` rejects as a
+// duplicate authorization on the same frame — a pre-existing issue in that
+// setter unrelated to #583, so we bypass it here to isolate the view logic.
+fn seed_global_refund_policy(s: &TestSetup, policy: &RefundPolicy) {
+    s.env.as_contract(&s.refund_client.address, || {
+        s.env
+            .storage()
+            .instance()
+            .set(&DataKey2::GlobalRefundPolicy, policy);
+    });
+}
+
+#[test]
+fn test_export_refund_policy_reflects_global_policy_immediately() {
+    let s = setup();
+    let merchant = Address::generate(&s.env);
+
+    seed_global_refund_policy(
+        &s,
+        &RefundPolicy {
+            eligible_window_ledgers: 1000,
+            max_refund_bps: 5000,
+            excluded_tags: Vec::new(&s.env),
+        },
+    );
+
+    let policy = s.refund_client.export_refund_policy(&merchant);
+    assert_eq!(policy.eligible_window_ledgers, 1000);
+    assert_eq!(policy.max_refund_bps, 5000);
+}
+
+#[test]
+fn test_export_refund_policy_prefers_merchant_over_global() {
+    let s = setup();
+    let merchant = Address::generate(&s.env);
+
+    seed_global_refund_policy(
+        &s,
+        &RefundPolicy {
+            eligible_window_ledgers: 1000,
+            max_refund_bps: 5000,
+            excluded_tags: Vec::new(&s.env),
+        },
+    );
+    s.refund_client.publish_refund_policy(
+        &merchant,
+        &2000u32,
+        &7500u32,
+        &Vec::new(&s.env),
+    );
+
+    let policy = s.refund_client.export_refund_policy(&merchant);
+    assert_eq!(policy.eligible_window_ledgers, 2000);
+    assert_eq!(policy.max_refund_bps, 7500);
+}
+
+// ===========================================================================
+//  #584: get_refund_stats_by_merchant
+// ===========================================================================
+
+#[test]
+fn test_get_refund_stats_by_merchant_zeroed_for_no_activity() {
+    let s = setup();
+    let merchant = Address::generate(&s.env);
+
+    let stats = s.refund_client.get_refund_stats_by_merchant(&merchant);
+    assert_eq!(stats.total_requested, 0);
+    assert_eq!(stats.total_approved, 0);
+    assert_eq!(stats.total_rejected, 0);
+    assert_eq!(stats.total_processed, 0);
+    assert_eq!(stats.total_amount_refunded, 0);
+}
+
+#[test]
+fn test_get_refund_stats_by_merchant_mixed_activity() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    let merchant = Address::generate(&s.env);
+
+    let pid_a = create_completed_payment(&s, &customer, &merchant, 100);
+    s.token_admin_client.mint(&customer, &300);
+    let rid_a = s.refund_client.request_refund(
+        &customer,
+        &pid_a,
+        &100,
+        &String::from_str(&s.env, "a"),
+        &0u32,
+    );
+    s.refund_client.approve_refund(&s.admin, &rid_a);
+    s.refund_client.process_refund(&s.admin, &rid_a);
+
+    let pid_b = create_completed_payment(&s, &customer, &merchant, 60);
+    let rid_b = s.refund_client.request_refund(
+        &customer,
+        &pid_b,
+        &60,
+        &String::from_str(&s.env, "b"),
+        &0u32,
+    );
+    s.refund_client
+        .reject_refund(&s.admin, &rid_b, &String::from_str(&s.env, "no"));
+
+    let stats = s.refund_client.get_refund_stats_by_merchant(&merchant);
+    assert_eq!(stats.total_requested, 2);
+    assert_eq!(stats.total_approved, 1);
+    assert_eq!(stats.total_rejected, 1);
+    assert_eq!(stats.total_processed, 1);
+    assert_eq!(stats.total_amount_refunded, 100);
+
+    // Matches the existing get_merchant_refund_stats view exactly.
+    assert_eq!(
+        stats.total_requested,
+        s.refund_client.get_merchant_refund_stats(&merchant).total_requested
+    );
 }

--- a/contracts/ahjoor-refund/src/test_reserve_fund.rs
+++ b/contracts/ahjoor-refund/src/test_reserve_fund.rs
@@ -2,6 +2,7 @@
 extern crate std;
 
 use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
 
 use crate::{AhjoorRefundContract, AhjoorRefundContractClient, RefundInitConfig};
@@ -93,4 +94,63 @@ fn test_compliance_check_passes_when_funded() {
     // No volume → required = 0 → always compliant
     let compliant = client.check_reserve_compliance(&admin, &merchant);
     assert!(compliant);
+}
+
+// --- #585: Reserve subsystem reconciliation ---
+
+#[test]
+fn test_migrate_merchant_reserve_moves_legacy_into_canonical() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup(&env);
+    let merchant = Address::generate(&env);
+    let (token_addr, token_admin) = make_token(&env, &admin);
+    let token_client = TokenClient::new(&env, &token_addr);
+
+    token_admin.mint(&merchant, &2000i128);
+
+    // Legacy (#274) balance via deposit_reserve.
+    client.deposit_reserve(&merchant, &token_addr, &300i128);
+    assert_eq!(client.get_merchant_reserve(&merchant), 300i128);
+
+    // Canonical (#334) balance via deposit_merchant_reserve. Reserve config is
+    // seeded directly rather than via `set_reserve_config`, which calls
+    // `admin.require_auth()` twice (once directly, once inside `require_admin`)
+    // and trips soroban-sdk's mock_all_auths duplicate-authorization check —
+    // a pre-existing issue in that setter, unrelated to #585.
+    env.as_contract(&client.address, || {
+        env.storage()
+            .instance()
+            .set(&crate::DataKey2::ReserveToken, &token_addr);
+    });
+    token_client.approve(
+        &merchant,
+        &client.address,
+        &200i128,
+        &(env.ledger().sequence() + 1000),
+    );
+    client.deposit_merchant_reserve(&merchant, &200i128);
+
+    let migrated = client.migrate_merchant_reserve(&admin, &merchant);
+
+    // Total preserved: 300 (legacy) + 200 (canonical) = 500, all now canonical.
+    assert_eq!(migrated, 300i128);
+    assert_eq!(client.get_merchant_reserve(&merchant), 0i128);
+
+    let key = crate::DataKey2::MerchantReserveBalance(merchant.clone());
+    let canonical_balance: i128 = env.as_contract(&client.address, || {
+        env.storage().persistent().get(&key).unwrap_or(0)
+    });
+    assert_eq!(canonical_balance, 500i128);
+}
+
+#[test]
+fn test_migrate_merchant_reserve_no_legacy_balance_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    let migrated = client.migrate_merchant_reserve(&admin, &merchant);
+    assert_eq!(migrated, 0i128);
 }


### PR DESCRIPTION
## Summary
- **#582**: Enforce a minimum `dispute_window` (1 hour) on `initialize` and a new `set_dispute_window` admin method, preventing `auto_approve_refund` from becoming callable immediately/near-immediately and bypassing the merchant review window.
- **#583**: Add `export_refund_policy` view returning the fully resolved `RefundPolicy` for a merchant (merchant policy → global default → hardcoded fallback), matching the resolution logic used to enforce refunds.
- **#584**: Add `get_refund_stats_by_merchant` as an alias of `get_merchant_refund_stats`, matching the name expected by merchant dashboards and buyer-trust/abuse-scoring consumers.
- **#585**: Add `migrate_merchant_reserve` admin action that moves a merchant's legacy (#274) reserve balance into the canonical (#334) reserve balance, zeroing the legacy entry and preserving the total exactly. Emits a new `MerchantReserveMigrated` event.

## Test plan
- [x] `cargo test` — 124 passed, 0 failed
- [x] New unit tests added for all four issues (dispute window floor on init/setter, policy export resolution order, per-merchant stats with mixed activity, reserve migration incl. no-op case)

closes #582
closes #583
closes #584
closes #585