### PR TITLE
  feat: loyalty balance view, bounded quota volume, paginated contribution history, vote weight snapshot

### DIFF
--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -8386,7 +8386,7 @@ impl AhjoorPaymentsContract {
     }
 
     /// Returns the loyalty points balance for a customer (after expiry check).
-    pub fn get_loyalty_balance(env: Env, customer: Address) -> i128 {
+    pub fn get_loyalty_points_balance(env: Env, customer: Address) -> i128 {
         Self::maybe_expire_points(&env, &customer);
         env.storage()
             .persistent()

--- a/contracts/ahjoor-payments/src/test_loyalty_points.rs
+++ b/contracts/ahjoor-payments/src/test_loyalty_points.rs
@@ -70,7 +70,7 @@ fn test_points_accrued_after_payment() {
     let payment_id = client.create_payment(&customer, &merchant, &1_000_000, &token_addr, &None, &None, &None);
     client.complete_payment(&payment_id);
 
-    assert_eq!(client.get_loyalty_balance(&customer), 1);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 1);
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn test_full_redemption() {
     // Accrue 10 points via a 10_000_000 payment
     let payment_id = client.create_payment(&customer, &merchant, &10_000_000, &token_addr, &None, &None, &None);
     client.complete_payment(&payment_id);
-    assert_eq!(client.get_loyalty_balance(&customer), 10);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 10);
 
     // Create a new payment and redeem all 10 points
     // discount = 10 * 100 / 10_000 = 0.1 per unit → 10 * 100 bps = 1000 bps of... wait
@@ -96,12 +96,12 @@ fn test_full_redemption() {
     let pid = client2.create_payment(&customer2, &merchant2, &5_000_000, &token_addr2, &None, &None, &None);
     client2.complete_payment(&pid);
     // points = 5_000_000 * 1 / 1_000_000 = 5
-    assert_eq!(client2.get_loyalty_balance(&customer2), 5);
+    assert_eq!(client2.get_loyalty_points_balance(&customer2), 5);
 
     // New payment of 1_000_000; redeem 5 points → discount = 5 * 10_000 / 10_000 = 5 units
     let pid2 = client2.create_payment(&customer2, &merchant2, &1_000_000, &token_addr2, &None, &None, &None);
     client2.redeem_points(&customer2, &pid2, &5);
-    assert_eq!(client2.get_loyalty_balance(&customer2), 0);
+    assert_eq!(client2.get_loyalty_points_balance(&customer2), 0);
 }
 
 #[test]
@@ -112,12 +112,12 @@ fn test_partial_redemption() {
     // Accrue 10 points
     let pid = client.create_payment(&customer, &merchant, &1_000_000, &token_addr, &None, &None, &None);
     client.complete_payment(&pid);
-    assert_eq!(client.get_loyalty_balance(&customer), 10);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 10);
 
     // Redeem only 3 points
     let pid2 = client.create_payment(&customer, &merchant, &1_000_000, &token_addr, &None, &None, &None);
     client.redeem_points(&customer, &pid2, &3);
-    assert_eq!(client.get_loyalty_balance(&customer), 7);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 7);
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn test_floor_enforcement() {
 
     let pid = client.create_payment(&customer, &merchant, &1_000_000, &token_addr, &None, &None, &None);
     client.complete_payment(&pid);
-    let balance = client.get_loyalty_balance(&customer);
+    let balance = client.get_loyalty_points_balance(&customer);
     assert!(balance > 0);
 
     // Try to redeem all points — discount would push below floor
@@ -171,13 +171,13 @@ fn test_points_expiry() {
 
     let pid = client.create_payment(&customer, &merchant, &1_000_000, &token_addr, &None, &None, &None);
     client.complete_payment(&pid);
-    assert_eq!(client.get_loyalty_balance(&customer), 1);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 1);
 
     // Advance ledger past expiry
     env.ledger().with_mut(|l| l.sequence_number += 200);
 
     // Balance should be 0 after expiry
-    assert_eq!(client.get_loyalty_balance(&customer), 0);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 0);
 }
 
 #[test]
@@ -189,7 +189,7 @@ fn test_non_transferability() {
 
     let other = Address::generate(&env);
     // Other customer has no points
-    assert_eq!(client.get_loyalty_balance(&other), 0);
+    assert_eq!(client.get_loyalty_points_balance(&other), 0);
 
     // Other customer cannot redeem customer's points on customer's payment
     let pid2 = client.create_payment(&customer, &merchant, &1_000_000, &token_addr, &None, &None, &None);
@@ -206,7 +206,7 @@ fn test_points_reversed_on_refund() {
     // Complete a payment to accrue points
     let pid_complete = client.create_payment(&customer, &merchant, &10_000_000, &token_addr, &None, &None, &None);
     client.complete_payment(&pid_complete);
-    assert_eq!(client.get_loyalty_balance(&customer), 10);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 10);
 
     // Full refund via dispute_resolve: dispute a new pending payment for the same amount
     let pid_dispute = client.create_payment(&customer, &merchant, &10_000_000, &token_addr, &None, &None, &None);
@@ -214,7 +214,7 @@ fn test_points_reversed_on_refund() {
     client.resolve_dispute(&pid_dispute, &false);
 
     // 10 points should be reversed (10_000_000 * 1 / 1_000_000 = 10)
-    assert_eq!(client.get_loyalty_balance(&customer), 0);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 0);
 }
 
 #[test]
@@ -226,7 +226,7 @@ fn test_partial_refund_proportional_reversal() {
     // Accrue 10 points
     let pid_complete = client.create_payment(&customer, &merchant, &10_000_000, &token_addr, &None, &None, &None);
     client.complete_payment(&pid_complete);
-    assert_eq!(client.get_loyalty_balance(&customer), 10);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 10);
 
     // Partial refund of 50% on a new disputed payment of the same amount
     let pid_refund = client.create_payment(&customer, &merchant, &10_000_000, &token_addr, &None, &None, &None);
@@ -234,11 +234,45 @@ fn test_partial_refund_proportional_reversal() {
     client.partial_refund(&pid_refund, &5_000_000); // 50% refund → reverse 5 points
 
     // Balance should be 10 - 5 = 5
-    assert_eq!(client.get_loyalty_balance(&customer), 5);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 5);
 
     // Second 50% refund → reverse remaining 5 points
     client.partial_refund(&pid_refund, &5_000_000);
-    assert_eq!(client.get_loyalty_balance(&customer), 0);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 0);
+}
+
+#[test]
+fn test_balance_zero_for_customer_with_no_activity() {
+    let (env, client, _admin, _merchant, _customer, _token_addr) = setup_loyalty_with_token();
+    let never_active = Address::generate(&env);
+    assert_eq!(client.get_loyalty_points_balance(&never_active), 0);
+}
+
+#[test]
+fn test_balance_reflects_earn_then_redeem_sequence() {
+    let (env, client, admin, merchant, customer, token_addr) = setup_loyalty_with_token();
+    // 1 point per 1_000_000 units, 10_000 bps (1 unit) per point, no floor
+    client.configure_loyalty(&admin, &1u32, &10_000u32, &0i128, &0u32);
+
+    // Earn 4 points
+    let pid1 = client.create_payment(&customer, &merchant, &4_000_000, &token_addr, &None, &None, &None);
+    client.complete_payment(&pid1);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 4);
+
+    // Earn 3 more points
+    let pid2 = client.create_payment(&customer, &merchant, &3_000_000, &token_addr, &None, &None, &None);
+    client.complete_payment(&pid2);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 7);
+
+    // Redeem 5 points
+    let pid3 = client.create_payment(&customer, &merchant, &1_000_000, &token_addr, &None, &None, &None);
+    client.redeem_points(&customer, &pid3, &5);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 2);
+
+    // Earn 1 more point
+    let pid4 = client.create_payment(&customer, &merchant, &1_000_000, &token_addr, &None, &None, &None);
+    client.complete_payment(&pid4);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 3);
 }
 
 #[test]
@@ -249,12 +283,12 @@ fn test_points_balance_never_below_zero() {
     // Accrue only 1 point from a small payment
     let pid = client.create_payment(&customer, &merchant, &1_000_000, &token_addr, &None, &None, &None);
     client.complete_payment(&pid);
-    assert_eq!(client.get_loyalty_balance(&customer), 1);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 1);
 
     // Dispute and refund a much larger amount — reverse must clamp to 0
     let pid_big = client.create_payment(&customer, &merchant, &100_000_000, &token_addr, &None, &None, &None);
     client.dispute_payment(&customer, &pid_big, &soroban_sdk::String::from_str(&env, "overcharge"));
     client.resolve_dispute(&pid_big, &false);
 
-    assert_eq!(client.get_loyalty_balance(&customer), 0);
+    assert_eq!(client.get_loyalty_points_balance(&customer), 0);
 }

--- a/contracts/ahjoor-rosca/src/audit_trail.rs
+++ b/contracts/ahjoor-rosca/src/audit_trail.rs
@@ -1,5 +1,5 @@
-use crate::{events, ContributionEntry, CycleRecord, DataKey2};
-use soroban_sdk::{Address, Env, Map, Vec};
+use crate::{events, ContributionEntry, CycleRecord, DataKey2, DataKey5};
+use soroban_sdk::{Address, Env, Vec};
 
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 100_000;
 const PERSISTENT_BUMP_AMOUNT: u32 = 120_000;
@@ -8,6 +8,10 @@ const TEMP_BUMP_AMOUNT: u32 = 15_000;
 
 /// Default retention window: keep 100 cycles in persistent storage
 const DEFAULT_RETENTION_WINDOW: u32 = 100;
+
+/// #544: maximum number of cycles `get_member_contribution_history` will scan
+/// in a single call, so cost stays bounded regardless of total group history.
+pub(crate) const MAX_CONTRIBUTION_HISTORY_RANGE: u32 = 100;
 
 /// Records a complete cycle audit trail atomically at round closure.
 /// This captures all significant events: contributions, payouts, defaults, skips, and penalties.
@@ -41,22 +45,20 @@ pub(crate) fn record_cycle_audit(
         cycle_end_timestamp,
     };
 
-    // Store in persistent storage
-    let mut cycle_records: Map<u32, CycleRecord> = env
-        .storage()
-        .persistent()
-        .get(&DataKey2::CycleRecords)
-        .unwrap_or(Map::new(env));
-
-    cycle_records.set(cycle_number, record);
+    // #544: store this cycle under its own key instead of a single blob Map
+    // shared by every cycle, so reads/writes cost O(1) regardless of how
+    // many cycles the group has completed.
+    let entry_key = DataKey5::CycleRecordEntry(cycle_number);
+    env.storage().persistent().set(&entry_key, &record);
     env.storage()
         .persistent()
-        .set(&DataKey2::CycleRecords, &cycle_records);
-    env.storage().persistent().extend_ttl(
-        &DataKey2::CycleRecords,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+        .extend_ttl(&entry_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+
+    if !env.storage().persistent().has(&DataKey5::OldestPersistentCycle) {
+        env.storage()
+            .persistent()
+            .set(&DataKey5::OldestPersistentCycle, &cycle_number);
+    }
 
     events::emit_cycle_record_created(env, cycle_number, total_pool_amount, payout_recipient);
 
@@ -66,6 +68,10 @@ pub(crate) fn record_cycle_audit(
 
 /// Archives old cycle records to temporary storage based on retention window.
 /// Records older than the retention window are moved from persistent to temporary storage.
+///
+/// Walks forward from the last known oldest persistent cycle rather than
+/// scanning every persisted cycle, so cost stays bounded (amortized O(1) per
+/// call in the common case of the current cycle advancing by one each round).
 fn archive_old_records(env: &Env, current_cycle: u32) {
     let retention_window: u32 = env
         .storage()
@@ -79,107 +85,76 @@ fn archive_old_records(env: &Env, current_cycle: u32) {
 
     let archive_threshold = current_cycle - retention_window;
 
-    let mut cycle_records: Map<u32, CycleRecord> = env
+    let oldest: u32 = env
         .storage()
         .persistent()
-        .get(&DataKey2::CycleRecords)
-        .unwrap_or(Map::new(env));
+        .get(&DataKey5::OldestPersistentCycle)
+        .unwrap_or(0);
 
-    let mut archived_records: Map<u32, CycleRecord> = env
-        .storage()
-        .temporary()
-        .get(&DataKey2::ArchivedCycleRecords)
-        .unwrap_or(Map::new(env));
-
-    // Find records to archive
-    let mut cycles_to_archive = Vec::new(env);
-    for (cycle_num, _) in cycle_records.iter() {
-        if cycle_num < archive_threshold {
-            cycles_to_archive.push_back(cycle_num);
-        }
+    if oldest >= archive_threshold {
+        return;
     }
 
-    // Move records to temporary storage
-    for cycle_num in cycles_to_archive.iter() {
-        if let Some(record) = cycle_records.get(cycle_num) {
-            archived_records.set(cycle_num, record);
-            cycle_records.remove(cycle_num);
+    for cycle_num in oldest..archive_threshold {
+        let entry_key = DataKey5::CycleRecordEntry(cycle_num);
+        if let Some(record) = env.storage().persistent().get::<_, CycleRecord>(&entry_key) {
+            let archived_key = DataKey5::ArchivedCycleRecordEntry(cycle_num);
+            env.storage().temporary().set(&archived_key, &record);
+            env.storage()
+                .temporary()
+                .extend_ttl(&archived_key, TEMP_LIFETIME_THRESHOLD, TEMP_BUMP_AMOUNT);
+            env.storage().persistent().remove(&entry_key);
             events::emit_cycle_record_archived(env, cycle_num);
         }
     }
 
-    // Update storage
-    if !cycles_to_archive.is_empty() {
-        env.storage()
-            .persistent()
-            .set(&DataKey2::CycleRecords, &cycle_records);
-        env.storage()
-            .temporary()
-            .set(&DataKey2::ArchivedCycleRecords, &archived_records);
-        env.storage().temporary().extend_ttl(
-            &DataKey2::ArchivedCycleRecords,
-            TEMP_LIFETIME_THRESHOLD,
-            TEMP_BUMP_AMOUNT,
-        );
-    }
+    env.storage()
+        .persistent()
+        .set(&DataKey5::OldestPersistentCycle, &archive_threshold);
 }
 
 /// Retrieves a cycle record from either persistent or archived storage.
 pub(crate) fn get_cycle_record(env: &Env, cycle_number: u32) -> Option<CycleRecord> {
-    // First check persistent storage
-    let cycle_records: Map<u32, CycleRecord> = env
+    if let Some(record) = env
         .storage()
         .persistent()
-        .get(&DataKey2::CycleRecords)
-        .unwrap_or(Map::new(env));
-
-    if let Some(record) = cycle_records.get(cycle_number) {
+        .get::<_, CycleRecord>(&DataKey5::CycleRecordEntry(cycle_number))
+    {
         return Some(record);
     }
 
-    // Then check archived storage
-    let archived_records: Map<u32, CycleRecord> = env
-        .storage()
+    env.storage()
         .temporary()
-        .get(&DataKey2::ArchivedCycleRecords)
-        .unwrap_or(Map::new(env));
-
-    archived_records.get(cycle_number)
+        .get(&DataKey5::ArchivedCycleRecordEntry(cycle_number))
 }
 
-/// Returns all contribution entries for a specific member across all cycles.
+/// Returns the contribution entries for `member` within cycles
+/// `from_cycle..=to_cycle` (inclusive), checking persistent then archived
+/// storage for each cycle in the range.
+///
+/// #544: bounded by `MAX_CONTRIBUTION_HISTORY_RANGE` so a single call's cost
+/// is capped by the requested window rather than the group's total history —
+/// callers page through older history with successive calls.
 pub(crate) fn get_member_contribution_history(
     env: &Env,
     member: Address,
+    from_cycle: u32,
+    to_cycle: u32,
 ) -> Vec<ContributionEntry> {
-    let mut history = Vec::new(env);
-
-    // Check persistent storage
-    let cycle_records: Map<u32, CycleRecord> = env
-        .storage()
-        .persistent()
-        .get(&DataKey2::CycleRecords)
-        .unwrap_or(Map::new(env));
-
-    for (_, record) in cycle_records.iter() {
-        for contribution in record.contributions.iter() {
-            if contribution.member == member {
-                history.push_back(contribution);
-            }
-        }
+    if from_cycle > to_cycle {
+        panic!("from_cycle must not exceed to_cycle");
+    }
+    if to_cycle - from_cycle >= MAX_CONTRIBUTION_HISTORY_RANGE {
+        panic!("cycle range exceeds maximum allowed");
     }
 
-    // Check archived storage
-    let archived_records: Map<u32, CycleRecord> = env
-        .storage()
-        .temporary()
-        .get(&DataKey2::ArchivedCycleRecords)
-        .unwrap_or(Map::new(env));
-
-    for (_, record) in archived_records.iter() {
-        for contribution in record.contributions.iter() {
-            if contribution.member == member {
-                history.push_back(contribution);
+    let mut history = Vec::new(env);
+    for cycle_num in from_cycle..=to_cycle {
+        if let Some(record) = get_cycle_record(env, cycle_num) {
+            for contribution in record.contributions.iter() {
+                if contribution.member == member {
+                    history.push_back(contribution);
+                }
             }
         }
     }
@@ -217,11 +192,11 @@ pub(crate) fn get_retention_window(env: &Env) -> u32 {
 
 /// Records the start timestamp for a cycle.
 pub(crate) fn record_cycle_start(env: &Env, cycle_number: u32, timestamp: u64) {
-    let mut timestamps: Map<u32, u64> = env
+    let mut timestamps: soroban_sdk::Map<u32, u64> = env
         .storage()
         .instance()
         .get(&DataKey2::CycleStartTimestamps)
-        .unwrap_or(Map::new(env));
+        .unwrap_or(soroban_sdk::Map::new(env));
 
     timestamps.set(cycle_number, timestamp);
     env.storage()
@@ -231,11 +206,11 @@ pub(crate) fn record_cycle_start(env: &Env, cycle_number: u32, timestamp: u64) {
 
 /// Gets the start timestamp for a cycle.
 pub(crate) fn get_cycle_start_timestamp(env: &Env, cycle_number: u32) -> u64 {
-    let timestamps: Map<u32, u64> = env
+    let timestamps: soroban_sdk::Map<u32, u64> = env
         .storage()
         .instance()
         .get(&DataKey2::CycleStartTimestamps)
-        .unwrap_or(Map::new(env));
+        .unwrap_or(soroban_sdk::Map::new(env));
 
     timestamps.get(cycle_number).unwrap_or(0)
 }

--- a/contracts/ahjoor-rosca/src/internals.rs
+++ b/contracts/ahjoor-rosca/src/internals.rs
@@ -174,6 +174,7 @@ pub(crate) fn complete_round_payout(env: &Env, _paid_members: &Vec<Address>) {
     let mut total_payout_history_amt = 0i128;
     let mut reinvested_amount = 0i128;
     let mut total_fee_collected = 0i128;
+    let mut insurance_drawn_this_round = 0i128;
 
     // Calculate expected pot based on member tiers and check for shortfall
     let base_amount: i128 = env
@@ -254,6 +255,7 @@ pub(crate) fn complete_round_payout(env: &Env, _paid_members: &Vec<Address>) {
             }
         };
         if draw_amount > 0 {
+            insurance_drawn_this_round = draw_amount;
             insurance_pool -= draw_amount;
             env.storage().instance().set(&DataKey2::InsurancePool, &insurance_pool);
             events::emit_insurance_paid_out(env, current_round, shortfall, insurance_pool);
@@ -419,18 +421,21 @@ pub(crate) fn complete_round_payout(env: &Env, _paid_members: &Vec<Address>) {
         env.ledger().sequence() as u64
     };
 
-    let cycle_start_timestamp = audit_trail::get_cycle_start_timestamp(env, current_round);
+    // Cycle 0's start isn't captured by the "new cycle begins" hook below
+    // (that only fires once a preceding round has completed), so fall back
+    // to this round's own end-of-processing marker rather than reporting 0.
+    let recorded_cycle_start = audit_trail::get_cycle_start_timestamp(env, current_round);
+    let cycle_start_timestamp = if recorded_cycle_start > 0 {
+        recorded_cycle_start
+    } else {
+        cycle_end_timestamp
+    };
 
     // Get penalty and insurance amounts from storage
     let penalty_amount: i128 = env
         .storage()
         .instance()
         .get(&DataKey::PenaltyAmount)
-        .unwrap_or(0);
-    let insurance_pool: i128 = env
-        .storage()
-        .instance()
-        .get(&DataKey2::InsurancePool)
         .unwrap_or(0);
 
     // Calculate penalties collected and insurance drawn from events/defaults
@@ -441,9 +446,7 @@ pub(crate) fn complete_round_payout(env: &Env, _paid_members: &Vec<Address>) {
         0
     };
 
-    // Insurance drawn is available from previous insurance balance - current balance
-    // For this round, we track what was drawn via events; default to 0 if not tracked separately
-    let insurance_drawn = 0i128;
+    let insurance_drawn = insurance_drawn_this_round;
 
     // Record the cycle audit trail
     audit_trail::record_cycle_audit(

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -1411,8 +1411,18 @@ impl AhjoorContract {
         audit_trail::get_retention_window(&env)
     }
 
-    pub fn get_member_contribution_history(env: Env, member: Address) -> Vec<ContributionEntry> {
-        audit_trail::get_member_contribution_history(&env, member)
+    /// Returns `member`'s contribution entries within cycles
+    /// `from_cycle..=to_cycle` (inclusive). The range is capped at
+    /// `audit_trail::MAX_CONTRIBUTION_HISTORY_RANGE` (100) cycles per call —
+    /// callers with longer histories page through it with successive calls
+    /// instead of loading the whole history at once (#544).
+    pub fn get_member_contribution_history(
+        env: Env,
+        member: Address,
+        from_cycle: u32,
+        to_cycle: u32,
+    ) -> Vec<ContributionEntry> {
+        audit_trail::get_member_contribution_history(&env, member, from_cycle, to_cycle)
     }
 
     pub fn finalize_round(env: Env) {
@@ -11441,6 +11451,7 @@ impl AhjoorContract {
 }
 
 mod test;
+mod test_audit_trail;
 mod test_contrib_delegation;
 mod test_cosigner_guarantee;
 mod test_emergency_reserve;

--- a/contracts/ahjoor-rosca/src/test_audit_trail.rs
+++ b/contracts/ahjoor-rosca/src/test_audit_trail.rs
@@ -33,21 +33,20 @@ fn create_test_contract(env: &Env) -> (AhjoorContractClient, Address, Vec<Addres
         fee_bps: 100u32, // 1%
         fee_recipient: Some(admin.clone()),
         max_defaults: 3u32,
-            grace_period_ledgers: 0,
-            grace_period_seconds: 0,
-            use_timestamp_schedule: false,
+        grace_period_ledgers: 0,
+        use_timestamp_schedule: false,
         round_duration_seconds: 0u64,
         max_members: Some(10u32),
         skip_fee: 10i128,
         max_skips_per_cycle: 1u32,
         voting_mode: VotingMode::Equal,
-    late_fee_bps: 0,
-    grace_period_seconds: 0,
-    auction_enabled: false,
-    auction_window_ledgers: 0,
-    randomize_payout_order: false,
-    reserve_enabled: false,
-    reserve_contribution_bps: 0,
+        late_fee_bps: 0,
+        grace_period_seconds: 0,
+        auction_enabled: false,
+        auction_window_ledgers: 0,
+        randomize_payout_order: false,
+        reserve_enabled: false,
+        reserve_contribution_bps: 0,
     };
 
     client.init(
@@ -57,6 +56,7 @@ fn create_test_contract(env: &Env) -> (AhjoorContractClient, Address, Vec<Addres
         &token,
         &round_duration,
         &config,
+        &None,
     );
 
     (client, admin, members)
@@ -185,9 +185,7 @@ fn test_cycle_record_tracks_skippers() {
     });
 
     // Finalize round to trigger payout and audit recording
-    client.close_round();
-
-
+    client.finalize_round();
 
     // Get cycle record
     let cycle_record = client.get_cycle_record(&0u32).unwrap();
@@ -220,7 +218,7 @@ fn test_member_contribution_history() {
 
     // Get contribution history for member1
     let member1 = members.get(0).unwrap();
-    let history = client.get_member_contribution_history(&member1);
+    let history = client.get_member_contribution_history(&member1, &0u32, &2u32);
 
     // Verify history contains 3 contributions
     assert_eq!(history.len(), 3);
@@ -229,6 +227,113 @@ fn test_member_contribution_history() {
         assert_eq!(contribution.member, member1);
         assert_eq!(contribution.amount, 1000i128);
     }
+}
+
+#[test]
+fn test_member_contribution_history_range_returns_only_requested_slice() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, members) = create_test_contract(&env);
+    let token = client.get_state().4;
+
+    let token_admin_client = token::StellarAssetClient::new(&env, &token);
+    for member in members.iter() {
+        token_admin_client.mint(&member, &100000i128);
+    }
+
+    // Complete 5 cycles (0..4).
+    for _round in 0..5 {
+        for member in members.iter() {
+            client.contribute(&member, &token, &1000i128);
+        }
+    }
+
+    let member1 = members.get(0).unwrap();
+
+    // Full history across all 5 cycles.
+    let full = client.get_member_contribution_history(&member1, &0u32, &4u32);
+    assert_eq!(full.len(), 5);
+
+    // A narrower slice (cycles 1..=2) returns only those two entries.
+    let slice = client.get_member_contribution_history(&member1, &1u32, &2u32);
+    assert_eq!(slice.len(), 2);
+
+    // A single-cycle window.
+    let single = client.get_member_contribution_history(&member1, &3u32, &3u32);
+    assert_eq!(single.len(), 1);
+    assert_eq!(single.get(0).unwrap().member, member1);
+}
+
+#[test]
+#[should_panic(expected = "cycle range exceeds maximum allowed")]
+fn test_member_contribution_history_rejects_oversized_range() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, _members) = create_test_contract(&env);
+    let member = Address::generate(&env);
+
+    client.get_member_contribution_history(&member, &0u32, &crate::audit_trail::MAX_CONTRIBUTION_HISTORY_RANGE);
+}
+
+#[test]
+#[should_panic(expected = "from_cycle must not exceed to_cycle")]
+fn test_member_contribution_history_rejects_inverted_range() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, _members) = create_test_contract(&env);
+    let member = Address::generate(&env);
+
+    client.get_member_contribution_history(&member, &5u32, &1u32);
+}
+
+#[test]
+fn test_member_contribution_history_cost_bounded_by_range_not_total_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, members) = create_test_contract(&env);
+    let token = client.get_state().4;
+
+    // Retention window large enough that nothing archives during this test,
+    // so every cycle stays in persistent storage.
+    let token_admin_client = token::StellarAssetClient::new(&env, &token);
+    for member in members.iter() {
+        token_admin_client.mint(&member, &10_000_000i128);
+    }
+
+    // Build up a long history: 60 completed cycles.
+    for _round in 0..60 {
+        for member in members.iter() {
+            client.contribute(&member, &token, &1000i128);
+        }
+    }
+
+    let member1 = members.get(0).unwrap();
+
+    // Query a fixed-size 5-cycle window early in history...
+    env.cost_estimate().budget().reset_default();
+    let early = client.get_member_contribution_history(&member1, &0u32, &4u32);
+    let early_cost = env.cost_estimate().budget().cpu_instruction_cost();
+    assert_eq!(early.len(), 5);
+
+    // ...and the same size window at the far end of the 60-cycle history.
+    env.cost_estimate().budget().reset_default();
+    let late = client.get_member_contribution_history(&member1, &55u32, &59u32);
+    let late_cost = env.cost_estimate().budget().cpu_instruction_cost();
+    assert_eq!(late.len(), 5);
+
+    // Cost for the same-sized window should not meaningfully grow just
+    // because the group has more total history behind it — it's driven by
+    // the requested range, not by how many cycles exist overall.
+    assert!(
+        late_cost < early_cost * 3,
+        "contribution history query cost scaled with total history: early={}, late={}",
+        early_cost,
+        late_cost
+    );
 }
 
 #[test]
@@ -281,18 +386,18 @@ fn test_cycle_record_includes_insurance_drawn() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (client, admin, members) = create_test_contract(&env);
+    let (client, _admin, members) = create_test_contract(&env);
     let token = client.get_state().4;
 
-    // Mint tokens for members and admin
+    // Mint tokens for members
     let sac = token::StellarAssetClient::new(&env, &token);
     for member in members.iter() {
         sac.mint(&member, &10000i128);
     }
-    sac.mint(&admin, &10000i128);
 
-    // Add to insurance pool
-    client.contribute_to_insurance(&admin, &token, &500i128);
+    // Add to insurance pool. Only members may contribute; member3 (who will
+    // default this round) funds it without making their own contribution.
+    client.contribute_to_insurance(&members.get(2).unwrap(), &token, &500i128);
 
     // Only 2 members contribute (shortfall expected)
     client.contribute(&members.get(0).unwrap(), &token, &1000i128);

--- a/contracts/ahjoor-rosca/src/types.rs
+++ b/contracts/ahjoor-rosca/src/types.rs
@@ -255,9 +255,7 @@ pub enum DataKey2 {
     ReinvestPreference = 58,
     ExitRequests = 59,
     TokenWhitelistContract = 60,
-    CycleRecords = 61,
     CycleRecordRetentionWindow = 62,
-    ArchivedCycleRecords = 63,
     CycleStartTimestamps = 64,
     EmergencyPayoutConfig = 65,
     EmergencyPayoutRequests = 66,
@@ -399,6 +397,16 @@ pub enum DataKey5 {
     // #454: Collective goal reward pool
     GoalRewardPool,             // i128 — funded by admin, distributed once collective_goal is reached
     GoalRewardDistributed,
+    // #544: per-cycle CycleRecord storage, keyed by cycle_number, replacing
+    // the single CycleRecords blob so lookups/writes are O(1) instead of
+    // requiring the whole history to be deserialized on every call.
+    CycleRecordEntry(u32),
+    // #544: per-cycle archived CycleRecord storage (temporary), keyed by
+    // cycle_number, replacing the single ArchivedCycleRecords blob.
+    ArchivedCycleRecordEntry(u32),
+    // #544: smallest cycle_number not yet archived, so `archive_old_records`
+    // can find archival candidates without scanning every persisted cycle.
+    OldestPersistentCycle,
 }
 
 

--- a/contracts/ahjoor-token-whitelist/src/lib.rs
+++ b/contracts/ahjoor-token-whitelist/src/lib.rs
@@ -22,6 +22,11 @@ const MAX_QUOTA_PERIOD_LEDGERS: u32 = 518_400;
 /// Bounded to keep the per-ledger storage-read loop within the host's CPU/memory budget.
 const MAX_VOLUME_QUERY_RANGE: u32 = 500;
 
+/// #540: fixed number of aggregate buckets covering a quota period. Keeps
+/// `record_token_volume`'s cost constant regardless of `period_ledgers`
+/// instead of scaling linearly with it.
+const VOLUME_AGG_BUCKET_COUNT: u32 = 24;
+
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -40,6 +45,18 @@ pub enum Error {
 pub struct TokenQuota {
     pub max_volume_per_period: i128,
     pub period_ledgers: u32,
+}
+
+/// #540: one slot of the fixed-size rolling window used by `record_token_volume`.
+/// `bucket_id` is `ledger / bucket_span`; a slot is live (counted toward the
+/// current period total) only while `current_bucket_id - bucket_id` is less
+/// than `VOLUME_AGG_BUCKET_COUNT`, otherwise it holds stale volume from a
+/// previous cycle through this slot and is ignored.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VolumeAggBucket {
+    pub bucket_id: u32,
+    pub volume: i128,
 }
 
 pub type TokenSuspension = SuspensionRecord;
@@ -91,6 +108,9 @@ pub enum DataKey {
     SuspensionHistory(Address),
     TokenQuota(Address),
     TokenVolumeBucket(Address, u32),
+    /// #540: fixed-size aggregate bucket slot (token, slot_index) used to
+    /// track rolling period volume without iterating every ledger.
+    TokenVolumeAggBucket(Address, u32),
     RiskTier(u32),
     TokenTier(Address),
     TokenLimitOverride(Address),
@@ -144,9 +164,6 @@ mod test_contract_allowlist;
 mod test_governance;
 #[cfg(test)]
 mod test_suspension;
-
-#[cfg(test)]
-mod test;
 
 pub use client::TokenWhitelistClient;
 
@@ -713,19 +730,42 @@ impl TokenWhitelistContract {
             return Ok(());
         };
         let current_ledger = env.ledger().sequence();
-        let start_ledger = current_ledger.saturating_sub(quota.period_ledgers - 1);
+
+        // #540: sum the rolling window from a fixed number of aggregate
+        // buckets instead of iterating every ledger in the period, so cost
+        // stays constant regardless of how large `period_ledgers` is.
+        let bucket_span = (quota.period_ledgers / VOLUME_AGG_BUCKET_COUNT).max(1);
+        let current_bucket_id = current_ledger / bucket_span;
         let mut current_period_volume: i128 = 0;
-        for bucket_ledger in start_ledger..=current_ledger {
-            let bucket_volume: i128 = env
+        for slot in 0..VOLUME_AGG_BUCKET_COUNT {
+            if let Some(bucket) = env
                 .storage().persistent()
-                .get(&DataKey::TokenVolumeBucket(token.clone(), bucket_ledger))
-                .unwrap_or(0);
-            current_period_volume += bucket_volume;
+                .get::<_, VolumeAggBucket>(&DataKey::TokenVolumeAggBucket(token.clone(), slot))
+            {
+                if current_bucket_id.saturating_sub(bucket.bucket_id) < VOLUME_AGG_BUCKET_COUNT {
+                    current_period_volume += bucket.volume;
+                }
+            }
         }
         if current_period_volume + amount > quota.max_volume_per_period {
             events::emit_token_quota_exceeded(&env, token, amount, current_period_volume);
             return Err(Error::QuotaExceeded);
         }
+
+        let slot = current_bucket_id % VOLUME_AGG_BUCKET_COUNT;
+        let agg_key = DataKey::TokenVolumeAggBucket(token.clone(), slot);
+        let existing: Option<VolumeAggBucket> = env.storage().persistent().get(&agg_key);
+        let new_volume = match existing {
+            Some(b) if b.bucket_id == current_bucket_id => b.volume + amount,
+            _ => amount,
+        };
+        env.storage().persistent().set(
+            &agg_key,
+            &VolumeAggBucket { bucket_id: current_bucket_id, volume: new_volume },
+        );
+        env.storage().persistent().extend_ttl(&agg_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+
+        // Exact per-ledger record retained for `get_token_volume` transparency/audit queries.
         let bucket_key = DataKey::TokenVolumeBucket(token.clone(), current_ledger);
         let mut bucket_volume: i128 = env.storage().persistent().get(&bucket_key).unwrap_or(0);
         bucket_volume += amount;

--- a/contracts/ahjoor-token-whitelist/src/test.rs
+++ b/contracts/ahjoor-token-whitelist/src/test.rs
@@ -403,6 +403,154 @@ fn test_suspend_nonwhitelisted_token_fails() {
     client.suspend_token_timed(&admin, &token, &50u32, &reason);
 }
 
+// ── #540/#588: set_token_quota / update_token_quota period_ledgers upper bound ──
+
+#[test]
+#[should_panic(expected = "period_ledgers exceeds maximum allowed")]
+fn test_set_token_quota_rejects_oversized_period() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    client.set_token_quota(&admin, &token, &1_000i128, &(MAX_QUOTA_PERIOD_LEDGERS + 1));
+}
+
+#[test]
+fn test_set_token_quota_accepts_max_period() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    client.set_token_quota(&admin, &token, &1_000i128, &MAX_QUOTA_PERIOD_LEDGERS);
+    let quota = client.get_token_quota(&token).unwrap();
+    assert_eq!(quota.period_ledgers, MAX_QUOTA_PERIOD_LEDGERS);
+}
+
+#[test]
+#[should_panic(expected = "period_ledgers exceeds maximum allowed")]
+fn test_update_token_quota_rejects_oversized_period() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+    client.set_token_quota(&admin, &token, &1_000i128, &100u32);
+
+    client.update_token_quota(&admin, &token, &1_000i128, &(MAX_QUOTA_PERIOD_LEDGERS + 1));
+}
+
+// ── Companion: get_token_volume bounded range ────────────────────────────────
+
+#[test]
+#[should_panic(expected = "ledger range exceeds maximum allowed")]
+fn test_get_token_volume_rejects_oversized_range() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    client.get_token_volume(&token, &0u32, &(MAX_VOLUME_QUERY_RANGE + 1));
+}
+
+#[test]
+fn test_get_token_volume_accepts_max_range() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    let volume = client.get_token_volume(&token, &0u32, &MAX_VOLUME_QUERY_RANGE);
+    assert_eq!(volume, 0);
+}
+
+#[test]
+#[should_panic(expected = "from_ledger must not exceed to_ledger")]
+fn test_get_token_volume_rejects_inverted_range() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+
+    client.get_token_volume(&token, &10u32, &5u32);
+}
+
+// ── #540: record_token_volume quota enforcement with aggregate buckets ──────
+
+#[test]
+fn test_record_token_volume_within_quota_accumulates() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+    client.set_token_quota(&admin, &token, &100i128, &50u32);
+    env.ledger().set_sequence_number(1_000);
+
+    client.record_token_volume(&token, &40);
+    client.record_token_volume(&token, &50);
+    // 40 + 50 = 90, still within the 100 quota.
+}
+
+#[test]
+fn test_record_token_volume_rejects_when_quota_exceeded() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+    client.set_token_quota(&admin, &token, &100i128, &50u32);
+    env.ledger().set_sequence_number(1_000);
+
+    client.record_token_volume(&token, &60);
+    let result = client.try_record_token_volume(&token, &60);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_record_token_volume_window_rolls_over_after_period_elapses() {
+    let (env, admin, client) = setup_test();
+    let token = Address::generate(&env);
+    client.add_token(&admin, &token);
+    client.set_token_quota(&admin, &token, &100i128, &48u32);
+    env.ledger().set_sequence_number(1_000);
+
+    client.record_token_volume(&token, &90);
+    // Immediately re-recording within the same window should fail.
+    assert!(client.try_record_token_volume(&token, &20).is_err());
+
+    // Advance well past the full period so every aggregate bucket rolls out
+    // of the window; volume should reset and admit new activity.
+    env.ledger().set_sequence_number(1_000 + 48 * 2);
+    client.record_token_volume(&token, &20);
+}
+
+// ── #540: record_token_volume cost stays bounded at the maximum configured period ──
+
+#[test]
+fn test_record_token_volume_cost_bounded_at_max_period() {
+    let (env, admin, client) = setup_test();
+
+    let small_period_token = Address::generate(&env);
+    client.add_token(&admin, &small_period_token);
+    client.set_token_quota(&admin, &small_period_token, &1_000_000_000i128, &100u32);
+    env.ledger().set_sequence_number(1_000);
+
+    env.cost_estimate().budget().reset_default();
+    assert!(client.try_record_token_volume(&small_period_token, &1i128).is_ok());
+    let small_period_cost = env.cost_estimate().budget().cpu_instruction_cost();
+
+    let max_period_token = Address::generate(&env);
+    client.add_token(&admin, &max_period_token);
+    client.set_token_quota(&admin, &max_period_token, &1_000_000_000i128, &MAX_QUOTA_PERIOD_LEDGERS);
+    env.ledger().set_sequence_number(MAX_QUOTA_PERIOD_LEDGERS + 1_000);
+
+    env.cost_estimate().budget().reset_default();
+    assert!(client.try_record_token_volume(&max_period_token, &1i128).is_ok());
+    let max_period_cost = env.cost_estimate().budget().cpu_instruction_cost();
+
+    // Cost is driven by the fixed VOLUME_AGG_BUCKET_COUNT, not by
+    // period_ledgers, so it should stay within a small constant factor of the
+    // cost at a tiny period rather than scaling toward the ~518,400x a
+    // per-ledger scan would need at the maximum configured period.
+    assert!(
+        max_period_cost < small_period_cost * 3,
+        "record_token_volume cost scaled with period_ledgers: small_period={}, max_period={}",
+        small_period_cost,
+        max_period_cost
+    );
+}
+
 #[test]
 fn test_is_token_allowed_cost_is_constant_at_scale() {
     let (env, admin, client) = setup_test();

--- a/contracts/ahjoor-token-whitelist/src/test_governance.rs
+++ b/contracts/ahjoor-token-whitelist/src/test_governance.rs
@@ -298,3 +298,35 @@ fn test_vote_weight_capped_by_snapshot_not_live_balance_on_revote() {
 
     client.vote_listing(&voter, &proposal_id, &true, &1_000i128);
 }
+
+#[test]
+fn test_vote_weight_uses_snapshot_not_live_balance() {
+    let (env, admin, client, gov_token) = setup_governance();
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    let sink = Address::generate(&env);
+    let new_token = Address::generate(&env);
+
+    mint_gov_tokens(&env, &gov_token, &admin, &proposer, 200);
+    // Voter flash-acquires a large balance right before voting.
+    mint_gov_tokens(&env, &gov_token, &admin, &voter, 1_000);
+
+    let rationale = BytesN::from_array(&env, &[11u8; 32]);
+    let proposal_id = client.propose_token_listing(&proposer, &new_token, &rationale);
+
+    // Vote weight is snapshotted at first vote.
+    client.vote_listing(&voter, &proposal_id, &true, &1_000i128);
+
+    // Voter moves the tokens elsewhere before finalisation — the recorded
+    // weight must not be affected by this post-vote balance change.
+    soroban_sdk::token::Client::new(&env, &gov_token).transfer(&voter, &sink, &1_000i128);
+    assert_eq!(soroban_sdk::token::Client::new(&env, &gov_token).balance(&voter), 0);
+
+    env.ledger().set_sequence_number(env.ledger().sequence() + 101);
+    client.finalise_listing_proposal(&proposal_id);
+
+    let proposal = client.get_listing_proposal(&proposal_id);
+    assert_eq!(proposal.approve_weight, 1_000);
+    assert_eq!(proposal.status, ProposalStatus::PendingEnactment);
+}


### PR DESCRIPTION


## Summary

- **#567**: Rename `get_loyalty_balance` to `get_loyalty_points_balance` in
  ahjoor-payments to match the requested view-function API. Adds tests for
  a zero balance on an inactive customer and an earn-then-redeem sequence.

- **#540**: `record_token_volume` in ahjoor-token-whitelist accepted a
  `period_ledgers` quota whose per-call cost scaled linearly with the
  period — at the existing MAX_QUOTA_PERIOD_LEDGERS cap (518,400 ledgers)
  it actually exceeded the host CPU budget and panicked. Replaces the
  per-ledger scan with a 24-slot rolling aggregate-bucket window, so cost
  is now driven by a fixed bucket count instead of `period_ledgers`. Exact
  per-ledger volume is still recorded for `get_token_volume` audit
  queries. Adds quota-enforcement and bounded-cost tests.

- **#544**: `get_member_contribution_history` in ahjoor-rosca re-scanned
  the group's entire cycle history (persistent + archived) on every call.
  Migrates `CycleRecord` storage from a single shared blob `Map` to
  per-cycle keys, adds `from_cycle`/`to_cycle` pagination (capped at a
  100-cycle window per call), and makes cycle archival amortized O(1)
  instead of scanning every persisted cycle each round. Adds
  slice/range/bounded-cost tests.

- **#542**: `vote_listing` in ahjoor-token-whitelist already snapshots a
  voter's governance-token balance at first vote and caps weight by that
  snapshot rather than a live balance check. Adds the specifically
  requested `test_vote_weight_uses_snapshot_not_live_balance`.

## Pre-existing bugs fixed along the way

These were blocking verification of the work above, so they're included:

- ahjoor-token-whitelist: `lib.rs` declared `mod test;` twice, so the
  crate's test suite has never compiled or run. Fixed the duplicate.
- ahjoor-rosca: `test_audit_trail.rs` (17 tests covering the audit trail
  feature) was never wired into `lib.rs`'s module tree and had also
  bit-rotted against the current `RoscaConfig`/`init` signature. Wired it
  up and fixed the stale calls, which caught two real bugs:
  - `insurance_drawn` was hardcoded to `0` in `CycleRecord` regardless of
    actual insurance draws (internals.rs).
  - a test used `close_round` (which never records the audit trail) where
    `finalize_round` was required.
  - cycle 0's `cycle_start_timestamp` fell back to `0` in ledger-mode
    since its start is only recorded when a *preceding* round completes;
    added a same-round fallback for the first cycle.

## Known pre-existing failures (left alone, out of scope)

Confirmed present on `main` before this branch, unrelated to any of the
above:

- `ahjoor-token-whitelist::test_contract_allowlist` (3 tests) and
  `test_is_token_allowed_cost_is_constant_at_scale` — only surfaced now
  because the duplicate `mod test;` fix above let the suite compile for
  the first time; not touched by this PR.

## Test plan

- [x] `cargo test -p ahjoor-payments` — 364 passed
- [x] `cargo test -p ahjoor-token-whitelist` — 79 passed, 

- [x] `cargo test -p ahjoor-rosca` — 262 passed
- [x] `cargo build --workspace` — clean

Closes #567
closes #540
closes #544
 closes #542