### PR TITLE
feat:  Add admin-configurable cap

### DIFF
--- a/contracts/ahjoor-payments/src/events.rs
+++ b/contracts/ahjoor-payments/src/events.rs
@@ -2039,6 +2039,14 @@ pub struct DaoVerdictExecuted {
     pub votes_for_customer: u32,
 }
 
+/// Event: DAO escalation was cancelled before voting began.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct DaoEscalationCancelled {
+    pub payment_id: u32,
+    pub case_id: u32,
+}
+
 pub fn emit_dao_configured(e: &Env, member_count: u32, vote_window_seconds: u64, min_votes: u32) {
     DaoConfigured { member_count, vote_window_seconds, min_votes }.publish(e);
 }
@@ -2073,4 +2081,8 @@ pub fn emit_dao_verdict_executed(
     votes_for_customer: u32,
 ) {
     DaoVerdictExecuted { case_id, payment_id, merchant_wins, votes_for_merchant, votes_for_customer }.publish(e);
+}
+
+pub fn emit_dao_escalation_cancelled(e: &Env, payment_id: u32, case_id: u32) {
+    DaoEscalationCancelled { payment_id, case_id }.publish(e);
 }

--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -208,6 +208,10 @@ pub enum Error {
     DaoMinVotesNotMet = 58,
     /// Payment is not in Disputed status; cannot escalate.
     PaymentNotDisputed = 59,
+    /// No active DAO mediation case exists for the payment.
+    DaoCaseNotFoundForPayment = 60,
+    /// DAO escalation cannot be cancelled because voting has started.
+    DaoEscalationHasVotes = 61,
 }
 
 /// Extension errors that overflow the 50-variant contracterror limit.
@@ -1155,6 +1159,27 @@ pub struct AhjoorPaymentsContract;
 
 #[contractimpl]
 impl AhjoorPaymentsContract {
+    fn find_open_dao_case_id_by_payment(env: &Env, payment_id: u32) -> Option<u32> {
+        let case_counter: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey3::DaoMediationCounter)
+            .unwrap_or(0);
+
+        for case_id in 0..case_counter {
+            let maybe_case: Option<DaoMediationCase> = env
+                .storage()
+                .persistent()
+                .get(&DataKey3::DaoMediationCase(case_id));
+            if let Some(case) = maybe_case {
+                if case.payment_id == payment_id && !case.executed {
+                    return Some(case_id);
+                }
+            }
+        }
+        None
+    }
+
     /// One-time contract initialization.
     /// Admin, counters, and config go to instance storage.
     /// fee_recipient: Address that receives protocol fees
@@ -10084,7 +10109,11 @@ impl AhjoorPaymentsContract {
             .get(&DataKey3::DaoVoteWindowSeconds)
             .unwrap_or(DEFAULT_DAO_VOTE_WINDOW_SECONDS);
 
-        // Ensure not already escalated (check for existing case with this payment_id).
+        // Ensure not already escalated (check for existing open case with this payment_id).
+        if Self::find_open_dao_case_id_by_payment(&env, payment_id).is_some() {
+            panic_with_error!(&env, Error::DaoAlreadyEscalated);
+        }
+
         let case_counter: u32 = env
             .storage()
             .instance()
@@ -10121,6 +10150,36 @@ impl AhjoorPaymentsContract {
         events::emit_dispute_escalated_to_dao(&env, payment_id, case_id, initiator, vote_window_closes_at);
         env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         case_id
+    }
+
+    /// Cancel an active DAO escalation for a payment before any votes are cast.
+    ///
+    /// Admin-gated: only the contract admin may call this function.
+    /// Panics with `DaoCaseNotFoundForPayment` if there is no active case for the payment.
+    /// Panics with `DaoEscalationHasVotes` if voting activity has already started.
+    pub fn cancel_dao_escalation(env: Env, payment_id: u32) {
+        Self::require_not_paused(&env);
+
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("Not initialized");
+        admin.require_auth();
+
+        let case_id = Self::find_open_dao_case_id_by_payment(&env, payment_id)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::DaoCaseNotFoundForPayment));
+        let case: DaoMediationCase = env
+            .storage()
+            .persistent()
+            .get(&DataKey3::DaoMediationCase(case_id))
+            .expect("Mediation case not found");
+
+        if case.votes_for_merchant > 0 || case.votes_for_customer > 0 {
+            panic_with_error!(&env, Error::DaoEscalationHasVotes);
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey3::DaoMediationCase(case_id));
+        events::emit_dao_escalation_cancelled(&env, payment_id, case_id);
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 
     /// Cast a vote on a DAO mediation case.

--- a/contracts/ahjoor-payments/src/test_dao_mediation.rs
+++ b/contracts/ahjoor-payments/src/test_dao_mediation.rs
@@ -86,6 +86,40 @@ fn test_escalate_to_dao() {
 }
 
 #[test]
+fn test_cancel_dao_escalation_before_votes() {
+    let (env, client, _admin, customer, _merchant, _token, payment_id) =
+        setup_with_payment();
+
+    let mediator = Address::generate(&env);
+    client.configure_dao(&vec![&env, mediator.clone()], &86_400u64, &1u32);
+
+    let case_id_0 = client.escalate_to_dao(&customer, &payment_id);
+    assert_eq!(case_id_0, 0);
+
+    client.cancel_dao_escalation(&payment_id);
+
+    // Cancellation removes the active case, allowing a fresh escalation.
+    let case_id_1 = client.escalate_to_dao(&customer, &payment_id);
+    assert_eq!(case_id_1, 1);
+}
+
+#[test]
+#[should_panic]
+fn test_cancel_dao_escalation_after_vote_panics() {
+    let (env, client, _admin, customer, _merchant, _token, payment_id) =
+        setup_with_payment();
+
+    let mediator = Address::generate(&env);
+    client.configure_dao(&vec![&env, mediator.clone()], &86_400u64, &1u32);
+
+    let case_id = client.escalate_to_dao(&customer, &payment_id);
+    client.dao_vote(&mediator, &case_id, &false);
+
+    // Any vote activity blocks cancellation.
+    client.cancel_dao_escalation(&payment_id);
+}
+
+#[test]
 fn test_dao_vote_and_execute_customer_wins() {
     let (env, client, admin, customer, _merchant, token_client, payment_id) =
         setup_with_payment();

--- a/contracts/ahjoor-rosca/src/events.rs
+++ b/contracts/ahjoor-rosca/src/events.rs
@@ -898,12 +898,30 @@ pub struct InsurancePaidOut {
     pub remaining_pool: i128,
 }
 
+/// Event: Insurance pool dropped below configured low threshold
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct InsurancePoolLow {
+    pub round: u32,
+    pub threshold: i128,
+    pub remaining_pool: i128,
+}
+
 pub fn emit_insurance_top_up(e: &Env, contributor: Address, amount: i128) {
     InsurancePoolTopUp { contributor, amount }.publish(e);
 }
 
 pub fn emit_insurance_paid_out(e: &Env, round: u32, shortfall: i128, remaining_pool: i128) {
     InsurancePaidOut { round, shortfall, remaining_pool }.publish(e);
+}
+
+pub fn emit_insurance_pool_low(e: &Env, round: u32, threshold: i128, remaining_pool: i128) {
+    InsurancePoolLow {
+        round,
+        threshold,
+        remaining_pool,
+    }
+    .publish(e);
 }
 
 pub fn emit_round_skip_requested(e: &Env, member: Address, round: u32, fee_paid: i128) {

--- a/contracts/ahjoor-rosca/src/internals.rs
+++ b/contracts/ahjoor-rosca/src/internals.rs
@@ -255,10 +255,28 @@ pub(crate) fn complete_round_payout(env: &Env, _paid_members: &Vec<Address>) {
             }
         };
         if draw_amount > 0 {
+            let insurance_pool_before_draw = insurance_pool;
             insurance_drawn_this_round = draw_amount;
             insurance_pool -= draw_amount;
             env.storage().instance().set(&DataKey2::InsurancePool, &insurance_pool);
             events::emit_insurance_paid_out(env, current_round, shortfall, insurance_pool);
+
+            let low_threshold: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey4::InsurancePoolLowThreshold)
+                .unwrap_or(0);
+            if low_threshold > 0
+                && insurance_pool_before_draw >= low_threshold
+                && insurance_pool < low_threshold
+            {
+                events::emit_insurance_pool_low(env, current_round, low_threshold, insurance_pool);
+            }
+
+            let shortfall_remaining = shortfall - draw_amount;
+            if insurance_pool == 0 {
+                events::emit_insurance_pool_exhausted(env, current_round, shortfall_remaining);
+            }
             events::emit_insurance_claim_executed(env, current_round, payout_recipient.clone(), draw_amount);
             let mut claims: Map<u32, Vec<InsuranceClaim>> = env
                 .storage()

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -717,6 +717,12 @@ impl AhjoorContract {
             .unwrap_or(0)
     }
 
+    /// Read-only balance view for integrators expecting a group-scoped API.
+    /// `group_id` is currently unused because this contract manages one group.
+    pub fn get_insurance_pool_balance(env: Env, _group_id: u32) -> i128 {
+        Self::get_insurance_pool(env)
+    }
+
     /// Get the proposed admin address, if any.
     pub fn get_proposed_admin(env: Env) -> Option<Address> {
         env.storage().instance().get(&DataKey2::ProposedAdmin)
@@ -7456,6 +7462,32 @@ impl AhjoorContract {
         events::emit_insurance_coverage_mode_set(&env, mode as u32);
     }
 
+    pub fn set_insurance_pool_low_threshold(env: Env, admin: Address, threshold: i128) {
+        admin.require_auth();
+        internals::check_not_paused(&env);
+        let a: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("No admin");
+        if admin != a {
+            panic_with_error!(&env, ExtError::OnlyAdminAllowed);
+        }
+        if threshold < 0 {
+            panic_with_error!(&env, ExtError::InvalidAmount);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey4::InsurancePoolLowThreshold, &threshold);
+    }
+
+    pub fn get_insurance_pool_low_threshold(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey4::InsurancePoolLowThreshold)
+            .unwrap_or(0)
+    }
+
     pub fn get_insurance_claims(env: Env, round: u32) -> Vec<InsuranceClaim> {
         let claims: Map<u32, Vec<InsuranceClaim>> = env
             .storage()
@@ -9520,6 +9552,23 @@ impl AhjoorContract {
             groups_completed: 0,
             score: 0,
         })
+    }
+
+    /// Batch-read member credit score records for UI/leaderboard rendering.
+    /// Returns entries in the same order as the `members` input.
+    /// `group_id` is currently unused because this contract manages one group.
+    pub fn get_member_scores(env: Env, _group_id: u32, members: Vec<Address>) -> Vec<Option<MemberScore>> {
+        let scores: Map<Address, MemberScore> = env
+            .storage()
+            .persistent()
+            .get(&PersistentKey::MemberCreditScores)
+            .unwrap_or(Map::new(&env));
+
+        let mut result: Vec<Option<MemberScore>> = Vec::new(&env);
+        for member in members.iter() {
+            result.push_back(scores.get(member));
+        }
+        result
     }
 
     /// #457: Cross-contract credit score oracle.

--- a/contracts/ahjoor-rosca/src/test_emergency_reserve.rs
+++ b/contracts/ahjoor-rosca/src/test_emergency_reserve.rs
@@ -3,7 +3,7 @@ use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::{Client as TokenClient, StellarAssetClient as TokenAdminClient},
-    Address, Env,
+    Address, Env, IntoVal, Symbol,
 };
 
 fn setup_insurance<'a>(
@@ -87,6 +87,17 @@ fn setup_insurance<'a>(
     (env, client, admin, token_addr, token_client, token_admin_client, members)
 }
 
+fn count_topic_events(env: &Env, topic: &str) -> u32 {
+    let expected_topics = (Symbol::new(env, topic),).into_val(env);
+    let mut count = 0u32;
+    for event in env.events().all().iter() {
+        if event.1 == expected_topics {
+            count += 1;
+        }
+    }
+    count
+}
+
 /// #395: Drawing from an underfunded Full-mode insurance pool must transfer
 /// exactly pool_balance (not the full shortfall), leave the pool at 0, and
 /// never allow the stored pool balance to go negative.
@@ -142,4 +153,47 @@ fn test_insurance_pool_partial_cover_when_underfunded() {
     // Pool had 50 < shortfall of 100; all 50 should be drawn, leaving 0.
     assert!(pool_after >= 0, "InsurancePool must never go negative, got {}", pool_after);
     assert_eq!(pool_after, 0, "Pool should be 0 after exhausting 50 towards 100 shortfall");
+}
+
+#[test]
+fn test_insurance_pool_low_emits_once_then_exhausts() {
+    let (env, client, admin, token_addr, _token_client, _token_admin_client, members) =
+        setup_insurance(250);
+
+    client.set_insurance_pool_low_threshold(&admin, &200);
+    assert_eq!(client.get_insurance_pool_low_threshold(), 200);
+    assert_eq!(client.get_insurance_pool_balance(&0), 250);
+
+    let member0 = members.get(0).unwrap();
+    let member1 = members.get(1).unwrap();
+
+    // Round 0: draw 100 from 250 -> 150 (crosses below 200; low event should fire once).
+    env.ledger().with_mut(|l| l.timestamp = 100);
+    client.contribute(&member0, &token_addr, &100);
+    client.contribute(&member1, &token_addr, &100);
+    env.ledger().with_mut(|l| l.timestamp = 3800);
+    client.finalize_round();
+    assert_eq!(client.get_insurance_pool(), 150);
+    assert_eq!(count_topic_events(&env, "insurance_pool_low"), 1);
+    assert_eq!(count_topic_events(&env, "InsExhausted"), 0);
+
+    // Round 1: draw 100 from 150 -> 50 (already below threshold; no new low event).
+    env.ledger().with_mut(|l| l.timestamp = 3900);
+    client.contribute(&member0, &token_addr, &100);
+    client.contribute(&member1, &token_addr, &100);
+    env.ledger().with_mut(|l| l.timestamp = 7600);
+    client.finalize_round();
+    assert_eq!(client.get_insurance_pool(), 50);
+    assert_eq!(count_topic_events(&env, "insurance_pool_low"), 1);
+    assert_eq!(count_topic_events(&env, "InsExhausted"), 0);
+
+    // Round 2: draw remaining 50 from 50 -> 0; pool exhausted event should fire.
+    env.ledger().with_mut(|l| l.timestamp = 7700);
+    client.contribute(&member0, &token_addr, &100);
+    client.contribute(&member1, &token_addr, &100);
+    env.ledger().with_mut(|l| l.timestamp = 11400);
+    client.finalize_round();
+    assert_eq!(client.get_insurance_pool(), 0);
+    assert_eq!(count_topic_events(&env, "insurance_pool_low"), 1);
+    assert_eq!(count_topic_events(&env, "InsExhausted"), 1);
 }

--- a/contracts/ahjoor-rosca/src/types.rs
+++ b/contracts/ahjoor-rosca/src/types.rs
@@ -303,6 +303,8 @@ pub enum DataKey4 {
     /// `finalize_round`, which would advance rounds without ever paying out
     /// the pot or recording audit trail / receipts / cycle bonuses.
     UnfinalizedRoundStreak = 100,
+    /// Insurance pool low-balance alert threshold.
+    InsurancePoolLowThreshold = 101,
 }
 
 /// Waitlist ordering mode (#456).


### PR DESCRIPTION
closes #568
closes #561
closes #562
closes #564

## Ahjoor Contracts Update Summary

## Scope
Implemented requested feature updates across `ahjoor-rosca` and `ahjoor-payments` (code-only changes, no new build/test runs requested).

## 1) ahjoor-rosca: Insurance Pool Health + Low-Balance Alert

## ✅ Changes Made
- Added new view function:
  - `get_insurance_pool_balance(group_id: u32) -> i128`
- Added configurable low-balance threshold:
  - `set_insurance_pool_low_threshold(admin: Address, threshold: i128)`
  - `get_insurance_pool_low_threshold() -> i128`
- Added new event:
  - `InsurancePoolLow { round, threshold, remaining_pool }`
  - helper emitter `emit_insurance_pool_low(...)`
- Updated payout flow logic in `complete_round_payout`:
  - Emits low-balance event **only once per crossing** (`>= threshold` to `< threshold`)
  - Emits exhausted event when draw drains pool to `0`

## 📂 Files Updated
- `contracts/ahjoor-rosca/src/lib.rs`
- `contracts/ahjoor-rosca/src/internals.rs`
- `contracts/ahjoor-rosca/src/events.rs`
- `contracts/ahjoor-rosca/src/types.rs`
- `contracts/ahjoor-rosca/src/test_emergency_reserve.rs`

## 🧪 Tests Added/Updated
- Added `test_insurance_pool_low_emits_once_then_exhausts` to validate:
  - top-up
  - threshold-crossing low event (fires once)
  - no duplicate low event while already below threshold
  - full exhaustion path

## 2) ahjoor-rosca: Batch Member Score Query

## ✅ Changes Made
- Added batch API:
  - `get_member_scores(_group_id: u32, members: Vec<Address>) -> Vec<Option<MemberScore>>`
- Behavior:
  - Preserves input order
  - Returns `None` for members with no stored score entry

## 📂 File Updated
- `contracts/ahjoor-rosca/src/lib.rs`

## 3) ahjoor-payments: Cancel DAO Escalation Before Voting Starts

## ✅ Changes Made
- Added admin-gated cancel function:
  - `cancel_dao_escalation(payment_id: u32)`
- Added internal lookup helper:
  - `find_open_dao_case_id_by_payment(...)`
- Added guard:
  - cancel only allowed when `votes_for_merchant == 0 && votes_for_customer == 0`
- Added event:
  - `DaoEscalationCancelled { payment_id, case_id }`
- Added new errors:
  - `DaoCaseNotFoundForPayment`
  - `DaoEscalationHasVotes`
- Tightened `escalate_to_dao` to enforce existing intended behavior:
  - rejects duplicate open escalation for same payment (`DaoAlreadyEscalated`)

## 📂 Files Updated
- `contracts/ahjoor-payments/src/lib.rs`
- `contracts/ahjoor-payments/src/events.rs`
- `contracts/ahjoor-payments/src/test_dao_mediation.rs`

## 🧪 Tests Added
- `test_cancel_dao_escalation_before_votes`
- `test_cancel_dao_escalation_after_vote_panics`

## 4) ahjoor-payments: Batch Size Configurability Request

## ℹ️ Result
- No code change required: feature already existed.
- Verified current behavior already matches request:
  - `set_max_batch_size(...)` (admin-gated)
  - stored in `DataKey::MaxBatchSize`
  - `create_payments_batch(...)` reads configured value from storage
  - `get_max_batch_size()` exists
  - tests already present in `contracts/ahjoor-payments/src/test.rs`

