### PR TITLE
feat: Add get_dao_case_by_payment lookup

### DIFF
--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -1037,6 +1037,8 @@ pub enum DataKey3 {
     DaoMediationCounter,
     /// Persistent: DAO mediation case record keyed by case ID
     DaoMediationCase(u32),
+    /// Persistent: payment_id -> DAO mediation case ID
+    DaoCaseByPayment(u32),
     /// Persistent: (case_id, voter) → bool vote cast by DAO member
     DaoMediationVote(u32, Address),
     /// Instance: list of DAO mediator addresses
@@ -10115,6 +10117,14 @@ impl AhjoorPaymentsContract {
             PERSISTENT_BUMP_AMOUNT,
         );
         env.storage()
+            .persistent()
+            .set(&DataKey3::DaoCaseByPayment(payment_id), &case_id);
+        env.storage().persistent().extend_ttl(
+            &DataKey3::DaoCaseByPayment(payment_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage()
             .instance()
             .set(&DataKey3::DaoMediationCounter, &(case_counter + 1));
 
@@ -10299,6 +10309,28 @@ impl AhjoorPaymentsContract {
             .persistent()
             .get(&DataKey3::DaoMediationCase(case_id))
             .expect("Mediation case not found")
+    }
+
+    /// Return the DAO mediation case for `payment_id`, if one exists.
+    pub fn get_dao_case_by_payment(env: Env, payment_id: u32) -> Option<DaoMediationCase> {
+        let case_id: u32 = env.storage().persistent().get(&DataKey3::DaoCaseByPayment(payment_id))?;
+        env.storage().persistent().extend_ttl(
+            &DataKey3::DaoCaseByPayment(payment_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        let case_opt: Option<DaoMediationCase> = env
+            .storage()
+            .persistent()
+            .get(&DataKey3::DaoMediationCase(case_id));
+        if case_opt.is_some() {
+            env.storage().persistent().extend_ttl(
+                &DataKey3::DaoMediationCase(case_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        }
+        case_opt
     }
 
     /// Return the list of registered DAO mediator addresses.

--- a/contracts/ahjoor-payments/src/test_dao_mediation.rs
+++ b/contracts/ahjoor-payments/src/test_dao_mediation.rs
@@ -86,6 +86,28 @@ fn test_escalate_to_dao() {
 }
 
 #[test]
+fn test_get_dao_case_by_payment_returns_existing_case() {
+    let (env, client, _admin, customer, _merchant, _token, payment_id) = setup_with_payment();
+
+    let mediator = Address::generate(&env);
+    client.configure_dao(&vec![&env, mediator], &86_400u64, &1u32);
+
+    let case_id = client.escalate_to_dao(&customer, &payment_id);
+    let by_id = client.get_dao_mediation_case(&case_id);
+    let by_payment = client.get_dao_case_by_payment(&payment_id);
+
+    assert!(by_payment.is_some());
+    assert_eq!(by_payment.unwrap(), by_id);
+}
+
+#[test]
+fn test_get_dao_case_by_payment_returns_none_when_absent() {
+    let (env, client, _admin, _customer, _merchant, _token, _payment_id) = setup_with_payment();
+    let missing = client.get_dao_case_by_payment(&999u32);
+    assert!(missing.is_none());
+}
+
+#[test]
 fn test_dao_vote_and_execute_customer_wins() {
     let (env, client, admin, customer, _merchant, token_client, payment_id) =
         setup_with_payment();

--- a/contracts/ahjoor-rosca/src/audit_trail.rs
+++ b/contracts/ahjoor-rosca/src/audit_trail.rs
@@ -1,4 +1,4 @@
-use crate::{events, ContributionEntry, CycleRecord, DataKey2, DataKey5};
+use crate::{events, ContributionEntry, CycleRecord, DataKey, DataKey2, DataKey5};
 use soroban_sdk::{Address, Env, Vec};
 
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 100_000;
@@ -12,6 +12,8 @@ const DEFAULT_RETENTION_WINDOW: u32 = 100;
 /// #544: maximum number of cycles `get_member_contribution_history` will scan
 /// in a single call, so cost stays bounded regardless of total group history.
 pub(crate) const MAX_CONTRIBUTION_HISTORY_RANGE: u32 = 100;
+/// Default cycles scanned when history bounds are omitted.
+pub(crate) const DEFAULT_CONTRIBUTION_HISTORY_WINDOW: u32 = 25;
 
 /// Records a complete cycle audit trail atomically at round closure.
 /// This captures all significant events: contributions, payouts, defaults, skips, and penalties.
@@ -138,9 +140,24 @@ pub(crate) fn get_cycle_record(env: &Env, cycle_number: u32) -> Option<CycleReco
 pub(crate) fn get_member_contribution_history(
     env: &Env,
     member: Address,
-    from_cycle: u32,
-    to_cycle: u32,
+    from_cycle: Option<u32>,
+    to_cycle: Option<u32>,
 ) -> Vec<ContributionEntry> {
+    let current_round: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::CurrentRound)
+        .unwrap_or(0);
+    let latest_cycle = current_round.saturating_sub(1);
+    let default_span = DEFAULT_CONTRIBUTION_HISTORY_WINDOW.saturating_sub(1);
+
+    let (from_cycle, to_cycle) = match (from_cycle, to_cycle) {
+        (Some(from), Some(to)) => (from, to),
+        (Some(from), None) => (from, from.saturating_add(default_span)),
+        (None, Some(to)) => (to.saturating_sub(default_span), to),
+        (None, None) => (latest_cycle.saturating_sub(default_span), latest_cycle),
+    };
+
     if from_cycle > to_cycle {
         panic!("from_cycle must not exceed to_cycle");
     }

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -1411,16 +1411,18 @@ impl AhjoorContract {
         audit_trail::get_retention_window(&env)
     }
 
-    /// Returns `member`'s contribution entries within cycles
-    /// `from_cycle..=to_cycle` (inclusive). The range is capped at
-    /// `audit_trail::MAX_CONTRIBUTION_HISTORY_RANGE` (100) cycles per call —
-    /// callers with longer histories page through it with successive calls
-    /// instead of loading the whole history at once (#544).
+    /// Returns `member`'s contribution entries within an optional cycle window.
+    ///
+    /// When both bounds are omitted, this returns the most recent
+    /// `audit_trail::DEFAULT_CONTRIBUTION_HISTORY_WINDOW` cycles.
+    /// When one bound is omitted, the other side is expanded by that same
+    /// default window. Any resolved range is still capped by
+    /// `audit_trail::MAX_CONTRIBUTION_HISTORY_RANGE` (100) cycles per call.
     pub fn get_member_contribution_history(
         env: Env,
         member: Address,
-        from_cycle: u32,
-        to_cycle: u32,
+        from_cycle: Option<u32>,
+        to_cycle: Option<u32>,
     ) -> Vec<ContributionEntry> {
         audit_trail::get_member_contribution_history(&env, member, from_cycle, to_cycle)
     }
@@ -3309,6 +3311,64 @@ impl AhjoorContract {
                     .set(&DataKey3::IncomingMigrations, &incoming);
             }
         }
+    }
+
+    /// Admin override to force-cancel a stalled migration request.
+    ///
+    /// Unlike `cancel_migration`, this does not require timeout expiry and can
+    /// remove migration state at any intermediate approval stage.
+    ///
+    /// Removes, when present, both:
+    /// - `MigrationRequests[member]`   (source-side request record)
+    /// - `IncomingMigrations[member]`  (destination-side approval record)
+    ///
+    /// Panics with `MigrationNotFound` if no migration state exists for `member`
+    /// on this contract.
+    pub fn admin_cancel_migration(env: Env, member: Address) {
+        internals::check_not_paused(&env);
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        admin.require_auth();
+
+        let mut changed = false;
+
+        let mut requests: Map<Address, MigrationRequest> = env
+            .storage()
+            .instance()
+            .get(&DataKey3::MigrationRequests)
+            .unwrap_or(Map::new(&env));
+        if requests.contains_key(member.clone()) {
+            requests.remove(member.clone());
+            env.storage()
+                .instance()
+                .set(&DataKey3::MigrationRequests, &requests);
+            changed = true;
+        }
+
+        let mut incoming: Map<Address, IncomingMigration> = env
+            .storage()
+            .instance()
+            .get(&DataKey3::IncomingMigrations)
+            .unwrap_or(Map::new(&env));
+        if incoming.contains_key(member.clone()) {
+            incoming.remove(member.clone());
+            env.storage()
+                .instance()
+                .set(&DataKey3::IncomingMigrations, &incoming);
+            changed = true;
+        }
+
+        if !changed {
+            panic_with_error!(&env, ExtError2::MigrationNotFound);
+        }
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 
     /// Returns the pending outbound migration request for `member`, if any.
@@ -9146,12 +9206,20 @@ impl AhjoorContract {
             state_hash: state_hash.clone(),
         };
 
-        log.push_back(snapshot);
+        log.push_back(snapshot.clone());
         env.storage()
             .persistent()
             .set(&PersistentKey::SnapshotLog, &log);
         env.storage().persistent().extend_ttl(
             &PersistentKey::SnapshotLog,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage()
+            .persistent()
+            .set(&PersistentKey::SnapshotByRound(current_round), &snapshot);
+        env.storage().persistent().extend_ttl(
+            &PersistentKey::SnapshotByRound(current_round),
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
         );
@@ -9192,6 +9260,55 @@ impl AhjoorContract {
             .get(&PersistentKey::SnapshotLog)
             .unwrap_or(Vec::new(&env));
         log.len() as u32
+    }
+
+    /// Returns the latest snapshot captured for `round`, if one exists.
+    /// `group_id` is accepted for interface consistency but ignored (each contract is one group).
+    pub fn get_group_snapshot_at(env: Env, _group_id: u32, round: u32) -> Option<GroupSnapshot> {
+        if let Some(snapshot) = env
+            .storage()
+            .persistent()
+            .get::<PersistentKey, GroupSnapshot>(&PersistentKey::SnapshotByRound(round))
+        {
+            env.storage().persistent().extend_ttl(
+                &PersistentKey::SnapshotByRound(round),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+            env.storage()
+                .instance()
+                .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+            return Some(snapshot);
+        }
+
+        // Backward-compat fallback for snapshots created before round indexing existed.
+        let log: Vec<GroupSnapshot> = env
+            .storage()
+            .persistent()
+            .get(&PersistentKey::SnapshotLog)
+            .unwrap_or(Vec::new(&env));
+        for i in (0..log.len()).rev() {
+            let candidate = log.get(i).expect("snapshot index in bounds");
+            if candidate.round_number == round {
+                env.storage()
+                    .persistent()
+                    .set(&PersistentKey::SnapshotByRound(round), &candidate);
+                env.storage().persistent().extend_ttl(
+                    &PersistentKey::SnapshotByRound(round),
+                    PERSISTENT_LIFETIME_THRESHOLD,
+                    PERSISTENT_BUMP_AMOUNT,
+                );
+                env.storage()
+                    .instance()
+                    .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+                return Some(candidate);
+            }
+        }
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        None
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/contracts/ahjoor-rosca/src/test_audit_trail.rs
+++ b/contracts/ahjoor-rosca/src/test_audit_trail.rs
@@ -218,7 +218,7 @@ fn test_member_contribution_history() {
 
     // Get contribution history for member1
     let member1 = members.get(0).unwrap();
-    let history = client.get_member_contribution_history(&member1, &0u32, &2u32);
+    let history = client.get_member_contribution_history(&member1, &Some(0u32), &Some(2u32));
 
     // Verify history contains 3 contributions
     assert_eq!(history.len(), 3);
@@ -252,17 +252,45 @@ fn test_member_contribution_history_range_returns_only_requested_slice() {
     let member1 = members.get(0).unwrap();
 
     // Full history across all 5 cycles.
-    let full = client.get_member_contribution_history(&member1, &0u32, &4u32);
+    let full = client.get_member_contribution_history(&member1, &Some(0u32), &Some(4u32));
     assert_eq!(full.len(), 5);
 
     // A narrower slice (cycles 1..=2) returns only those two entries.
-    let slice = client.get_member_contribution_history(&member1, &1u32, &2u32);
+    let slice = client.get_member_contribution_history(&member1, &Some(1u32), &Some(2u32));
     assert_eq!(slice.len(), 2);
 
     // A single-cycle window.
-    let single = client.get_member_contribution_history(&member1, &3u32, &3u32);
+    let single = client.get_member_contribution_history(&member1, &Some(3u32), &Some(3u32));
     assert_eq!(single.len(), 1);
     assert_eq!(single.get(0).unwrap().member, member1);
+}
+
+#[test]
+fn test_member_contribution_history_defaults_to_recent_bounded_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, members) = create_test_contract(&env);
+    let token = client.get_state().4;
+
+    let token_admin_client = token::StellarAssetClient::new(&env, &token);
+    for member in members.iter() {
+        token_admin_client.mint(&member, &100000i128);
+    }
+
+    // Build 30 completed cycles so the default window (25) excludes early history.
+    for _round in 0..30 {
+        for member in members.iter() {
+            client.contribute(&member, &token, &1000i128);
+        }
+    }
+
+    let member1 = members.get(0).unwrap();
+    let recent_default = client.get_member_contribution_history(&member1, &None, &None);
+    assert_eq!(
+        recent_default.len(),
+        crate::audit_trail::DEFAULT_CONTRIBUTION_HISTORY_WINDOW
+    );
 }
 
 #[test]
@@ -274,7 +302,11 @@ fn test_member_contribution_history_rejects_oversized_range() {
     let (client, _admin, _members) = create_test_contract(&env);
     let member = Address::generate(&env);
 
-    client.get_member_contribution_history(&member, &0u32, &crate::audit_trail::MAX_CONTRIBUTION_HISTORY_RANGE);
+    client.get_member_contribution_history(
+        &member,
+        &Some(0u32),
+        &Some(crate::audit_trail::MAX_CONTRIBUTION_HISTORY_RANGE),
+    );
 }
 
 #[test]
@@ -286,7 +318,7 @@ fn test_member_contribution_history_rejects_inverted_range() {
     let (client, _admin, _members) = create_test_contract(&env);
     let member = Address::generate(&env);
 
-    client.get_member_contribution_history(&member, &5u32, &1u32);
+    client.get_member_contribution_history(&member, &Some(5u32), &Some(1u32));
 }
 
 #[test]
@@ -315,13 +347,13 @@ fn test_member_contribution_history_cost_bounded_by_range_not_total_history() {
 
     // Query a fixed-size 5-cycle window early in history...
     env.cost_estimate().budget().reset_default();
-    let early = client.get_member_contribution_history(&member1, &0u32, &4u32);
+    let early = client.get_member_contribution_history(&member1, &Some(0u32), &Some(4u32));
     let early_cost = env.cost_estimate().budget().cpu_instruction_cost();
     assert_eq!(early.len(), 5);
 
     // ...and the same size window at the far end of the 60-cycle history.
     env.cost_estimate().budget().reset_default();
-    let late = client.get_member_contribution_history(&member1, &55u32, &59u32);
+    let late = client.get_member_contribution_history(&member1, &Some(55u32), &Some(59u32));
     let late_cost = env.cost_estimate().budget().cpu_instruction_cost();
     assert_eq!(late.len(), 5);
 

--- a/contracts/ahjoor-rosca/src/test_migration.rs
+++ b/contracts/ahjoor-rosca/src/test_migration.rs
@@ -164,3 +164,58 @@ fn test_migration_timeout_cancellation() {
     // Slot 1 should be available again — dest member count was only 1 so slot 1 is a new slot
     // Key assertion: second cancel doesn't panic, i.e. idempotent on dest
 }
+
+/// Test that source admin can force-cancel an outbound migration regardless of timeout/state.
+#[test]
+fn test_admin_cancel_migration_clears_source_request() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token = sac.address();
+
+    let src_admin = Address::generate(&env);
+    let member = Address::generate(&env);
+    let src_client = setup_group(&env, &src_admin, &member, &token);
+
+    let dest_admin = Address::generate(&env);
+    let dest_member = Address::generate(&env);
+    let dest_client = setup_group(&env, &dest_admin, &dest_member, &token);
+
+    src_client.request_group_migration(&member, &dest_client.address, &0u32);
+    src_client.approve_migration_exit(&member);
+    assert!(src_client.get_migration_request(&member).is_some());
+
+    src_client.admin_cancel_migration(&member);
+    assert!(src_client.get_migration_request(&member).is_none());
+}
+
+/// Test that destination admin can force-cancel incoming migration approvals.
+#[test]
+fn test_admin_cancel_migration_clears_destination_incoming() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token = sac.address();
+
+    let src_admin = Address::generate(&env);
+    let member = Address::generate(&env);
+    let src_client = setup_group(&env, &src_admin, &member, &token);
+
+    let dest_admin = Address::generate(&env);
+    let dest_member = Address::generate(&env);
+    let dest_client = setup_group(&env, &dest_admin, &dest_member, &token);
+
+    src_client.request_group_migration(&member, &dest_client.address, &0u32);
+    dest_client.approve_migration_entry(&member, &src_client.address, &0u32);
+
+    // Force-cancel on destination before source reaches BothApproved.
+    dest_client.admin_cancel_migration(&member);
+
+    // Incoming state should be gone; execute now fails because migration is no longer present.
+    let exec_res = dest_client.try_execute_migration(&member, &src_client.address);
+    assert!(exec_res.is_err(), "execute should fail after admin force-cancel");
+}

--- a/contracts/ahjoor-rosca/src/test_snapshot.rs
+++ b/contracts/ahjoor-rosca/src/test_snapshot.rs
@@ -160,3 +160,28 @@ fn test_get_snapshot_by_id() {
     assert_eq!(s0.snapshot_id, 0);
     assert_eq!(s1.snapshot_id, 1);
 }
+
+// ---------------------------------------------------------------------------
+// Test: get_group_snapshot_at returns snapshot for the requested round
+// ---------------------------------------------------------------------------
+#[test]
+fn test_get_group_snapshot_at_round_found() {
+    let (_env, client, admin, _m1, _m2) = setup_snapshot();
+    client.take_snapshot(&admin);
+
+    let snap_opt = client.get_group_snapshot_at(&0u32, &0u32);
+    assert!(snap_opt.is_some());
+    let snap = snap_opt.unwrap();
+    assert_eq!(snap.round_number, 0);
+    assert_eq!(snap.snapshot_id, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Test: get_group_snapshot_at returns None when no snapshot exists
+// ---------------------------------------------------------------------------
+#[test]
+fn test_get_group_snapshot_at_round_not_found() {
+    let (_env, client, _admin, _m1, _m2) = setup_snapshot();
+    let snap_opt = client.get_group_snapshot_at(&0u32, &99u32);
+    assert!(snap_opt.is_none());
+}

--- a/contracts/ahjoor-rosca/src/types.rs
+++ b/contracts/ahjoor-rosca/src/types.rs
@@ -461,6 +461,7 @@ pub enum PersistentKey {
     ReputationScores,          // Map<Address, i128> — cumulative member reliability score
     FreezeLog,                 // Vec<FreezeRecord> — append-only freeze audit log
     SnapshotLog,               // Vec<GroupSnapshot> — append-only snapshot log (#243)
+    SnapshotByRound(u32),      // round_number → latest GroupSnapshot for that round
     LastSnapshotLedger,        // u32 — last snapshot ledger for spam guard (#243)
     MinSnapshotIntervalLedgers, // u32 — min interval between snapshots (#243)
     MemberCreditScores,        // Map<Address, MemberScore> — per-member credit score (#269)


### PR DESCRIPTION
## PR Summary 

---
closes #558
closes #559
closes #560
closes #563
## ✅ What I implemented

### 1) ROSCA: historical snapshot lookup by round
- Added: `get_group_snapshot_at(group_id, round) -> Option<GroupSnapshot>`
- Storage index added: `SnapshotByRound(round)`
- `take_snapshot` now stores both:
  - append-only `SnapshotLog` (existing)
  - indexed `SnapshotByRound` (new, fast lookup)
- Backward compatibility:
  - if index not found, it falls back to scanning old `SnapshotLog`
  - when found, it backfills the index for next time

---

### 2) ROSCA: bounded contribution history defaults
- Updated signature:
  - `get_member_contribution_history(member, from_cycle: Option<u32>, to_cycle: Option<u32>)`
- Added default bounded window:
  - `DEFAULT_CONTRIBUTION_HISTORY_WINDOW = 25`
- Max range still enforced:
  - `MAX_CONTRIBUTION_HISTORY_RANGE = 100`
- New behavior:
  - `Some(from), Some(to)` => exact range
  - `Some(from), None` => `from..from+24`
  - `None, Some(to)` => `to-24..to`
  - `None, None` => last 25 completed cycles

---

### 3) ROSCA: admin force-cancel for stuck migrations
- Added: `admin_cancel_migration(member)` (admin-only)
- Can cancel regardless of timeout/state
- Cleans up local migration state:
  - `MigrationRequests[member]`
  - `IncomingMigrations[member]`
- Returns `MigrationNotFound` if nothing to cancel

---

### 4) Payments: DAO case lookup by payment id
- Added: `get_dao_case_by_payment(payment_id) -> Option<DaoMediationCase>`
- Added index: `DaoCaseByPayment(payment_id) -> case_id`
- `escalate_to_dao` now writes this index
- This gives UIs/integrators a fast pre-check before escalating

---

## 🧪 Tests added/updated

### ROSCA
- `test_snapshot.rs`
  - round found => `Some`
  - round missing => `None`
- `test_audit_trail.rs`
  - migrated to new `Option<u32>` range args
  - added default-window bounded-history test
- `test_migration.rs`
  - admin cancel on source-side request
  - admin cancel on destination-side incoming migration

### Payments
- `test_dao_mediation.rs`
  - `get_dao_case_by_payment` returns existing case
  - returns `None` when absent

---

## 🧹 Validation
- Ran lint checks on edited files
- No linter errors
- Did **not** run build/tests (as requested)

---

## 📁 Files touched

### ROSCA
- `contracts/ahjoor-rosca/src/types.rs`
- `contracts/ahjoor-rosca/src/lib.rs`
- `contracts/ahjoor-rosca/src/audit_trail.rs`
- `contracts/ahjoor-rosca/src/test_snapshot.rs`
- `contracts/ahjoor-rosca/src/test_audit_trail.rs`
- `contracts/ahjoor-rosca/src/test_migration.rs`

### Payments
- `contracts/ahjoor-payments/src/lib.rs`
- `contracts/ahjoor-payments/src/test_dao_mediation.rs`