### PR TITLE
fix(escrow): enforce losing-party check and prevent insurance double-…

### DIFF
--- a/contracts/ahjoor-errors/src/lib.rs
+++ b/contracts/ahjoor-errors/src/lib.rs
@@ -209,7 +209,7 @@ pub mod payments {
 
 pub mod escrow {
     /// See [`crate::rosca::COUNT`] for why this exists.
-    pub const COUNT: usize = 248;
+    pub const COUNT: usize = 249;
 
     pub const INVALID_DEADLINE: u32        = 3001;
     pub const INVALID_TRANCHE_INDEX: u32   = 3002;
@@ -459,6 +459,7 @@ pub mod escrow {
     pub const MILESTONE_MUST_BE_SUBMITTED_BEFORE_APPROVAL: u32 = 3246;
     pub const ONLY_ESCROW_BUYER_MAY_REJECT_MILESTONES: u32 = 3247;
     pub const ONLY_SUBMITTED_MILESTONE_CAN_BE_REJECTED: u32 = 3248;
+    pub const ONLY_LOSING_PARTY_CAN_FLAG_RESOLUTION_ERROR: u32 = 3249;
 }
 
 // ---------------------------------------------------------------------------
@@ -921,6 +922,7 @@ pub static ALL_ERRORS: &[ErrorEntry] = &[
     ErrorEntry { code: escrow::MILESTONE_MUST_BE_SUBMITTED_BEFORE_APPROVAL, name: "MilestoneMustBeSubmittedBeforeApproval", contract: "ahjoor-escrow" },
     ErrorEntry { code: escrow::ONLY_ESCROW_BUYER_MAY_REJECT_MILESTONES, name: "OnlyEscrowBuyerMayRejectMilestones", contract: "ahjoor-escrow" },
     ErrorEntry { code: escrow::ONLY_SUBMITTED_MILESTONE_CAN_BE_REJECTED, name: "OnlySubmittedMilestoneCanBeRejected", contract: "ahjoor-escrow" },
+    ErrorEntry { code: escrow::ONLY_LOSING_PARTY_CAN_FLAG_RESOLUTION_ERROR, name: "OnlyLosingPartyCanFlagResolutionError", contract: "ahjoor-escrow" },
 
     // refund (8 entries — must match refund::COUNT)
     ErrorEntry { code: refund::ALREADY_INITIALIZED, name: "AlreadyInitialized", contract: "ahjoor-refund" },

--- a/contracts/ahjoor-escrow/src/lib.rs
+++ b/contracts/ahjoor-escrow/src/lib.rs
@@ -296,6 +296,8 @@ pub enum EscrowErrorExt4 {
     MilestoneMustBeSubmittedBeforeApproval = 46,
     OnlyEscrowBuyerMayRejectMilestones = 47,
     OnlySubmittedMilestoneCanBeRejected = 48,
+    /// Caller is the winning party and may not flag a resolution error.
+    OnlyLosingPartyCanFlagResolutionError = 49,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2908,6 +2910,22 @@ impl AhjoorEscrowContract {
             panic_with_error!(&env, EscrowErrorExt::OnlyBuyerOrSellerCanFlagResolutionError);
         }
 
+        // Only the losing party may flag a resolution error.
+        // - buyer_percent == 100  → buyer won outright; seller lost → only seller may flag
+        // - buyer_percent == 0    → seller won outright; buyer lost → only buyer may flag
+        // - 0 < buyer_percent < 100 → split verdict; both parties received something, so
+        //   either may flag (neither is an unambiguous "winner").
+        let buyer_won_outright = verdict.buyer_percent == 100;
+        let seller_won_outright = verdict.buyer_percent == 0;
+        if buyer_won_outright && caller == escrow.buyer {
+            // Buyer won — buyer is NOT the losing party
+            panic_with_error!(&env, EscrowErrorExt4::OnlyLosingPartyCanFlagResolutionError);
+        }
+        if seller_won_outright && caller == escrow.seller {
+            // Seller won — seller is NOT the losing party
+            panic_with_error!(&env, EscrowErrorExt4::OnlyLosingPartyCanFlagResolutionError);
+        }
+
         // Enforce cooling-off window has not expired
         let cooling_off_seconds: u64 = env
             .storage()
@@ -3076,10 +3094,38 @@ impl AhjoorEscrowContract {
             panic_with_error!(&env, EscrowErrorExt::FeeConfigurationExceedsEscrowAmount);
         }
 
+        // --- Insurance double-payment prevention ---
+        // If a party already received an insurance payout while this escrow was
+        // disputed, that amount must be deducted from their verdict payout so
+        // total receipts (insurance + verdict) never exceed `escrow.amount`.
+        let insurance_paid: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::InsuranceClaimed(escrow_id))
+            .unwrap_or(0);
+
         let seller_percent = 100 - buyer_percent;
 
-        let buyer_amount = (distributable * buyer_percent as i128) / 100;
-        let seller_amount = distributable - buyer_amount;
+        let raw_buyer_amount = (distributable * buyer_percent as i128) / 100;
+        let raw_seller_amount = distributable - raw_buyer_amount;
+
+        // Deduct insurance from the winning side's share (floor at 0).
+        // For a split verdict both sides "won" a portion, so we conservatively
+        // deduct from whichever side received the larger share. If split is
+        // exactly equal we deduct from buyer (to be safe).
+        let (buyer_amount, seller_amount) = if insurance_paid > 0 {
+            if buyer_percent >= seller_percent {
+                // Buyer's side received more (or equal) → deduct from buyer
+                let buyer_net = (raw_buyer_amount - insurance_paid).max(0);
+                (buyer_net, raw_seller_amount)
+            } else {
+                // Seller's side received more → deduct from seller
+                let seller_net = (raw_seller_amount - insurance_paid).max(0);
+                (raw_buyer_amount, seller_net)
+            }
+        } else {
+            (raw_buyer_amount, raw_seller_amount)
+        };
 
         if buyer_amount > 0 {
             Self::transfer_to_buyers(env, &escrow, buyer_amount, escrow_id);
@@ -3607,8 +3653,9 @@ impl AhjoorEscrowContract {
         if env
             .storage()
             .persistent()
-            .get::<DataKey, bool>(&DataKey::InsuranceClaimed(escrow_id))
-            .unwrap_or(false)
+            .get::<DataKey, i128>(&DataKey::InsuranceClaimed(escrow_id))
+            .unwrap_or(0)
+            > 0
         {
             panic_with_error!(&env, EscrowErrorExt::InsuranceAlreadyClaimed);
         }
@@ -3666,7 +3713,7 @@ impl AhjoorEscrowContract {
             .set(&DataKey::InsurancePool, &(pool_balance - claim_amount));
         env.storage()
             .persistent()
-            .set(&DataKey::InsuranceClaimed(escrow_id), &true);
+            .set(&DataKey::InsuranceClaimed(escrow_id), &claim_amount);
         env.storage().persistent().extend_ttl(
             &DataKey::InsuranceClaimed(escrow_id),
             PERSISTENT_LIFETIME_THRESHOLD,

--- a/contracts/ahjoor-escrow/src/test.rs
+++ b/contracts/ahjoor-escrow/src/test.rs
@@ -3060,6 +3060,196 @@ fn test_insurance_pool_capped_by_pool_balance() {
     assert_eq!(s.client.get_insurance_pool(), 0);
 }
 
+// ---------------------------------------------------------------------------
+// Insurance double-payment prevention tests (fix #b)
+// ---------------------------------------------------------------------------
+
+/// Scenario 1: Claimant wins the verdict.
+/// Buyer claims insurance (500) while disputed, then arbiter rules 100% for buyer.
+/// Total received by buyer must not exceed the original escrow amount (1000).
+/// execute_verdict should pay buyer at most 1000 - 500 = 500 from the verdict.
+#[test]
+fn test_insurance_no_double_payment_claimant_wins() {
+    let s = setup();
+    setup_insurance(&s);
+
+    // Fund the insurance pool generously
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &10_000);
+    s.client.contribute_to_insurance(&contributor, &10_000);
+
+    let buyer  = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1_000);
+
+    s.env.ledger().set_timestamp(1_000);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &1_000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    // Open dispute for the full escrow amount
+    s.client.dispute_escrow(
+        &buyer, &escrow_id,
+        &String::from_str(&s.env, "stuck"), &1_000,
+    );
+
+    // Advance past 7-day insurance trigger
+    s.env.ledger().set_timestamp(1_000 + 604_801);
+    s.client.confirm_insurance_inactivity(&s.admin, &escrow_id, &true);
+
+    // Buyer claims insurance: capped at 50% of 1000 = 500
+    s.client.claim_insurance(&buyer, &escrow_id);
+    let bal_after_insurance = s.token_client.balance(&buyer);
+    assert_eq!(bal_after_insurance, 500, "insurance payout should be 500");
+
+    // Arbiter resolves 100% in buyer's favour (no cooling-off configured)
+    s.client.resolve_dispute(&arbiter, &escrow_id, &100u32);
+
+    let bal_after_verdict = s.token_client.balance(&buyer);
+    // Total received = insurance (500) + verdict payout
+    // Verdict payout must be capped so total ≤ original escrow amount (1000)
+    assert_eq!(
+        bal_after_verdict, 1_000,
+        "buyer total receipts must not exceed original escrow amount"
+    );
+    // Specifically the verdict should have paid 500 (1000 - 500 insurance)
+    assert_eq!(
+        bal_after_verdict - bal_after_insurance, 500,
+        "verdict payout must be reduced by the already-paid insurance amount"
+    );
+}
+
+/// Scenario 2: Claimant (buyer) claimed insurance but loses the verdict.
+/// Seller wins 100%, so the insurance deduction applies to the buyer's share,
+/// which is already 0 — no extra deduction needed.  Seller should receive
+/// the full distributable amount; buyer keeps the insurance payment but
+/// receives nothing from the verdict.
+#[test]
+fn test_insurance_no_double_payment_claimant_loses() {
+    let s = setup();
+    setup_insurance(&s);
+
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &10_000);
+    s.client.contribute_to_insurance(&contributor, &10_000);
+
+    let buyer  = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1_000);
+
+    s.env.ledger().set_timestamp(1_000);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &1_000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    s.client.dispute_escrow(
+        &buyer, &escrow_id,
+        &String::from_str(&s.env, "stuck"), &1_000,
+    );
+
+    s.env.ledger().set_timestamp(1_000 + 604_801);
+    s.client.confirm_insurance_inactivity(&s.admin, &escrow_id, &true);
+
+    // Buyer claims 500 insurance
+    s.client.claim_insurance(&buyer, &escrow_id);
+    let buyer_bal_after_insurance = s.token_client.balance(&buyer);
+    assert_eq!(buyer_bal_after_insurance, 500);
+
+    let seller_bal_before = s.token_client.balance(&seller);
+
+    // Arbiter rules 0% for buyer → seller wins outright
+    s.client.resolve_dispute(&arbiter, &escrow_id, &0u32);
+
+    let buyer_bal_final  = s.token_client.balance(&buyer);
+    let seller_bal_final = s.token_client.balance(&seller);
+
+    // Buyer receives nothing from the verdict (seller won)
+    assert_eq!(
+        buyer_bal_final, buyer_bal_after_insurance,
+        "buyer should receive nothing from a verdict they lost"
+    );
+
+    // Seller receives the full distributable (1000, no fees configured)
+    // The insurance deduction only affects the winner's share; seller won 100%
+    // and the insurance was paid to the buyer-side, so deduction hits buyer's
+    // already-zero share → seller gets the full 1000.
+    assert_eq!(
+        seller_bal_final - seller_bal_before, 1_000,
+        "seller should receive the full escrow amount when buyer claimed insurance and lost"
+    );
+}
+
+/// Scenario 3: Claimant (buyer) claimed insurance and gets a split verdict (50/50).
+/// Buyer's split share is 500; insurance already paid 500 → verdict pays buyer 0.
+/// Seller's split share is 500 and is unaffected.
+#[test]
+fn test_insurance_no_double_payment_split_verdict() {
+    let s = setup();
+    setup_insurance(&s);
+
+    let contributor = Address::generate(&s.env);
+    s.token_admin_client.mint(&contributor, &10_000);
+    s.client.contribute_to_insurance(&contributor, &10_000);
+
+    let buyer  = Address::generate(&s.env);
+    let seller = Address::generate(&s.env);
+    let arbiter = Address::generate(&s.env);
+    s.token_admin_client.mint(&buyer, &1_000);
+
+    s.env.ledger().set_timestamp(1_000);
+    let deadline = s.env.ledger().timestamp() + 10_000;
+    let escrow_id = s.client.create_escrow(
+        &buyer, &seller, &arbiter, &1_000, &s.token_addr, &deadline,
+        &None, &Vec::new(&s.env), &false, &0u32,
+    );
+
+    s.client.dispute_escrow(
+        &buyer, &escrow_id,
+        &String::from_str(&s.env, "stuck"), &1_000,
+    );
+
+    s.env.ledger().set_timestamp(1_000 + 604_801);
+    s.client.confirm_insurance_inactivity(&s.admin, &escrow_id, &true);
+
+    // Buyer claims 500 insurance (50% of 1000)
+    s.client.claim_insurance(&buyer, &escrow_id);
+    assert_eq!(s.token_client.balance(&buyer), 500);
+
+    let seller_bal_before = s.token_client.balance(&seller);
+
+    // 50/50 split verdict — buyer_percent == seller_percent == 50
+    // buyer's raw share = 500, insurance_paid = 500 → buyer verdict payout = 0
+    // seller's raw share = 500, untouched
+    s.client.resolve_dispute(&arbiter, &escrow_id, &50u32);
+
+    let buyer_bal_final  = s.token_client.balance(&buyer);
+    let seller_bal_final = s.token_client.balance(&seller);
+
+    // Buyer: 500 (insurance) + 0 (verdict, deducted) = 500 total
+    assert_eq!(
+        buyer_bal_final, 500,
+        "buyer verdict payout should be zero after full insurance offset"
+    );
+
+    // Seller: receives their 500 split share unaffected
+    assert_eq!(
+        seller_bal_final - seller_bal_before, 500,
+        "seller split share should be unaffected by buyer's insurance claim"
+    );
+
+    // Grand total paid out: 500 (insurance) + 0 (buyer verdict) + 500 (seller verdict) = 1000
+    // This equals the original escrow amount — no over-payment.
+    let total_paid = (buyer_bal_final)   // buyer net (started with 0 after escrow deposit)
+        + (seller_bal_final - seller_bal_before); // seller net
+    assert_eq!(total_paid, 1_000, "grand total payout must equal original escrow amount");
+}
+
 // ===========================================================================
 //  Issue #138: Arbitration Fee Mechanism Tests
 // ===========================================================================

--- a/contracts/ahjoor-escrow/src/test_cooling_off.rs
+++ b/contracts/ahjoor-escrow/src/test_cooling_off.rs
@@ -152,3 +152,168 @@ fn test_no_cooling_off_immediate_release() {
     assert_eq!(escrow.status, EscrowStatus::Refunded);
     assert_eq!(token_client.balance(&buyer), buyer_bal_before + 500);
 }
+
+// ---------------------------------------------------------------------------
+// Tests for flag_resolution_error losing-party enforcement (#a)
+// ---------------------------------------------------------------------------
+
+/// Buyer won (buyer_percent == 100): seller lost, so seller MAY flag.
+/// Buyer calling flag_resolution_error must revert with OnlyLosingPartyCanFlagResolutionError.
+#[test]
+fn test_flag_resolution_error_winner_buyer_cannot_flag() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AhjoorEscrowContract, ());
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    let admin   = Address::generate(&env);
+    let buyer   = Address::generate(&env);
+    let seller  = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_admin_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token_admin_client.mint(&buyer, &1_000);
+
+    client.initialize(&admin);
+    client.add_allowed_token(&admin, &token_addr);
+
+    let deadline = env.ledger().timestamp() + 10_000;
+    let escrow_id = client.create_escrow(
+        &buyer, &seller, &arbiter, &500, &token_addr, &deadline,
+        &None, &Vec::new(&env), &false, &0u32,
+    );
+    client.dispute_escrow(
+        &buyer, &escrow_id,
+        &soroban_sdk::String::from_str(&env, "dispute"), &500,
+    );
+    client.set_resolution_cooloff_secs(&admin, &3_600u64);
+    // Arbiter rules 100% in buyer's favour → buyer is the WINNER
+    client.resolve_dispute(&arbiter, &escrow_id, &100u32);
+
+    let reason = BytesN::from_array(&env, &[2u8; 32]);
+
+    // Winning buyer tries to flag — must fail
+    let err = client
+        .try_flag_resolution_error(&buyer, &escrow_id, &reason)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, EscrowErrorExt4::OnlyLosingPartyCanFlagResolutionError.into());
+
+    // Losing seller flags — must succeed
+    client.flag_resolution_error(&seller, &escrow_id, &reason);
+    // Confirm the flag was recorded (finalization now blocked)
+    env.ledger().with_mut(|l| l.timestamp += 3_601);
+    let finalize_err = client.try_finalize_resolution(&escrow_id).unwrap_err().unwrap();
+    assert_eq!(
+        finalize_err,
+        EscrowErrorExt::ResolutionIsFlaggedAdminMustReviewBeforeFinalization.into(),
+    );
+}
+
+/// Seller won (buyer_percent == 0): buyer lost, so buyer MAY flag.
+/// Seller calling flag_resolution_error must revert with OnlyLosingPartyCanFlagResolutionError.
+#[test]
+fn test_flag_resolution_error_winner_seller_cannot_flag() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AhjoorEscrowContract, ());
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    let admin   = Address::generate(&env);
+    let buyer   = Address::generate(&env);
+    let seller  = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_admin_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token_admin_client.mint(&buyer, &1_000);
+
+    client.initialize(&admin);
+    client.add_allowed_token(&admin, &token_addr);
+
+    let deadline = env.ledger().timestamp() + 10_000;
+    let escrow_id = client.create_escrow(
+        &buyer, &seller, &arbiter, &500, &token_addr, &deadline,
+        &None, &Vec::new(&env), &false, &0u32,
+    );
+    client.dispute_escrow(
+        &buyer, &escrow_id,
+        &soroban_sdk::String::from_str(&env, "dispute"), &500,
+    );
+    client.set_resolution_cooloff_secs(&admin, &3_600u64);
+    // Arbiter rules 0% for buyer → seller is the WINNER
+    client.resolve_dispute(&arbiter, &escrow_id, &0u32);
+
+    let reason = BytesN::from_array(&env, &[3u8; 32]);
+
+    // Winning seller tries to flag — must fail
+    let err = client
+        .try_flag_resolution_error(&seller, &escrow_id, &reason)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, EscrowErrorExt4::OnlyLosingPartyCanFlagResolutionError.into());
+
+    // Losing buyer flags — must succeed
+    client.flag_resolution_error(&buyer, &escrow_id, &reason);
+    // Confirm finalization is blocked
+    env.ledger().with_mut(|l| l.timestamp += 3_601);
+    let finalize_err = client.try_finalize_resolution(&escrow_id).unwrap_err().unwrap();
+    assert_eq!(
+        finalize_err,
+        EscrowErrorExt::ResolutionIsFlaggedAdminMustReviewBeforeFinalization.into(),
+    );
+}
+
+/// Split verdict (buyer_percent == 50): both parties received a share,
+/// so BOTH buyer and seller may flag (no one is the outright winner).
+/// We verify that neither call is rejected with OnlyLosingPartyCanFlagResolutionError.
+#[test]
+fn test_flag_resolution_error_split_verdict_both_parties_may_flag() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AhjoorEscrowContract, ());
+    let client = AhjoorEscrowContractClient::new(&env, &contract_id);
+
+    let admin   = Address::generate(&env);
+    let buyer   = Address::generate(&env);
+    let seller  = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_admin_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token_admin_client.mint(&buyer, &1_000);
+
+    client.initialize(&admin);
+    client.add_allowed_token(&admin, &token_addr);
+
+    let deadline = env.ledger().timestamp() + 10_000;
+    let escrow_id = client.create_escrow(
+        &buyer, &seller, &arbiter, &500, &token_addr, &deadline,
+        &None, &Vec::new(&env), &false, &0u32,
+    );
+    client.dispute_escrow(
+        &buyer, &escrow_id,
+        &soroban_sdk::String::from_str(&env, "dispute"), &500,
+    );
+    client.set_resolution_cooloff_secs(&admin, &3_600u64);
+    // Split verdict — neither side is an outright winner
+    client.resolve_dispute(&arbiter, &escrow_id, &50u32);
+
+    let reason = BytesN::from_array(&env, &[4u8; 32]);
+
+    // Buyer flags the split → must succeed (buyer's share is == seller's share, so not outright winner)
+    client.flag_resolution_error(&buyer, &escrow_id, &reason);
+
+    // Confirm flag recorded and finalization blocked
+    env.ledger().with_mut(|l| l.timestamp += 3_601);
+    let finalize_err = client.try_finalize_resolution(&escrow_id).unwrap_err().unwrap();
+    assert_eq!(
+        finalize_err,
+        EscrowErrorExt::ResolutionIsFlaggedAdminMustReviewBeforeFinalization.into(),
+    );
+    // (A second flag from seller would hit ResolutionAlreadyFlagged, not the losing-party guard.)
+}


### PR DESCRIPTION


closes #536
closes #535

## Summary

### Fix (a) — flag_resolution_error: losing-party enforcement
- Only the party ruled against by the verdict may call `flag_resolution_error`
- `buyer_percent == 100` → buyer won, only seller may flag
- `buyer_percent == 0` → seller won, only buyer may flag
- Split (1–99) → either party may flag
- New error `OnlyLosingPartyCanFlagResolutionError = 49` in `EscrowErrorExt4`

### Fix (b) — execute_verdict: insurance double-payment prevention
- `InsuranceClaimed` storage changed from `bool` to `i128` (stores actual payout)
- `execute_verdict` deducts prior insurance from the winning side's payout
- Total receipts (insurance + verdict) can never exceed `escrow.amount`

### Supporting changes
- `ahjoor-errors`: `escrow::COUNT` 248 → 249, new constant `ONLY_LOSING_PARTY_CAN_FLAG_RESOLUTION_ERROR = 3249`, matching `ALL_ERRORS` entry

### Tests (6 new)
- `test_flag_resolution_error_winner_buyer_cannot_flag`
- `test_flag_resolution_error_winner_seller_cannot_flag`
- `test_flag_resolution_error_split_verdict_both_parties_may_flag`
- `test_insurance_no_double_payment_claimant_wins`
- `test_insurance_no_double_payment_claimant_loses`
- `test_insurance_no_double_payment_split_verdict`
