### PR TITLE
feat(payments,refund,docs): merchant/admin views and co-payer split docs

### DIFF
--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -208,6 +208,12 @@ pub enum Error {
     DaoMinVotesNotMet = 58,
     /// Payment is not in Disputed status; cannot escalate.
     PaymentNotDisputed = 59,
+}
+
+/// Overflow Error2 — split from Error because #[contracterror] is bounded to 50 variants.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error2 {
     /// No active DAO mediation case exists for the payment.
     DaoCaseNotFoundForPayment = 60,
     /// DAO escalation cannot be cancelled because voting has started.
@@ -961,10 +967,6 @@ pub enum DataKey2 {
     ReferralRecord(Address),
     /// Persistent: pending commission balance for a referrer (#242)
     PendingCommission(Address),
-    /// Persistent: lifetime total commission earned by a referrer (#570)
-    TotalEarnedCommission(Address),
-    /// Persistent: lifetime total commission claimed by a referrer (#570)
-    TotalClaimedCommission(Address),
     /// Persistent: dynamic payment record (#246)
     DynamicPayment(u32),
     /// Instance: admin-maintained oracle whitelist (#246)
@@ -1023,6 +1025,10 @@ pub enum DataKey2 {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey3 {
+    /// Persistent: lifetime total commission earned by a referrer (#570)
+    TotalEarnedCommission(Address),
+    /// Persistent: lifetime total commission claimed by a referrer (#570)
+    TotalClaimedCommission(Address),
     /// #351: counter for recurring payment schedules
     RecurringCounter,
     /// #351: recurring payment schedule record
@@ -8701,7 +8707,7 @@ impl AhjoorPaymentsContract {
             PERSISTENT_BUMP_AMOUNT,
         );
 
-        let claimed_key = DataKey2::TotalClaimedCommission(referrer.clone());
+        let claimed_key = DataKey3::TotalClaimedCommission(referrer.clone());
         let total_claimed: i128 = env.storage().persistent().get(&claimed_key).unwrap_or(0);
         let new_total_claimed = total_claimed.saturating_add(pending);
         env.storage().persistent().set(&claimed_key, &new_total_claimed);
@@ -8741,12 +8747,12 @@ impl AhjoorPaymentsContract {
         let total_earned: i128 = env
             .storage()
             .persistent()
-            .get(&DataKey2::TotalEarnedCommission(referrer.clone()))
+            .get(&DataKey3::TotalEarnedCommission(referrer.clone()))
             .unwrap_or(0);
         let total_claimed: i128 = env
             .storage()
             .persistent()
-            .get(&DataKey2::TotalClaimedCommission(referrer))
+            .get(&DataKey3::TotalClaimedCommission(referrer))
             .unwrap_or(0);
         (total_earned, total_claimed)
     }
@@ -8806,7 +8812,7 @@ impl AhjoorPaymentsContract {
             PERSISTENT_BUMP_AMOUNT,
         );
 
-        let earned_key = DataKey2::TotalEarnedCommission(record.referrer.clone());
+        let earned_key = DataKey3::TotalEarnedCommission(record.referrer.clone());
         let total_earned: i128 = env.storage().persistent().get(&earned_key).unwrap_or(0);
         let new_total_earned = total_earned.saturating_add(commission);
         env.storage().persistent().set(&earned_key, &new_total_earned);
@@ -10230,7 +10236,7 @@ impl AhjoorPaymentsContract {
         admin.require_auth();
 
         let case_id = Self::find_open_dao_case_id_by_payment(&env, payment_id)
-            .unwrap_or_else(|| panic_with_error!(&env, Error::DaoCaseNotFoundForPayment));
+            .unwrap_or_else(|| panic_with_error!(&env, Error2::DaoCaseNotFoundForPayment));
         let case: DaoMediationCase = env
             .storage()
             .persistent()
@@ -10238,7 +10244,7 @@ impl AhjoorPaymentsContract {
             .expect("Mediation case not found");
 
         if case.votes_for_merchant > 0 || case.votes_for_customer > 0 {
-            panic_with_error!(&env, Error::DaoEscalationHasVotes);
+            panic_with_error!(&env, Error2::DaoEscalationHasVotes);
         }
 
         env.storage()

--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -4165,6 +4165,45 @@ impl AhjoorPaymentsContract {
             .expect("No dispute found for this payment")
     }
 
+    /// Merchant/admin view of all disputes tied to a given merchant (#565).
+    /// Only disputes still present in temporary storage are returned (a
+    /// resolved dispute is not TTL-extended and will naturally expire and
+    /// drop out of this view). `limit` is capped at 50 per call.
+    pub fn list_disputes_by_merchant(
+        env: Env,
+        merchant: Address,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<Dispute> {
+        let effective_limit = limit.min(50);
+        let counter: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentCounter)
+            .unwrap_or(0);
+
+        let mut result = Vec::new(&env);
+        let mut matched: u32 = 0;
+        for payment_id in 0..counter {
+            let payment: Payment = match env.storage().persistent().get(&DataKey::Payment(payment_id)) {
+                Some(p) => p,
+                None => continue,
+            };
+            if payment.merchant != merchant {
+                continue;
+            }
+            let dispute: Dispute = match env.storage().temporary().get(&DataKey::Dispute(payment_id)) {
+                Some(d) => d,
+                None => continue,
+            };
+            if matched >= offset && result.len() < effective_limit {
+                result.push_back(dispute);
+            }
+            matched += 1;
+        }
+        result
+    }
+
     pub fn get_dispute_timeout(env: Env) -> u64 {
         env.storage()
             .instance()
@@ -10470,6 +10509,9 @@ impl AhjoorPaymentsContract {
             .unwrap_or(Vec::new(&env))
     }
 }
+
+#[cfg(test)]
+mod test_disputes_by_merchant;
 
 #[cfg(test)]
 mod test_tip;

--- a/contracts/ahjoor-payments/src/test_disputes_by_merchant.rs
+++ b/contracts/ahjoor-payments/src/test_disputes_by_merchant.rs
@@ -1,0 +1,108 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup() -> (Env, AhjoorPaymentsContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AhjoorPaymentsContract, ());
+    let client = AhjoorPaymentsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let fee_recipient = Address::generate(&env);
+
+    let token_addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    client.initialize(&admin, &fee_recipient, &0);
+
+    (env, client, admin, token_addr)
+}
+
+fn disputed_payment(
+    env: &Env,
+    client: &AhjoorPaymentsContractClient<'static>,
+    token_addr: &Address,
+    customer: &Address,
+    merchant: &Address,
+) -> u32 {
+    let token_admin = TokenAdminClient::new(env, token_addr);
+    token_admin.mint(customer, &1_000_000);
+
+    let payment_id = client.create_payment(
+        customer, merchant, &500_000, token_addr, &None, &None, &None,
+    );
+    client.dispute_payment(
+        customer,
+        &payment_id,
+        &String::from_str(env, "Goods not received"),
+    );
+    payment_id
+}
+
+#[test]
+fn test_returns_only_given_merchants_disputes() {
+    let (env, client, _admin, token_addr) = setup();
+    let customer = Address::generate(&env);
+    let merchant_a = Address::generate(&env);
+    let merchant_b = Address::generate(&env);
+
+    let pid_a = disputed_payment(&env, &client, &token_addr, &customer, &merchant_a);
+    let _pid_b = disputed_payment(&env, &client, &token_addr, &customer, &merchant_b);
+
+    let disputes_a = client.list_disputes_by_merchant(&merchant_a, &0, &10);
+    assert_eq!(disputes_a.len(), 1);
+    assert_eq!(disputes_a.get(0).unwrap().payment_id, pid_a);
+}
+
+#[test]
+fn test_merchant_with_no_disputes_returns_empty_vec() {
+    let (env, client, _admin, _token_addr) = setup();
+    let merchant = Address::generate(&env);
+
+    let disputes = client.list_disputes_by_merchant(&merchant, &0, &10);
+    assert_eq!(disputes.len(), 0);
+}
+
+#[test]
+fn test_pagination_spans_multiple_pages() {
+    let (env, client, _admin, token_addr) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let mut expected_ids = soroban_sdk::Vec::new(&env);
+    for _ in 0..5 {
+        expected_ids.push_back(disputed_payment(
+            &env,
+            &client,
+            &token_addr,
+            &customer,
+            &merchant,
+        ));
+    }
+
+    // Page through 2 at a time.
+    let page_0 = client.list_disputes_by_merchant(&merchant, &0, &2);
+    let page_1 = client.list_disputes_by_merchant(&merchant, &2, &2);
+    let page_2 = client.list_disputes_by_merchant(&merchant, &4, &2);
+
+    assert_eq!(page_0.len(), 2);
+    assert_eq!(page_1.len(), 2);
+    assert_eq!(page_2.len(), 1);
+
+    let mut collected: soroban_sdk::Vec<u32> = soroban_sdk::Vec::new(&env);
+    for d in page_0.iter() {
+        collected.push_back(d.payment_id);
+    }
+    for d in page_1.iter() {
+        collected.push_back(d.payment_id);
+    }
+    for d in page_2.iter() {
+        collected.push_back(d.payment_id);
+    }
+
+    assert_eq!(collected, expected_ids);
+}

--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -279,6 +279,9 @@ pub enum DataKey2 {
     BlockDurationLedgers,
     /// Ledger window for detecting rapid submissions
     RapidSubmissionWindowLedgers,
+    /// Vec<Address> of every customer who has ever had an abuse record
+    /// touched, used to drive `list_abuse_flagged_customers` (#580).
+    AbuseTrackedCustomers,
 
     // --- Feature: Cross-Contract Refund Registration ---
     /// Vec<Address> of whitelisted origin contracts
@@ -426,6 +429,19 @@ const DEFAULT_MAX_VOUCHER_BONUS_BPS: u32 = 1_000;
 pub struct BatchRefundResult {
     pub processed: Vec<u32>,
     pub skipped: Vec<u32>,
+}
+
+/// Combined reserve balance view across both parallel reserve subsystems (#579).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReserveSummary {
+    pub merchant: Address,
+    /// Legacy (#274) reserve balance held under `DataKey::MerchantReserve`.
+    pub legacy_reserve_balance: i128,
+    /// Canonical (#334) reserve balance held under `DataKey2::MerchantReserveBalance`.
+    pub merchant_reserve_balance: i128,
+    /// Sum of both subsystems' balances.
+    pub total_reserve_balance: i128,
 }
 
 /// Optional extended configuration for `initialize`.
@@ -4767,6 +4783,45 @@ impl AhjoorRefundContract {
         Self::load_abuse_record_with_decay(&env, &customer)
     }
 
+    /// #580: Admin view of customers currently above the abuse block
+    /// threshold (with lazy decay applied), correctly paginated.
+    /// A customer reset via `reset_customer_abuse_score` drops out of this
+    /// view since their decayed score falls back below the threshold.
+    /// Returns an empty vec if no threshold is configured. `limit` is
+    /// capped at 50 per call.
+    pub fn list_abuse_flagged_customers(
+        env: Env,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<(Address, RefundAbuseRecord)> {
+        let effective_limit = limit.min(50);
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey2::AbuseBlockThreshold)
+            .unwrap_or(u32::MAX);
+
+        let tracked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::AbuseTrackedCustomers)
+            .unwrap_or(Vec::new(&env));
+
+        let mut result = Vec::new(&env);
+        let mut matched: u32 = 0;
+        for customer in tracked.iter() {
+            let record = Self::load_abuse_record_with_decay(&env, &customer);
+            if record.abuse_score < threshold {
+                continue;
+            }
+            if matched >= offset && result.len() < effective_limit {
+                result.push_back((customer, record));
+            }
+            matched += 1;
+        }
+        result
+    }
+
     // ─── #355: Configurable Abuse Score Decay ────────────────────────────────
 
     /// Admin configures the exponential decay parameters for the abuse score system.
@@ -4962,7 +5017,30 @@ impl AhjoorRefundContract {
         }
     }
 
+    /// Adds `customer` to the registry of customers ever tracked by the
+    /// abuse-score system, used by `list_abuse_flagged_customers` (#580).
+    /// No-op if already tracked.
+    fn track_abuse_customer(env: &Env, customer: &Address) {
+        let mut tracked: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::AbuseTrackedCustomers)
+            .unwrap_or(Vec::new(env));
+        if !tracked.contains(customer) {
+            tracked.push_back(customer.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey2::AbuseTrackedCustomers, &tracked);
+            env.storage().persistent().extend_ttl(
+                &DataKey2::AbuseTrackedCustomers,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        }
+    }
+
     fn update_abuse_on_request(env: &Env, customer: &Address, current_seq: u32, rapid_window: u32) {
+        Self::track_abuse_customer(env, customer);
         let old_record = Self::load_abuse_record_with_decay(env, customer);
         let mut record = old_record.clone();
         record.total_requests += 1;
@@ -4985,6 +5063,7 @@ impl AhjoorRefundContract {
     }
 
     fn increment_abuse_score(env: &Env, customer: &Address, delta: u32, is_elevated: bool) {
+        Self::track_abuse_customer(env, customer);
         // Load with in-memory decay applied (does NOT write to storage)
         let old_record = Self::load_abuse_record_with_decay(env, customer);
         let mut record = old_record.clone();
@@ -5485,6 +5564,34 @@ impl AhjoorRefundContract {
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 
         legacy_balance
+    }
+
+    /// #579: Combined reserve balance view across both parallel reserve
+    /// subsystems — the legacy (#274) `*_reserve` balances and the
+    /// canonical (#334) `*_merchant_reserve` balances. Reports both side by
+    /// side so a merchant/admin has one place to check reserve status
+    /// without querying each subsystem separately. See
+    /// `migrate_merchant_reserve` (#585) to consolidate the two into one.
+    /// A merchant with no activity in either subsystem gets zeroed values.
+    pub fn get_reserve_balance_summary(env: Env, merchant: Address) -> ReserveSummary {
+        let legacy_reserve_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MerchantReserve(merchant.clone()))
+            .unwrap_or(0);
+        let merchant_reserve_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey2::MerchantReserveBalance(merchant.clone()))
+            .unwrap_or(0);
+        let total_reserve_balance = legacy_reserve_balance + merchant_reserve_balance;
+
+        ReserveSummary {
+            merchant,
+            legacy_reserve_balance,
+            merchant_reserve_balance,
+            total_reserve_balance,
+        }
     }
 
     pub fn set_merchant_response_deadline(

--- a/contracts/ahjoor-refund/src/test_abuse_score.rs
+++ b/contracts/ahjoor-refund/src/test_abuse_score.rs
@@ -238,3 +238,91 @@ fn test_block_expiry_allows_new_requests() {
     // Should not panic
     refund_client.request_refund(&customer, &pid, &100, &String::from_str(&env, "ok"), &0);
 }
+
+// --- #580: list_abuse_flagged_customers ---
+
+#[test]
+fn test_list_abuse_flagged_customers_only_above_threshold() {
+    let (env, refund_client, payment_client, admin, token_addr, _tc, token_admin) = setup_abuse();
+    let flagged_customer = Address::generate(&env);
+    let unflagged_customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    // 3 rejections push flagged_customer's score to 30 (>= threshold of 30).
+    for _ in 0..3 {
+        let pid = make_payment(&env, &payment_client, &token_admin, &flagged_customer, &merchant, &token_addr, 1000);
+        token_admin.mint(&flagged_customer, &100);
+        let rid = refund_client.request_refund(
+            &flagged_customer, &pid, &100, &String::from_str(&env, "bad"), &0,
+        );
+        refund_client.reject_refund(&admin, &rid, &String::from_str(&env, "no"));
+    }
+
+    // A single rejection leaves unflagged_customer's score at 10 (< threshold).
+    let pid = make_payment(&env, &payment_client, &token_admin, &unflagged_customer, &merchant, &token_addr, 1000);
+    token_admin.mint(&unflagged_customer, &100);
+    let rid = refund_client.request_refund(
+        &unflagged_customer, &pid, &100, &String::from_str(&env, "bad"), &0,
+    );
+    refund_client.reject_refund(&admin, &rid, &String::from_str(&env, "no"));
+
+    let flagged = refund_client.list_abuse_flagged_customers(&0, &10);
+    assert_eq!(flagged.len(), 1);
+    assert_eq!(flagged.get(0).unwrap().0, flagged_customer);
+}
+
+#[test]
+fn test_reset_customer_no_longer_appears_in_flagged_list() {
+    let (env, refund_client, payment_client, admin, token_addr, _tc, token_admin) = setup_abuse();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    for _ in 0..3 {
+        let pid = make_payment(&env, &payment_client, &token_admin, &customer, &merchant, &token_addr, 1000);
+        token_admin.mint(&customer, &100);
+        let rid = refund_client.request_refund(
+            &customer, &pid, &100, &String::from_str(&env, "bad"), &0,
+        );
+        refund_client.reject_refund(&admin, &rid, &String::from_str(&env, "no"));
+    }
+
+    assert_eq!(refund_client.list_abuse_flagged_customers(&0, &10).len(), 1);
+
+    refund_client.reset_customer_abuse_score(&admin, &customer);
+
+    assert_eq!(refund_client.list_abuse_flagged_customers(&0, &10).len(), 0);
+}
+
+#[test]
+fn test_list_abuse_flagged_customers_pagination() {
+    let (env, refund_client, payment_client, admin, token_addr, _tc, token_admin) = setup_abuse();
+    let merchant = Address::generate(&env);
+
+    let mut customers = soroban_sdk::Vec::new(&env);
+    for _ in 0..4 {
+        let customer = Address::generate(&env);
+        for _ in 0..3 {
+            let pid = make_payment(&env, &payment_client, &token_admin, &customer, &merchant, &token_addr, 1000);
+            token_admin.mint(&customer, &100);
+            let rid = refund_client.request_refund(
+                &customer, &pid, &100, &String::from_str(&env, "bad"), &0,
+            );
+            refund_client.reject_refund(&admin, &rid, &String::from_str(&env, "no"));
+        }
+        customers.push_back(customer);
+    }
+
+    let page1 = refund_client.list_abuse_flagged_customers(&0, &2);
+    let page2 = refund_client.list_abuse_flagged_customers(&2, &2);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page2.len(), 2);
+
+    let mut collected = soroban_sdk::Vec::new(&env);
+    for (customer, _record) in page1.iter() {
+        collected.push_back(customer);
+    }
+    for (customer, _record) in page2.iter() {
+        collected.push_back(customer);
+    }
+    assert_eq!(collected, customers);
+}

--- a/contracts/ahjoor-refund/src/test_reserve_fund.rs
+++ b/contracts/ahjoor-refund/src/test_reserve_fund.rs
@@ -154,3 +154,72 @@ fn test_migrate_merchant_reserve_no_legacy_balance_is_noop() {
     let migrated = client.migrate_merchant_reserve(&admin, &merchant);
     assert_eq!(migrated, 0i128);
 }
+
+// --- #579: Combined reserve balance summary ---
+
+#[test]
+fn test_reserve_balance_summary_no_activity_is_zeroed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    let summary = client.get_reserve_balance_summary(&merchant);
+    assert_eq!(summary.legacy_reserve_balance, 0i128);
+    assert_eq!(summary.merchant_reserve_balance, 0i128);
+    assert_eq!(summary.total_reserve_balance, 0i128);
+}
+
+#[test]
+fn test_reserve_balance_summary_reflects_both_subsystems() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup(&env);
+    let merchant = Address::generate(&env);
+    let (token_addr, token_admin) = make_token(&env, &admin);
+    let token_client = TokenClient::new(&env, &token_addr);
+
+    token_admin.mint(&merchant, &2000i128);
+
+    // Legacy (#274) balance via deposit_reserve.
+    client.deposit_reserve(&merchant, &token_addr, &300i128);
+
+    // Canonical (#334) balance via deposit_merchant_reserve (seeded as in
+    // `test_migrate_merchant_reserve_moves_legacy_into_canonical` above).
+    env.as_contract(&client.address, || {
+        env.storage()
+            .instance()
+            .set(&crate::DataKey2::ReserveToken, &token_addr);
+    });
+    token_client.approve(
+        &merchant,
+        &client.address,
+        &200i128,
+        &(env.ledger().sequence() + 1000),
+    );
+    client.deposit_merchant_reserve(&merchant, &200i128);
+
+    let summary = client.get_reserve_balance_summary(&merchant);
+    assert_eq!(summary.legacy_reserve_balance, 300i128);
+    assert_eq!(summary.merchant_reserve_balance, 200i128);
+    assert_eq!(summary.total_reserve_balance, 500i128);
+}
+
+#[test]
+fn test_reserve_balance_summary_activity_in_only_one_system() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup(&env);
+    let merchant = Address::generate(&env);
+    let (token_addr, token_admin) = make_token(&env, &admin);
+
+    token_admin.mint(&merchant, &2000i128);
+
+    // Only the legacy (#274) subsystem has activity.
+    client.deposit_reserve(&merchant, &token_addr, &150i128);
+
+    let summary = client.get_reserve_balance_summary(&merchant);
+    assert_eq!(summary.legacy_reserve_balance, 150i128);
+    assert_eq!(summary.merchant_reserve_balance, 0i128);
+    assert_eq!(summary.total_reserve_balance, 150i128);
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Welcome to the Ahjoor contract documentation directory. Below is a structured in
 
 - [**Cosigner Guarantee in ROSCA**](rosca-cosigner-guarantee.md) — Overview of co-signer nomination, acceptance, and default coverage logic for community savings groups.
 - [**Contribution Delegation in ROSCA**](rosca-contribution-delegation.md) — Overview of contribution and voting weight delegation, proxy execution, limits, and revocation.
+- [**Co-Payer Contribution Splitting in ROSCA**](rosca-co-payer-splitting.md) — How co-payers are registered for a member's slot, how the split ratio is set and enforced, and what happens if a co-payer fails to contribute.
 
 ---
 

--- a/docs/rosca-co-payer-splitting.md
+++ b/docs/rosca-co-payer-splitting.md
@@ -1,0 +1,115 @@
+# Co-Payer Contribution Splitting in ROSCA
+
+This document explains how a `ahjoor-rosca` member can split their per-round
+contribution obligation across one or more co-payers, so that other addresses
+cover part (or all) of the member's slot payment on their behalf.
+
+---
+
+## 1. How Co-Payers Are Registered for a Member's Slot
+
+A member registers their own co-payer split by calling:
+
+```rust
+register_co_payer_splits(member: Address, splits: Vec<CoPayerSplit>)
+```
+
+```rust
+pub struct CoPayerSplit {
+    pub co_payer: Address,
+    pub amount: i128,
+}
+```
+
+- **Authentication:** The transaction must be signed and authorized by the
+  `member` themselves (`require_auth()`). A co-payer cannot register a split
+  on behalf of a member.
+- **Membership Check:** `member` must be an active, registered member of the
+  ROSCA group (not previously exited).
+- **One Active Split Per Member:** A member may only have one registered
+  split at a time. Calling `register_co_payer_splits` while a split is
+  already on file panics with `CopayerSplitsAlreadySet`; the member must
+  call `revoke_co_payer_splits` first before registering a new one.
+- **Amount Validation:** Every `CoPayerSplit.amount` must be strictly
+  positive (`Error::AmountMustBePositive`), and the sum of all split amounts
+  must exactly equal the member's required contribution for the round
+  (`base_amount × tier_bps / 10_000`, i.e. the member's tier-adjusted
+  contribution). Any mismatch panics with `CopayerAmountsMismatch`.
+- On success, the split list is stored under `DataKey3::CoPayerSplits(member)`
+  and a `CoPayerSplitRegistered` event is emitted with the co-payer count and
+  total split amount.
+
+Registered splits can be read back at any time with:
+
+```rust
+get_co_payer_splits(member: Address) -> Vec<CoPayerSplit>
+```
+
+which returns an empty vector if no split is registered.
+
+## 2. How the Split Ratio Is Set and Enforced
+
+The "ratio" between co-payers is simply the set of exact token amounts each
+`CoPayerSplit` specifies — there is no implicit percentage; the member
+chooses the exact amount each co-payer will contribute when the split is
+registered. Enforcement happens at two points:
+
+1. **Registration time:** the amounts must sum to exactly the member's
+   required contribution (see above), so the split always fully covers the
+   member's obligation for the round.
+2. **Contribution time:** the member (or anyone triggering the flow on the
+   member's behalf) calls:
+
+   ```rust
+   contribute_split(member: Address, token: Address)
+   ```
+
+   - Requires `member.require_auth()`.
+   - Panics with `GroupNotYetActive` if the group has not reached its
+     configured start time yet, `NotAMember`/`MemberHasExited` if `member`
+     is not an active member, and `TokenNotApproved` if `token` is not on
+     the group's approved-token list — the same guards the standard
+     contribution flow enforces.
+   - Panics with `NoCopayersRegistered` if no split exists for `member`.
+   - Panics with `Error::AlreadyContributed` if the member already paid for
+     the current round.
+   - For each `CoPayerSplit` in the registered list, the contract calls
+     `token_client.transfer(&split.co_payer, &contract, &split.amount)` —
+     tokens move **directly from each co-payer to the contract**. Each
+     co-payer must have pre-approved (via `approve`) the contract to transfer
+     at least `split.amount` of the token before this call.
+   - Once all transfers succeed, `member` is marked as paid for the round,
+     the sum of transfers is recorded as the member's contribution amount,
+     and a `CoPayerContributed` event is emitted per co-payer plus a regular
+     contribution event for the member.
+
+A member can remove their registered split entirely with:
+
+```rust
+revoke_co_payer_splits(member: Address)
+```
+
+which requires the member's own authorization, panics with
+`NoCopayersRegistered` if nothing is registered, and emits
+`CoPayerSplitRevoked`.
+
+## 3. What Happens If One Co-Payer Fails to Contribute
+
+`contribute_split` transfers from every co-payer in the split list within a
+single contract invocation. Soroban token transfers panic if the source
+account has not approved a sufficient allowance (or lacks sufficient
+balance). Because all state changes in one contract call are atomic:
+
+- If **any** co-payer's transfer fails (missing/insufficient allowance,
+  insufficient balance, etc.), the entire `contribute_split` call reverts.
+- **No partial contribution is recorded** — the member is not marked as
+  paid, no funds move from the co-payers who *would* have succeeded, and no
+  events are emitted for that call.
+- The member remains unpaid for the round until `contribute_split` is
+  retried successfully (e.g. after the failing co-payer grants/tops up their
+  allowance), or the member falls back to paying directly via the standard
+  contribution flow, or revokes the split and re-registers a different one.
+
+This "all co-payers succeed or none do" semantics avoids a co-payer being
+charged for a contribution that ultimately doesn't cover the member's full
+obligation.


### PR DESCRIPTION
## Summary

Closes #523
Closes #565
Closes #579
Closes #580

- **#565** — `ahjoor-payments`: add `list_disputes_by_merchant(merchant, offset, limit) -> Vec<Dispute>` so merchants/admins can page through a merchant's disputes without off-chain event indexing. Only disputes still present in temporary storage are returned; a resolved dispute naturally drops out once it expires.
- **#579** — `ahjoor-refund`: add `get_reserve_balance_summary(merchant) -> ReserveSummary`, reporting the legacy (`*_reserve`, #274) and canonical (`*_merchant_reserve`, #334) balances side by side plus their total, giving one place to check combined reserve status.
- **#580** — `ahjoor-refund`: add `list_abuse_flagged_customers(offset, limit) -> Vec<(Address, RefundAbuseRecord)>` for customers currently at/above the configured abuse threshold (lazy decay applied), backed by a new `DataKey2::AbuseTrackedCustomers` registry. Customers reset via `reset_customer_abuse_score` drop out of the list once their decayed score falls back below threshold.
- **#523** — docs: add `docs/rosca-co-payer-splitting.md` documenting how ROSCA co-payer splits are registered (`register_co_payer_splits`), how amounts are enforced at registration and contribution time (`contribute_split`), and the all-or-nothing semantics if a co-payer fails to contribute; linked from `docs/README.md`.

### Unrelated pre-existing fix included

While implementing #565, `cargo test`/`cargo build` for `ahjoor-payments` failed on `main` at `caacbad` — independent of these changes (verified by stashing and testing HEAD directly). The `#[contracterror] Error` and `#[contracttype] DataKey2` enums in `contracts/ahjoor-payments/src/lib.rs` had both grown to 52 variants, 2 over Soroban's hard 50-variant-per-enum cap, breaking compilation of the crate (and transitively `ahjoor-refund`, which dev-depends on it for tests).

This is fixed in a separate, clearly-labeled commit (`fix(payments): split overflowed Error/DataKey2 enums to unblock CI`) by moving the two most-recently-added variants of each enum into the existing `DataKey3` overflow enum and a new `Error2` overflow enum, mirroring the pattern the codebase already uses for `DataKey3`. No discriminant values or storage semantics changed — only which enum a variant lives in. All call sites updated.

## Testing/validation performed

- `cargo test --manifest-path contracts/ahjoor-payments/Cargo.toml` — 373 passed, 0 failed
- `cargo test --manifest-path contracts/ahjoor-refund/Cargo.toml` — 138 passed, 0 failed
- `cargo check --workspace` — clean (only pre-existing warnings, unrelated to this change)
- `cargo build --manifest-path contracts/ahjoor-payments/Cargo.toml` / `...ahjoor-refund...` — no errors
- New tests added: merchant-scoped/paginated dispute listing (incl. multi-page pagination), reserve summary for no-activity/single-subsystem/both-subsystems cases, and abuse-flagged pagination including the reset-drops-from-list case.
- Note: `cargo build --target wasm32-unknown-unknown --release` could not be run locally (target not installed in this sandbox, and dependency installation was out of scope for this task); CI installs this target explicitly via `dtolnay/rust-toolchain`, so this step is expected to succeed there.

## Risks / follow-ups

- The `Error`/`DataKey2` overflow fix touches storage-key/error-code enum layout in `ahjoor-payments`, outside the scope of the 4 linked issues but required for any of this branch's work to actually compile and pass CI — flagged here for visibility during review.
- `docs/rosca-co-payer-splitting.md` documents `register_co_payer_splits`/`contribute_split`/etc., which exist and are implemented in `ahjoor-rosca`, but currently have no dedicated test coverage in the repo (the `test_co_payer_split.rs` referenced by #523's problem statement is not present — it's commented out in `lib.rs` as "source file not yet committed"). Documentation was verified directly against the implementation instead. Adding that test coverage is out of scope for this docs-only issue but worth a follow-up.