### PR TITLE
fix/feat: validate max members cast, governance config getter, close_round event, counter-offer history

### DIFF
--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -330,6 +330,8 @@ pub enum DataKey2 {
     // --- Feature: Evidence Hash Anchoring (#365) ---
     /// On-chain SHA-256 content hash anchor per (refund_id, submitter) (#365)
     EvidenceHash(u32, Address),
+    /// Ordered history of counter-offer rounds for a refund (Vec<CounterOffer>)
+    CounterOfferHistory(u32),
 }
 
 mod events;
@@ -3527,7 +3529,10 @@ impl AhjoorRefundContract {
     }
 
     /// Merchant submits a counter-offer (partial amount) for a refund request.
-    /// Only one counter-offer is permitted per refund.
+    ///
+    /// The first offer requires `Requested` status. Subsequent offers while the
+    /// refund is still `CounterOffered` replace the live offer and append to
+    /// the negotiation history so multi-round bargaining is queryable.
     pub fn counter_offer_refund(env: Env, merchant: Address, refund_id: u32, amount: i128) {
         Self::require_not_paused(&env);
         merchant.require_auth();
@@ -3542,8 +3547,10 @@ impl AhjoorRefundContract {
             .get(&DataKey::Refund(refund_id))
             .expect("Refund not found");
 
-        if refund.status != RefundStatus::Requested {
-            panic!("Refund is not in Requested state");
+        if refund.status != RefundStatus::Requested
+            && refund.status != RefundStatus::CounterOffered
+        {
+            panic!("Refund is not open for counter-offer");
         }
 
         if merchant != refund.merchant {
@@ -3552,15 +3559,6 @@ impl AhjoorRefundContract {
 
         if amount > refund.amount {
             panic!("Counter-offer cannot exceed original refund amount");
-        }
-
-        // Prevent duplicate counter-offers
-        if env
-            .storage()
-            .persistent()
-            .has(&DataKey::CounterOffer(refund_id))
-        {
-            panic!("Counter-offer already submitted for this refund");
         }
 
         let expiry_seconds: u64 = env
@@ -3581,6 +3579,21 @@ impl AhjoorRefundContract {
             .set(&DataKey::CounterOffer(refund_id), &offer);
         env.storage().persistent().extend_ttl(
             &DataKey::CounterOffer(refund_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        // Append to negotiation history (preserved after accept/reject).
+        let history_key = DataKey2::CounterOfferHistory(refund_id);
+        let mut history: Vec<CounterOffer> = env
+            .storage()
+            .persistent()
+            .get(&history_key)
+            .unwrap_or(Vec::new(&env));
+        history.push_back(offer.clone());
+        env.storage().persistent().set(&history_key, &history);
+        env.storage().persistent().extend_ttl(
+            &history_key,
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
         );
@@ -3739,6 +3752,15 @@ impl AhjoorRefundContract {
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
         );
+    }
+
+    /// Returns every counter-offer round for `refund_id` in submission order.
+    /// Refunds with no negotiation return an empty vec.
+    pub fn get_counter_offer_history(env: Env, refund_id: u32) -> Vec<CounterOffer> {
+        env.storage()
+            .persistent()
+            .get(&DataKey2::CounterOfferHistory(refund_id))
+            .unwrap_or(Vec::new(&env))
     }
 
     // --- Issue #238: Refund Priority Labelling ---

--- a/contracts/ahjoor-refund/src/test_counter_offer.rs
+++ b/contracts/ahjoor-refund/src/test_counter_offer.rs
@@ -111,17 +111,92 @@ fn test_counter_offer_expiry_escalates() {
 }
 
 // ---------------------------------------------------------------------------
-// Test: duplicate counter-offer rejected
+// Test: subsequent counter-offers while CounterOffered update the live offer
 // ---------------------------------------------------------------------------
 #[test]
-#[should_panic(expected = "Refund is not in Requested state")]
-fn test_duplicate_counter_offer_rejected() {
-    let (_env, refund_client, _, _admin, _customer, merchant, _token_addr, _token_client, _) = setup_counter_offer();
+fn test_subsequent_counter_offer_updates_live_offer() {
+    let (_env, refund_client, _, _admin, _customer, merchant, _token_addr, _token_client, _) =
+        setup_counter_offer();
     let refund_id = 0u32;
 
     refund_client.counter_offer_refund(&merchant, &refund_id, &600);
-    // Second counter-offer should panic
     refund_client.counter_offer_refund(&merchant, &refund_id, &400);
+
+    let history = refund_client.get_counter_offer_history(&refund_id);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().amount, 600);
+    assert_eq!(history.get(1).unwrap().amount, 400);
+}
+
+// ---------------------------------------------------------------------------
+// Test: get_counter_offer_history empty when no negotiation
+// ---------------------------------------------------------------------------
+#[test]
+fn test_get_counter_offer_history_empty_without_negotiation() {
+    let (_env, refund_client, _, _admin, _customer, _merchant, _token_addr, _token_client, _) =
+        setup_counter_offer();
+    let refund_id = 0u32;
+
+    let history = refund_client.get_counter_offer_history(&refund_id);
+    assert_eq!(history.len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Test: multi-round negotiation ending in acceptance
+// ---------------------------------------------------------------------------
+#[test]
+fn test_counter_offer_history_multi_round_accept() {
+    let (_env, refund_client, _, _admin, customer, merchant, _token_addr, token_client, _) =
+        setup_counter_offer();
+    let refund_id = 0u32;
+
+    refund_client.counter_offer_refund(&merchant, &refund_id, &800);
+    refund_client.counter_offer_refund(&merchant, &refund_id, &600);
+    refund_client.counter_offer_refund(&merchant, &refund_id, &500);
+
+    let history = refund_client.get_counter_offer_history(&refund_id);
+    assert_eq!(history.len(), 3);
+    assert_eq!(history.get(0).unwrap().amount, 800);
+    assert_eq!(history.get(1).unwrap().amount, 600);
+    assert_eq!(history.get(2).unwrap().amount, 500);
+
+    let bal_before = token_client.balance(&customer);
+    refund_client.accept_counter_offer(&customer, &refund_id);
+
+    let refund = refund_client.get_refund(&refund_id);
+    assert_eq!(refund.status, RefundStatus::Processed);
+    assert_eq!(token_client.balance(&customer), bal_before + 500);
+
+    // History is preserved after acceptance
+    let history_after = refund_client.get_counter_offer_history(&refund_id);
+    assert_eq!(history_after.len(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Test: multi-round negotiation ending in rejection
+// ---------------------------------------------------------------------------
+#[test]
+fn test_counter_offer_history_multi_round_reject() {
+    let (_env, refund_client, _, _admin, customer, merchant, _token_addr, _token_client, _) =
+        setup_counter_offer();
+    let refund_id = 0u32;
+
+    refund_client.counter_offer_refund(&merchant, &refund_id, &700);
+    refund_client.counter_offer_refund(&merchant, &refund_id, &450);
+
+    let history = refund_client.get_counter_offer_history(&refund_id);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().amount, 700);
+    assert_eq!(history.get(1).unwrap().amount, 450);
+
+    refund_client.reject_counter_offer(&customer, &refund_id);
+
+    let refund = refund_client.get_refund(&refund_id);
+    assert_eq!(refund.status, RefundStatus::UnderAppeal);
+
+    // History is preserved after rejection
+    let history_after = refund_client.get_counter_offer_history(&refund_id);
+    assert_eq!(history_after.len(), 2);
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/ahjoor-rosca/src/events.rs
+++ b/contracts/ahjoor-rosca/src/events.rs
@@ -42,6 +42,16 @@ pub struct RoundClosed {
     pub defaulters: Vec<Address>,
 }
 
+/// Event: Round closed via `close_round` without a preceding `finalize_round`.
+///
+/// Distinguishes an admin-only state advance (no pot payout / audit trail)
+/// from the normal finalize-then-reset flow.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct RoundClosedWithoutPayout {
+    pub round: u32,
+}
+
 /// Event: Payout order finalized via randomization (#315)
 #[contractevent]
 #[derive(Clone, Debug)]
@@ -461,6 +471,10 @@ pub fn emit_milestone(e: &Env, milestone: u32, total_collected: i128) {
 
 pub fn emit_closed(e: &Env, round: u32, defaulters: Vec<Address>) {
     RoundClosed { round, defaulters }.publish(e);
+}
+
+pub fn emit_round_closed_without_payout(e: &Env, round: u32) {
+    RoundClosedWithoutPayout { round }.publish(e);
 }
 
 pub fn emit_payout_order_finalized(e: &Env, round: u32, payout_order: Vec<Address>) {

--- a/contracts/ahjoor-rosca/src/internals.rs
+++ b/contracts/ahjoor-rosca/src/internals.rs
@@ -708,29 +708,34 @@ pub(crate) fn execute_rule_change(env: &Env, new_quorum: Option<i128>) {
 }
 
 /// Updates the maximum member limit if the value is within [1, 100] and >= current count.
+///
+/// Validates the i128 range (including negativity) *before* casting to u32 so a
+/// negative input cannot wrap to a large u32 and rely on a later bounds check.
 pub(crate) fn execute_max_members_update(env: &Env, new_max_val: Option<i128>) {
     if let Some(new_max_i128) = new_max_val {
+        if new_max_i128 < 1 || new_max_i128 > 100 {
+            panic_with_error!(env, Error::InvalidMaxMembers);
+        }
         let new_max = new_max_i128 as u32;
-        if new_max >= 1 && new_max <= 100 {
-            let current_members: Vec<Address> = env
+
+        let current_members: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Members)
+            .unwrap_or(Vec::new(env));
+
+        if new_max >= current_members.len() as u32 {
+            let old_max: u32 = env
                 .storage()
                 .instance()
-                .get(&DataKey::Members)
-                .unwrap_or(Vec::new(env));
+                .get(&DataKey::MaxMembers)
+                .unwrap_or(50);
 
-            if new_max >= current_members.len() as u32 {
-                let old_max: u32 = env
-                    .storage()
-                    .instance()
-                    .get(&DataKey::MaxMembers)
-                    .unwrap_or(50);
+            env.storage()
+                .instance()
+                .set(&DataKey::MaxMembers, &new_max);
 
-                env.storage()
-                    .instance()
-                    .set(&DataKey::MaxMembers, &new_max);
-
-                events::emit_max_members_upd(env, old_max, new_max);
-            }
+            events::emit_max_members_upd(env, old_max, new_max);
         }
     }
 }

--- a/contracts/ahjoor-rosca/src/lib.rs
+++ b/contracts/ahjoor-rosca/src/lib.rs
@@ -1380,6 +1380,9 @@ impl AhjoorContract {
             .get(&DataKey::CurrentRound)
             .unwrap();
         events::emit_closed(&env, current_round, defaulters);
+        // Signal that this round was advanced without finalize_round (no pot
+        // payout / audit trail). The normal finalize_round path does not emit this.
+        events::emit_round_closed_without_payout(&env, current_round);
         env.storage()
             .instance()
             .set(&DataKey4::LastRoundDeadline, &deadline);

--- a/contracts/ahjoor-rosca/src/test.rs
+++ b/contracts/ahjoor-rosca/src/test.rs
@@ -4771,6 +4771,49 @@ fn test_finalize_round_pays_out_partial_contributions() {
     assert_eq!(round, 1);
 }
 
+fn event_topic_present(env: &Env, topic: &str) -> bool {
+    let target = Symbol::new(env, topic);
+    for (_, topics, _) in env.events().all().iter() {
+        let topics_vec: soroban_sdk::Vec<soroban_sdk::Val> = topics.into_val(env);
+        if let Some(first) = topics_vec.first() {
+            let first_sym: Symbol = first.into_val(env);
+            if first_sym == target {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[test]
+fn test_close_round_emits_without_payout_event() {
+    let env = Env::default();
+    let (client, _admin, _u1, _u2, _u3, _tc, _ta) = setup_finalize_env(&env);
+
+    env.ledger().set_timestamp(3601);
+    client.close_round();
+
+    assert!(
+        event_topic_present(&env, "round_closed_without_payout"),
+        "close_round must emit RoundClosedWithoutPayout"
+    );
+}
+
+#[test]
+fn test_finalize_round_does_not_emit_without_payout_event() {
+    let env = Env::default();
+    let (client, _admin, u1, _u2, _u3, _tc, ta) = setup_finalize_env(&env);
+
+    client.contribute(&u1, &ta, &100);
+    env.ledger().set_timestamp(3601);
+    client.finalize_round();
+
+    assert!(
+        !event_topic_present(&env, "round_closed_without_payout"),
+        "finalize_round must not emit RoundClosedWithoutPayout"
+    );
+}
+
 #[test]
 fn test_finalize_round_tracks_defaulters_and_suspends_after_three_misses() {
     let env = Env::default();

--- a/contracts/ahjoor-rosca/src/test_emergency_reserve.rs
+++ b/contracts/ahjoor-rosca/src/test_emergency_reserve.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 use super::*;
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
+    testutils::{Address as _, Events, Ledger},
     token::{Client as TokenClient, StellarAssetClient as TokenAdminClient},
     Address, Env, IntoVal, Symbol,
 };

--- a/contracts/ahjoor-rosca/src/test_new_features.rs
+++ b/contracts/ahjoor-rosca/src/test_new_features.rs
@@ -731,6 +731,74 @@ fn test_max_members_proposal() {
 }
 
 #[test]
+fn test_max_members_proposal_rejects_negative() {
+    let (env, client, admin, token_admin, _, _, members) =
+        setup_with_members(2, 1000);
+
+    client.init(
+        &admin,
+        &members,
+        &100,
+        &token_admin,
+        &3600,
+        &RoscaConfig {
+            strategy: PayoutStrategy::RoundRobin,
+            custom_order: None,
+            penalty_amount: 0,
+            exit_penalty_bps: 0,
+            collective_goal: None,
+            member_goals: None,
+            fee_bps: 0,
+            fee_recipient: None,
+            max_defaults: 3,
+            grace_period_ledgers: 0,
+            use_timestamp_schedule: false,
+            round_duration_seconds: 0,
+            max_members: Some(5),
+            skip_fee: 0,
+            max_skips_per_cycle: 0,
+            voting_mode: VotingMode::Equal,
+            late_fee_bps: 0,
+            grace_period_seconds: 0,
+            auction_enabled: false,
+            auction_window_ledgers: 0,
+            randomize_payout_order: false,
+            reserve_enabled: false,
+            reserve_contribution_bps: 0,
+        },
+        &None,
+    );
+
+    let user1 = members.get(0).unwrap();
+    let user2 = members.get(1).unwrap();
+
+    // Proposal with a negative new_max must be rejected before any u32 cast.
+    client.create_proposal(
+        &user1,
+        &ProposalType::MaxMembersUpdate,
+        &soroban_sdk::String::from_str(&env, "Negative max members"),
+        &user1,
+        &86400,
+        &Some(-1),
+    );
+
+    let proposal_id = 0;
+    client.vote_on_proposal(&user1, &proposal_id, &true);
+    client.vote_on_proposal(&user2, &proposal_id, &true);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86400 * 8);
+
+    let result = client.try_execute_proposal(&proposal_id);
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::InvalidMaxMembers.into()
+    );
+    // Max members must remain unchanged
+    assert_eq!(client.get_max_members(), 5);
+}
+
+#[test]
 fn test_configurable_max_defaults() {
     let (env, client, admin, token_admin, _, _, members) = 
         setup_with_members(2, 1000);

--- a/contracts/ahjoor-token-whitelist/src/lib.rs
+++ b/contracts/ahjoor-token-whitelist/src/lib.rs
@@ -847,6 +847,45 @@ impl TokenWhitelistContract {
         env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 
+    /// Returns the current governance configuration as
+    /// `(governance_token, min_stake, voting_window_ledgers, enactment_delay_ledgers, quorum_bps)`.
+    ///
+    /// Unset scalar values fall back to the same defaults used by proposal/voting
+    /// flows. `governance_token` is `None` until `set_governance_token` is called.
+    pub fn get_governance_config(env: Env) -> (Option<Address>, i128, u32, u32, u32) {
+        let governance_token: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::GovernanceToken);
+        let min_stake: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinProposalStake)
+            .unwrap_or(1);
+        let voting_window_ledgers: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::VotingWindowLedgers)
+            .unwrap_or(DEFAULT_VOTING_WINDOW_LEDGERS);
+        let enactment_delay_ledgers: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EnactmentDelayLedgers)
+            .unwrap_or(DEFAULT_ENACTMENT_DELAY_LEDGERS);
+        let quorum_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::QuorumBps)
+            .unwrap_or(DEFAULT_QUORUM_BPS);
+        (
+            governance_token,
+            min_stake,
+            voting_window_ledgers,
+            enactment_delay_ledgers,
+            quorum_bps,
+        )
+    }
+
     pub fn propose_token_listing(env: Env, proposer: Address, token: Address, rationale_hash: BytesN<32>) -> u32 {
         proposer.require_auth();
         let governance_token: Address = env

--- a/contracts/ahjoor-token-whitelist/src/test_governance.rs
+++ b/contracts/ahjoor-token-whitelist/src/test_governance.rs
@@ -330,3 +330,37 @@ fn test_vote_weight_uses_snapshot_not_live_balance() {
     assert_eq!(proposal.approve_weight, 1_000);
     assert_eq!(proposal.status, ProposalStatus::PendingEnactment);
 }
+
+#[test]
+fn test_get_governance_config_defaults_when_unset() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TokenWhitelistContract, ());
+    let client = TokenWhitelistContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let (gov_token, min_stake, voting_window, enactment_delay, quorum_bps) =
+        client.get_governance_config();
+
+    assert!(gov_token.is_none());
+    assert_eq!(min_stake, 1);
+    assert_eq!(voting_window, 120_960);
+    assert_eq!(enactment_delay, 34_560);
+    assert_eq!(quorum_bps, 5_000);
+}
+
+#[test]
+fn test_get_governance_config_returns_admin_configured_values() {
+    let (_env, _admin, client, gov_token) = setup_governance();
+
+    let (got_token, min_stake, voting_window, enactment_delay, quorum_bps) =
+        client.get_governance_config();
+
+    assert_eq!(got_token, Some(gov_token));
+    assert_eq!(min_stake, 100);
+    assert_eq!(voting_window, 100);
+    assert_eq!(enactment_delay, 50);
+    assert_eq!(quorum_bps, 5_000);
+}


### PR DESCRIPTION
closes #554 
closes #557 
closes #581 
closes #658


### PR description

## Summary
- **ROSCA max members:** Validate `new_max` as `i128` (including negativity / `> 100`) before casting to `u32` in `execute_max_members_update`, panicking with `InvalidMaxMembers` instead of relying on wraparound.
- **Token whitelist:** Add `get_governance_config` returning `(governance_token, min_stake, voting_window_ledgers, enactment_delay_ledgers, quorum_bps)` with the same defaults used by proposal/voting flows when unset.
- **ROSCA close_round:** Emit `RoundClosedWithoutPayout` when `close_round` advances state without payout; `finalize_round` does not emit it.
- **Refund counter-offers:** Persist ordered negotiation history and expose `get_counter_offer_history`; allow subsequent offers while still `CounterOffered` so multi-round bargaining is recorded.

## Changes by task

### Task 1 — `execute_max_members_update` cast-before-validate
- Range-check `new_max_i128` in `[1, 100]` **before** `as u32`.
- Negative / out-of-range values now fail with `Error::InvalidMaxMembers`.
- Test: `test_max_members_proposal_rejects_negative` (existing valid update/proposal tests still pass).

### Task 2 — `get_governance_config`
- New view: `(Option<Address>, i128, u32, u32, u32)`.
- Defaults when unset: `None`, `1`, `120_960`, `34_560`, `5_000`.
- Tests for unset defaults and admin-configured values.

### Task 3 — `close_round` without finalize signal
- New event `RoundClosedWithoutPayout` / `emit_round_closed_without_payout`.
- Emitted from `close_round` only.
- Tests assert presence on `close_round` and absence on `finalize_round`.

### Task 4 — `get_counter_offer_history`
- New `DataKey2::CounterOfferHistory(u32)` storing `Vec<CounterOffer>`.
- Each `counter_offer_refund` appends; history kept after accept/reject.
- Subsequent offers allowed while status is `CounterOffered`.
- Tests: empty history, multi-round accept, multi-round reject.

## Test plan
- [x] `cargo test -p ahjoor-rosca --lib max_members_proposal`
- [x] `cargo test -p ahjoor-rosca --lib without_payout`
- [x] `cargo test -p ahjoor-token-whitelist test_get_governance_config`
- [x] `cargo test -p ahjoor-refund test_counter_offer`