### PR TITLE
feat: add merchant reserve and risk-tier view getters

### DIFF
--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -4129,6 +4129,24 @@ impl AhjoorRefundContract {
             .unwrap_or(0)
     }
 
+    /// Whether a merchant is flagged for reserve non-compliance.
+    /// Returns `false` if the merchant has never been flagged.
+    pub fn is_merchant_flagged(env: Env, merchant: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MerchantFlagged(merchant))
+            .unwrap_or(false)
+    }
+
+    /// Get the recorded payment volume for a merchant.
+    /// Returns `0` if the merchant has no recorded volume.
+    pub fn get_merchant_volume(env: Env, merchant: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MerchantVolume(merchant))
+            .unwrap_or(0)
+    }
+
     /// Record payment volume for a merchant (called when a payment is created).
     /// Adds `amount` to the merchant's tracked volume used for reserve compliance.
     pub fn record_payment_volume(env: Env, merchant: Address, amount: i128) {
@@ -5502,6 +5520,21 @@ impl AhjoorRefundContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    /// Get the active reserve-waiver expiry ledger for a merchant.
+    /// Returns `None` when the merchant has no waiver, or the waiver has expired.
+    pub fn get_reserve_waiver_expiry(env: Env, merchant: Address) -> Option<u32> {
+        let expiry: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey2::ReserveWaiverExpiryLedger(merchant))
+            .unwrap_or(0);
+        if expiry > env.ledger().sequence() {
+            Some(expiry)
+        } else {
+            None
+        }
     }
 
     pub fn set_reserve_config(

--- a/contracts/ahjoor-refund/src/test_reserve_fund.rs
+++ b/contracts/ahjoor-refund/src/test_reserve_fund.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 extern crate std;
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
 
@@ -222,4 +225,78 @@ fn test_reserve_balance_summary_activity_in_only_one_system() {
     assert_eq!(summary.legacy_reserve_balance, 150i128);
     assert_eq!(summary.merchant_reserve_balance, 0i128);
     assert_eq!(summary.total_reserve_balance, 150i128);
+}
+
+// --- Merchant flagged / volume / waiver view getters ---
+
+#[test]
+fn test_is_merchant_flagged_flagged_and_unflagged() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _) = setup(&env);
+    let flagged = Address::generate(&env);
+    let unflagged = Address::generate(&env);
+
+    // Never flagged → false
+    assert!(!client.is_merchant_flagged(&unflagged));
+
+    client.set_reserve_ratio_bps(&admin, &200u32);
+    // Volume = 10000, required = 200, reserve = 0 → non-compliant → flagged
+    client.record_payment_volume(&flagged, &10_000i128);
+    assert!(!client.check_reserve_compliance(&admin, &flagged));
+    assert!(client.is_merchant_flagged(&flagged));
+    assert!(!client.is_merchant_flagged(&unflagged));
+}
+
+#[test]
+fn test_get_merchant_volume_with_and_without_volume() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let with_volume = Address::generate(&env);
+    let without_volume = Address::generate(&env);
+
+    assert_eq!(client.get_merchant_volume(&without_volume), 0i128);
+
+    client.record_payment_volume(&with_volume, &7_500i128);
+    client.record_payment_volume(&with_volume, &2_500i128);
+    assert_eq!(client.get_merchant_volume(&with_volume), 10_000i128);
+    assert_eq!(client.get_merchant_volume(&without_volume), 0i128);
+}
+
+#[test]
+fn test_get_reserve_waiver_expiry_active_expired_and_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _) = setup(&env);
+    let active = Address::generate(&env);
+    let expired = Address::generate(&env);
+    let never = Address::generate(&env);
+
+    assert_eq!(client.get_reserve_waiver_expiry(&never), None);
+
+    let now = env.ledger().sequence();
+    // Seed waiver expiries directly: `waive_reserve_requirement` calls
+    // `admin.require_auth()` twice (once directly, once inside `require_admin`)
+    // and trips soroban-sdk's mock_all_auths duplicate-authorization check.
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &crate::DataKey2::ReserveWaiverExpiryLedger(active.clone()),
+            &(now + 100),
+        );
+        env.storage().instance().set(
+            &crate::DataKey2::ReserveWaiverExpiryLedger(expired.clone()),
+            &(now + 5),
+        );
+    });
+
+    assert_eq!(client.get_reserve_waiver_expiry(&active), Some(now + 100));
+    assert_eq!(client.get_reserve_waiver_expiry(&expired), Some(now + 5));
+    assert_eq!(client.get_reserve_waiver_expiry(&never), None);
+
+    // Advance past the short waiver so it becomes inactive.
+    env.ledger().with_mut(|l| l.sequence_number = now + 10);
+    assert_eq!(client.get_reserve_waiver_expiry(&active), Some(now + 100));
+    assert_eq!(client.get_reserve_waiver_expiry(&expired), None);
+    assert_eq!(client.get_reserve_waiver_expiry(&never), None);
 }

--- a/contracts/ahjoor-token-whitelist/src/lib.rs
+++ b/contracts/ahjoor-token-whitelist/src/lib.rs
@@ -325,6 +325,12 @@ impl TokenWhitelistContract {
         TierLimits { name: soroban_sdk::String::from_str(&env, "tier-default"), max_single_tx_amount: 0, max_daily_volume: 0 }
     }
 
+    /// Get the raw risk-tier definition for `tier_id`.
+    /// Returns `None` if the tier was never defined.
+    pub fn get_risk_tier(env: Env, tier_id: u32) -> Option<TierLimits> {
+        env.storage().instance().get(&DataKey::RiskTier(tier_id))
+    }
+
     pub fn set_token_metadata(env: Env, admin: Address, token: Address, decimals: u32, symbol: soroban_sdk::String, logo_hash: BytesN<32>, canonical_oracle: Option<Address>) {
         admin.require_auth();
         Self::require_admin(&env, &admin);

--- a/contracts/ahjoor-token-whitelist/src/test.rs
+++ b/contracts/ahjoor-token-whitelist/src/test.rs
@@ -628,3 +628,19 @@ fn test_is_whitelisted_cost_is_constant_at_scale() {
         large_whitelist_cost
     );
 }
+
+#[test]
+fn test_get_risk_tier_defined_and_undefined() {
+    let (env, admin, client) = setup_test();
+
+    assert!(client.get_risk_tier(&99u32).is_none());
+
+    let name = soroban_sdk::String::from_str(&env, "standard");
+    client.set_risk_tier(&admin, &2u32, &name, &1_000i128, &50_000i128);
+
+    let tier = client.get_risk_tier(&2u32).expect("tier should be defined");
+    assert_eq!(tier.name, name);
+    assert_eq!(tier.max_single_tx_amount, 1_000i128);
+    assert_eq!(tier.max_daily_volume, 50_000i128);
+    assert!(client.get_risk_tier(&99u32).is_none());
+}


### PR DESCRIPTION
## Summary
Adds public read-only view functions so merchants and dashboards can inspect reserve compliance state and risk-tier definitions without requiring admin-only writes.

### Task 1 — `is_merchant_flagged`
- Adds `is_merchant_flagged(env, merchant) -> bool` on the refund contract.
- Reads `DataKey::MerchantFlagged(Address)` set by `check_reserve_compliance`.
- Returns `false` when the merchant has never been flagged.
- Unit test covers a flagged merchant (failed compliance) and an unflagged one.

### Task 2 — `get_merchant_volume`
- Adds `get_merchant_volume(env, merchant) -> i128`.
- Reads the trailing volume in `DataKey::MerchantVolume(Address)` written by `record_payment_volume`.
- Returns `0` when no volume has been recorded.
- Unit test covers a merchant with accumulated volume and one without.

### Task 3 — `get_reserve_waiver_expiry`
- Adds `get_reserve_waiver_expiry(env, merchant) -> Option<u32>`.
- Reads `DataKey2::ReserveWaiverExpiryLedger(Address)` set by `waive_reserve_requirement`.
- Returns `Some(expiry)` only while the waiver is still active (`expiry > current ledger`); otherwise `None` (never waived or expired).
- Unit test covers active waiver, expired waiver, and no waiver.

### Task 4 — `get_risk_tier`
- Adds `get_risk_tier(env, tier_id) -> Option<TierLimits>` on the token-whitelist contract.
- Returns the raw `TierLimits` stored under `DataKey::RiskTier(tier_id)` by `set_risk_tier`.
- Returns `None` for a tier that was never defined.
- Unit test covers a defined tier and an undefined one.

## Test plan
- [x] `cargo test -p ahjoor-refund is_merchant_flagged`
- [x] `cargo test -p ahjoor-refund get_merchant_volume`
- [x] `cargo test -p ahjoor-refund get_reserve_waiver_expiry`
- [x] `cargo test -p ahjoor-token-whitelist test_get_risk_tier`

closes #654 
closes #655
closes #656 
closes #659