### PR TITLE
feat: implement #660 #661 #569 #657 — get_vote_record, tier_id validation, list_active_consent_records, get_rapid_submission_window

### DIFF
--- a/contracts/ahjoor-errors/src/lib.rs
+++ b/contracts/ahjoor-errors/src/lib.rs
@@ -488,7 +488,7 @@ pub mod refund {
 
 pub mod whitelist {
     /// See [`crate::rosca::COUNT`] for why this exists.
-    pub const COUNT: usize = 8;
+    pub const COUNT: usize = 9;
 
     pub const NOT_INITIALIZED: u32            = 5001;
     pub const ALREADY_INITIALIZED: u32        = 5002;
@@ -498,6 +498,7 @@ pub mod whitelist {
     pub const QUOTA_EXCEEDED: u32             = 5006;
     pub const TOKEN_ALREADY_HAS_QUOTA: u32    = 5007;
     pub const TOKEN_HAS_NO_QUOTA: u32         = 5008;
+    pub const RISK_TIER_NOT_DEFINED: u32     = 5009;
 }
 
 // ---------------------------------------------------------------------------
@@ -943,6 +944,7 @@ pub static ALL_ERRORS: &[ErrorEntry] = &[
     ErrorEntry { code: whitelist::QUOTA_EXCEEDED, name: "QuotaExceeded", contract: "ahjoor-token-whitelist" },
     ErrorEntry { code: whitelist::TOKEN_ALREADY_HAS_QUOTA, name: "TokenAlreadyHasQuota", contract: "ahjoor-token-whitelist" },
     ErrorEntry { code: whitelist::TOKEN_HAS_NO_QUOTA, name: "TokenHasNoQuota", contract: "ahjoor-token-whitelist" },
+    ErrorEntry { code: whitelist::RISK_TIER_NOT_DEFINED, name: "RiskTierNotDefined", contract: "ahjoor-token-whitelist" },
 ];
 
 /// Look up an `ErrorEntry` by its numeric code.

--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -9762,6 +9762,36 @@ impl AhjoorPaymentsContract {
         next_id
     }
 
+    /// Returns all currently-active consent records for `customer`.
+    /// Records are excluded when revoked, expired, or not yet signed.
+    pub fn list_active_consent_records(env: Env, customer: Address) -> Vec<ConsentRecord> {
+        let counter: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey2::ConsentRecordCounter)
+            .unwrap_or(0);
+        let now = env.ledger().sequence() as u64;
+        let mut result = Vec::new(&env);
+        for consent_id in 0..counter {
+            let consent: ConsentRecord = match env
+                .storage()
+                .persistent()
+                .get(&DataKey2::ConsentRecord(consent_id))
+            {
+                Some(c) => c,
+                None => continue,
+            };
+            if consent.customer != customer {
+                continue;
+            }
+            if consent.is_revoked || !consent.is_signed || consent.expires_at <= now {
+                continue;
+            }
+            result.push_back(consent);
+        }
+        result
+    }
+
     /// Retry a failed debit. Enforces the exponential back-off schedule.
     /// Returns `RetryNotDue` if the back-off interval has not elapsed.
     /// On max attempts the record is moved to `AbandonedDebit` status.

--- a/contracts/ahjoor-payments/src/test_consent.rs
+++ b/contracts/ahjoor-payments/src/test_consent.rs
@@ -375,3 +375,74 @@ fn test_multiple_consent_records() {
         true
     );
 }
+
+#[test]
+fn test_list_active_consent_records() {
+    let s = setup();
+    s.init();
+
+    let merchant = Address::generate(&s.env);
+    let customer = Address::generate(&s.env);
+    let other_customer = Address::generate(&s.env);
+    let terms_hash_v1 = make_bytes32(&s.env, 1);
+    let terms_hash_v2 = make_bytes32(&s.env, 2);
+    let terms_hash_v3 = make_bytes32(&s.env, 3);
+    let terms_version_v1 = make_string(&s.env, "v1.0");
+    let terms_version_v2 = make_string(&s.env, "v2.0");
+    let terms_version_v3 = make_string(&s.env, "v3.0");
+    let expiry_ledger: u64 = u64::from(s.env.ledger().sequence()) + 1000;
+
+    // Create 3 consent records for customer: one active, one revoked, one unsigned
+    let consent_active = s.client.create_consent_record(
+        &merchant,
+        &customer,
+        &terms_hash_v1,
+        &terms_version_v1,
+        &expiry_ledger,
+    );
+    let consent_revoked = s.client.create_consent_record(
+        &merchant,
+        &customer,
+        &terms_hash_v2,
+        &terms_version_v2,
+        &expiry_ledger,
+    );
+    let consent_unsigned = s.client.create_consent_record(
+        &merchant,
+        &customer,
+        &terms_hash_v3,
+        &terms_version_v3,
+        &expiry_ledger,
+    );
+
+    // Also create a record for a different customer
+    let consent_other = s.client.create_consent_record(
+        &merchant,
+        &other_customer,
+        &terms_hash_v1,
+        &terms_version_v1,
+        &expiry_ledger,
+    );
+
+    // Sign the active and revoked record; leave unsigned unsigned
+    s.client.sign_consent(&customer, &consent_active);
+    s.client.sign_consent(&customer, &consent_revoked);
+
+    // Revoke the second record
+    s.client.revoke_consent(&merchant, &consent_revoked);
+
+    // List active records for customer
+    let active = s.client.list_active_consent_records(&customer);
+    assert_eq!(active.len(), 1);
+    assert_eq!(active.get(0).unwrap().id, consent_active);
+
+    // The other customer's record should not appear
+    for record in active.iter() {
+        assert_eq!(record.customer, customer);
+    }
+
+    // List active records for the other customer
+    let active_other = s.client.list_active_consent_records(&other_customer);
+    assert_eq!(active_other.len(), 1);
+    assert_eq!(active_other.get(0).unwrap().id, consent_other);
+}

--- a/contracts/ahjoor-refund/src/lib.rs
+++ b/contracts/ahjoor-refund/src/lib.rs
@@ -4916,6 +4916,14 @@ impl AhjoorRefundContract {
             .unwrap_or(5_000u32)
     }
 
+    /// Get the configured rapid-submission window in ledgers (default: 720).
+    pub fn get_rapid_submission_window(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey2::RapidSubmissionWindowLedgers)
+            .unwrap_or(DEFAULT_RAPID_SUBMISSION_WINDOW_LEDGERS)
+    }
+
     // --- Internal abuse-score helpers ---
 
     fn load_abuse_record_with_decay(env: &Env, customer: &Address) -> RefundAbuseRecord {

--- a/contracts/ahjoor-refund/src/test_abuse_score.rs
+++ b/contracts/ahjoor-refund/src/test_abuse_score.rs
@@ -326,3 +326,22 @@ fn test_list_abuse_flagged_customers_pagination() {
     }
     assert_eq!(collected, customers);
 }
+
+#[test]
+fn test_get_rapid_submission_window() {
+    let (env, refund_client, _payment_client, admin, _token, _token_client, _token_admin) =
+        setup_abuse();
+
+    // Default value when not explicitly set
+    let default_client = {
+        let env = Env::default();
+        env.mock_all_auths();
+        let refund_id = env.register(AhjoorRefundContract, ());
+        AhjoorRefundContractClient::new(&env, &refund_id)
+    };
+    assert_eq!(default_client.get_rapid_submission_window(), 720);
+
+    // Explicitly set value
+    refund_client.set_rapid_submission_window(&admin, &500u32);
+    assert_eq!(refund_client.get_rapid_submission_window(), 500);
+}

--- a/contracts/ahjoor-token-whitelist/src/client.rs
+++ b/contracts/ahjoor-token-whitelist/src/client.rs
@@ -81,4 +81,6 @@ pub trait TokenWhitelistInterface {
     fn get_token_suspension(env: Env, token: Address) -> Option<crate::SuspensionRecord>;
 
     fn get_suspension_history(env: Env, token: Address) -> soroban_sdk::Vec<crate::SuspensionHistoryEntry>;
+
+    fn get_vote_record(env: Env, proposal_id: u32, voter: Address) -> Option<bool>;
 }

--- a/contracts/ahjoor-token-whitelist/src/lib.rs
+++ b/contracts/ahjoor-token-whitelist/src/lib.rs
@@ -39,6 +39,7 @@ pub enum Error {
     TokenAlreadyHasQuota = 7,
     TokenHasNoQuota = 8,
     SuspensionExtensionOverflow = 9,
+    RiskTierNotDefined = 10,
 }
 
 #[contracttype]
@@ -296,6 +297,9 @@ impl TokenWhitelistContract {
     pub fn assign_token_tier(env: Env, admin: Address, token: Address, tier_id: u32) {
         admin.require_auth();
         Self::require_admin(&env, &admin);
+        if env.storage().instance().get::<_, TierLimits>(&DataKey::RiskTier(tier_id)).is_none() {
+            panic!("RiskTierNotDefined");
+        }
         env.storage().persistent().set(&DataKey::TokenTier(token.clone()), &tier_id);
         env.storage().persistent().extend_ttl(&DataKey::TokenTier(token.clone()), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
         events::emit_token_tier_assigned(&env, token, tier_id);
@@ -1064,5 +1068,11 @@ impl TokenWhitelistContract {
 
     pub fn get_proposal_counter(env: Env) -> u32 {
         env.storage().instance().get(&DataKey::ProposalCounter).unwrap_or(0)
+    }
+
+    /// Returns `Some(true)` if the voter approved, `Some(false)` if they
+    /// rejected, or `None` if they have not voted on this proposal.
+    pub fn get_vote_record(env: Env, proposal_id: u32, voter: Address) -> Option<bool> {
+        env.storage().persistent().get::<DataKey, (bool, i128)>(&DataKey::VoteRecord(proposal_id, voter)).map(|(approve, _)| approve)
     }
 }

--- a/contracts/ahjoor-token-whitelist/src/test.rs
+++ b/contracts/ahjoor-token-whitelist/src/test.rs
@@ -644,3 +644,30 @@ fn test_get_risk_tier_defined_and_undefined() {
     assert_eq!(tier.max_daily_volume, 50_000i128);
     assert!(client.get_risk_tier(&99u32).is_none());
 }
+
+#[test]
+#[should_panic(expected = "RiskTierNotDefined")]
+fn test_assign_token_tier_panics_on_undefined_tier() {
+    let (env, admin, client) = setup_test();
+
+    let token = Address::generate(&env);
+    client.assign_token_tier(&admin, &token, &99u32);
+}
+
+#[test]
+fn test_assign_token_tier_accepts_defined_tier() {
+    let (env, admin, client) = setup_test();
+
+    let name = soroban_sdk::String::from_str(&env, "standard");
+    client.set_risk_tier(&admin, &2u32, &name, &1_000i128, &50_000i128);
+
+    let token = Address::generate(&env);
+    client.assign_token_tier(&admin, &token, &2u32);
+
+    let tier_id: u32 = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::TokenTier(token))
+        .unwrap();
+    assert_eq!(tier_id, 2);
+}

--- a/contracts/ahjoor-token-whitelist/src/test_governance.rs
+++ b/contracts/ahjoor-token-whitelist/src/test_governance.rs
@@ -364,3 +364,28 @@ fn test_get_governance_config_returns_admin_configured_values() {
     assert_eq!(enactment_delay, 50);
     assert_eq!(quorum_bps, 5_000);
 }
+
+#[test]
+fn test_get_vote_record() {
+    let (env, admin, client, gov_token) = setup_governance();
+
+    let proposer = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let rejecter = Address::generate(&env);
+    let nonvoter = Address::generate(&env);
+    let new_token = Address::generate(&env);
+
+    mint_gov_tokens(&env, &gov_token, &admin, &proposer, 200);
+    mint_gov_tokens(&env, &gov_token, &admin, &approver, 600);
+    mint_gov_tokens(&env, &gov_token, &admin, &rejecter, 400);
+
+    let rationale = BytesN::from_array(&env, &[0xABu8; 32]);
+    let proposal_id = client.propose_token_listing(&proposer, &new_token, &rationale);
+
+    client.vote_listing(&approver, &proposal_id, &true, &600i128);
+    client.vote_listing(&rejecter, &proposal_id, &false, &400i128);
+
+    assert_eq!(client.get_vote_record(&proposal_id, &approver), Some(true));
+    assert_eq!(client.get_vote_record(&proposal_id, &rejecter), Some(false));
+    assert_eq!(client.get_vote_record(&proposal_id, &nonvoter), None);
+}


### PR DESCRIPTION
## Changes

This PR implements four features across four contracts:

### closes #660  — get_vote_record view for a voter's cast vote
- **Contract**: `ahjoor-token-whitelist`
- Added `get_vote_record(env, proposal_id, voter) -> Option<bool>` which returns `Some(true)` for an approval vote, `Some(false)` for a rejection vote, or `None` if the voter has not voted on the proposal.
- Added unit test `test_get_vote_record` covering a voter who approved, one who rejected, and one who never voted.
- Added `get_vote_record` to the `TokenWhitelistInterface` client trait.

### closes #661 — tier_id existence validation in assign_token_tier
- **Contract**: `ahjoor-token-whitelist`
- `assign_token_tier` now validates that `tier_id` exists (i.e. `DataKey::RiskTier(tier_id)` is present) before assigning. Panics with `RiskTierNotDefined` when the tier is absent.
- Added `RiskTierNotDefined` variant (value 10) to the token-whitelist `Error` enum.
- Added `RISK_TIER_NOT_DEFINED = 5009` to the `ahjoor-errors` whitelist module and `ALL_ERRORS` registry.
- Added regression tests: `test_assign_token_tier_panics_on_undefined_tier` and `test_assign_token_tier_accepts_defined_tier`.

### closes #569 — list_active_consent_records view per customer
- **Contract**: `ahjoor-payments`
- Added `list_active_consent_records(env, customer) -> Vec<ConsentRecord>` which returns only currently-active consent records for the given customer, filtering out revoked, unsigned, and expired records.
- Added integration test `test_list_active_consent_records` covering a customer with a mix of active, revoked, and unsigned consent records, plus cross-customer isolation.

### closes  #657 — get_rapid_submission_window config getter
- **Contract**: `ahjoor-refund`
- Added `get_rapid_submission_window(env) -> u32` returning the configured default (720 ledgers) when no value has been explicitly set.
- Added unit test `test_get_rapid_submission_window` covering the default and an admin-updated value.

## Checklist
- [x] All functions follow existing codebase patterns
- [x] Tests added for each new feature
- [x] Error codes registered in `ahjoor-errors` crate
- [x] Client traits updated where applicable