### PR TITLE
feat(payments): add get_approval_state view for multisig-pending paym…

### DIFF
--- a/contracts/ahjoor-payments/src/lib.rs
+++ b/contracts/ahjoor-payments/src/lib.rs
@@ -3553,6 +3553,14 @@ impl AhjoorPaymentsContract {
             .get(&DataKey::MultisigPolicy(merchant))
     }
 
+    /// Get the approval state for a payment.
+    /// Returns `None` for payments that were never routed through multisig approval.
+    pub fn get_approval_state(env: Env, payment_id: u32) -> Option<ApprovalState> {
+        env.storage()
+            .persistent()
+            .get(&DataKey2::ApprovalState(payment_id))
+    }
+
     /// A signer approves a PendingApproval payment.
     /// Once `m` approvals are recorded the payment transitions to Pending.
     pub fn approve_payment(env: Env, signer: Address, payment_id: u32) {
@@ -3636,6 +3644,15 @@ impl AhjoorPaymentsContract {
         state.approvals.push_back(signer.clone());
         events::emit_payment_approved(&env, payment_id, signer);
 
+        env.storage()
+            .persistent()
+            .set(&DataKey2::ApprovalState(payment_id), &state);
+        env.storage().persistent().extend_ttl(
+            &DataKey2::ApprovalState(payment_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
         if state.approvals.len() >= policy.m {
             // Quorum reached — transition to Pending
             let old_status = payment.status;
@@ -3653,15 +3670,6 @@ impl AhjoorPaymentsContract {
                 payment_id,
                 old_status,
                 PaymentStatus::Pending,
-            );
-        } else {
-            env.storage()
-                .persistent()
-                .set(&DataKey2::ApprovalState(payment_id), &state);
-            env.storage().persistent().extend_ttl(
-                &DataKey2::ApprovalState(payment_id),
-                PERSISTENT_LIFETIME_THRESHOLD,
-                PERSISTENT_BUMP_AMOUNT,
             );
         }
 

--- a/contracts/ahjoor-payments/src/test_external_id_multisig_voucher.rs
+++ b/contracts/ahjoor-payments/src/test_external_id_multisig_voucher.rs
@@ -256,6 +256,94 @@ fn test_approval_window_expired_auto_cancels() {
     assert_eq!(s.token_client.balance(&customer), 5000);
 }
 
+#[test]
+fn test_get_approval_state_zero_approvals() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let signer1 = Address::generate(&s.env);
+    let signer2 = Address::generate(&s.env);
+    let signers = vec![&s.env, signer1.clone(), signer2.clone()];
+    s.client.set_multisig_policy(&s.merchant, &1000, &signers, &2, &3600);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &2000, &s.token_addr,
+        &None, &None, &None, &None, &None,
+    );
+
+    let state = s.client.get_approval_state(&pid).unwrap();
+    assert_eq!(state.payment_id, pid);
+    assert_eq!(state.approvals.len(), 0);
+}
+
+#[test]
+fn test_get_approval_state_partial_approvals() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let signer1 = Address::generate(&s.env);
+    let signer2 = Address::generate(&s.env);
+    let signer3 = Address::generate(&s.env);
+    let signers = vec![&s.env, signer1.clone(), signer2.clone(), signer3.clone()];
+    s.client.set_multisig_policy(&s.merchant, &1000, &signers, &3, &3600);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &2000, &s.token_addr,
+        &None, &None, &None, &None, &None,
+    );
+
+    s.client.approve_payment(&signer1, &pid);
+    s.client.approve_payment(&signer2, &pid);
+
+    let state = s.client.get_approval_state(&pid).unwrap();
+    assert_eq!(state.payment_id, pid);
+    assert_eq!(state.approvals.len(), 2);
+}
+
+#[test]
+fn test_get_approval_state_fully_approved() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &5000);
+
+    let signer1 = Address::generate(&s.env);
+    let signer2 = Address::generate(&s.env);
+    let signers = vec![&s.env, signer1.clone(), signer2.clone()];
+    s.client.set_multisig_policy(&s.merchant, &1000, &signers, &2, &3600);
+
+    let pid = s.client.create_payment_with_voucher(
+        &customer, &s.merchant, &2000, &s.token_addr,
+        &None, &None, &None, &None, &None,
+    );
+
+    s.client.approve_payment(&signer1, &pid);
+    s.client.approve_payment(&signer2, &pid);
+
+    // Payment should now be Pending, but approval state should still be readable
+    assert_eq!(s.client.get_payment(&pid).status, PaymentStatus::Pending);
+    let state = s.client.get_approval_state(&pid).unwrap();
+    assert_eq!(state.approvals.len(), 2);
+}
+
+#[test]
+fn test_get_approval_state_returns_none_for_regular_payment() {
+    let s = setup();
+    let customer = Address::generate(&s.env);
+    s.token_admin_client.mint(&customer, &1000);
+
+    // No multisig policy set — payment goes through normally
+    let pid = s.client.create_payment(
+        &customer, &s.merchant, &500, &s.token_addr, &None, &None, &None,
+    );
+
+    let state = s.client.get_approval_state(&pid);
+    assert!(state.is_none());
+}
+
+// ===========================================================================
+// Task 3: Voucher / Coupon Code Redemption
 // ===========================================================================
 // Task 3: Voucher Tests
 // ===========================================================================


### PR DESCRIPTION
## Description

Adds a public getter \get_approval_state(env, payment_id) -> Option<ApprovalState>\ that returns the current approval state for a payment that went through multisig approval.

- Closes #647 
- Closes #651 
- Closes #652 
- Close #653 

Returns \None\ for payments that were never routed through multisig approval.

### Changes

- **\contracts/ahjoor-payments/src/lib.rs\**: Added \get_approval_state\ view function. Also fixed an existing bug where \pprove_payment\ did not persist the \ApprovalState\ back to storage when the approval quorum was reached (the final approval's state was lost).
- **\contracts/ahjoor-payments/src/test_external_id_multisig_voucher.rs\**: Added 4 unit tests covering:
  - Zero approvals (payment just created, no signer has approved yet)
  - Partial approvals (some signers approved, quorum not yet reached)
  - Fully approved (quorum reached, payment transitions to Pending)
  - Regular payment (no multisig) returns \None\

